### PR TITLE
Shrink UnsafeBuffer and JsBuffer after oversized messages

### DIFF
--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/AbstractBuffer.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/AbstractBuffer.kt
@@ -64,6 +64,14 @@ abstract class AbstractBuffer {
 
     abstract fun checkAvailable(moreSize: Int)
 
+    open fun reset() {
+        position = 0
+    }
+
+    fun rewind() {
+        position = 0
+    }
+
     //unsigned types
     @ExperimentalUnsignedTypes
     open fun readUByte() = readByte().toUByte()
@@ -120,7 +128,3 @@ abstract class AbstractBuffer {
 }
 
 expect fun createAbstractBuffer(): AbstractBuffer
-
-fun AbstractBuffer.rewind() {
-    this.position = 0
-}

--- a/rd-kt/rd-framework/src/jsMain/kotlin/com/jetbrains/rd/framework/JsBuffer.kt
+++ b/rd-kt/rd-framework/src/jsMain/kotlin/com/jetbrains/rd/framework/JsBuffer.kt
@@ -9,6 +9,7 @@ class JsBuffer(private var buffer: ArrayBuffer) : AbstractBuffer() {
             @Suppress("unused")
             val NONSTANDARD_allowLegacyEncoding = true
         })
+        private const val maximumSizeBeforeShrink = 1024 * 1024 // 1M
     }
 
     private var dataView: DataView = DataView(buffer)
@@ -314,8 +315,11 @@ class JsBuffer(private var buffer: ArrayBuffer) : AbstractBuffer() {
             1
     )
 
-    fun rewind() {
-        position = 0
+    override fun reset() {
+        offset = 0
+        if (buffer.byteLength > maximumSizeBeforeShrink) {
+            resizeBuffer(maximumSizeBeforeShrink)
+        }
     }
 
     fun getFirstBytes(length: Int): DataView {

--- a/rd-kt/rd-framework/src/jvmMain/kotlin/com/jetbrains/rd/framework/SocketWire.kt
+++ b/rd-kt/rd-framework/src/jvmMain/kotlin/com/jetbrains/rd/framework/SocketWire.kt
@@ -191,7 +191,7 @@ class SocketWire {
 
         private fun sendAck(seqn: Long) {
             try {
-                ackPkgHeader.rewind()
+                ackPkgHeader.reset()
                 ackPkgHeader.writeInt(ack_msg_len)
                 ackPkgHeader.writeLong(seqn)
 
@@ -216,7 +216,7 @@ class SocketWire {
                     chunk.seqn = ++sentSeqn
 
 
-                sendPkgHeader.rewind()
+                sendPkgHeader.reset()
                 sendPkgHeader.writeInt(chunk.ptr)
                 sendPkgHeader.writeLong(chunk.seqn)
 
@@ -250,7 +250,10 @@ class SocketWire {
                 val bytes = unsafeBuffer.getArray()
                 sendBuffer.put(bytes, initialPosition, len)
             } finally {
-                unsafeBuffer.position = initialPosition
+                if (initialPosition == 0)
+                    unsafeBuffer.reset() // apply shrinking logic
+                else
+                    unsafeBuffer.position = initialPosition
             }
         }
     }

--- a/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/UnsafeBufferTest.kt
+++ b/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/UnsafeBufferTest.kt
@@ -100,4 +100,43 @@ class UnsafeBufferTest {
 
         assertEquals(array.toString(), buf.readUIntArray().toString())
     }
+
+    @Test
+    fun testShrinking1() {
+        val initialSize = 2 * 1024 * 1024
+        val buf = UnsafeBuffer(initialSize.toLong())
+
+        buf.rewind()
+        assertEquals(initialSize, buf.allocated)
+
+        buf.reset()
+        assertEquals(1024 * 1024, buf.allocated)
+
+        buf.reset()
+        assertEquals(1024 * 1024, buf.allocated)
+    }
+
+    @Test
+    fun testShrinking2() {
+        val initialSize = 2 * 1024 * 1024
+        val buf = UnsafeBuffer(initialSize.toLong())
+
+        buf.writeByteArray(ByteArray(initialSize - 16))
+        assertEquals(initialSize, buf.allocated)
+
+        buf.reset()
+        assertEquals(1024 * 1024, buf.allocated)
+    }
+
+    @Test
+    fun testShrinking3() {
+        val initialSize = 65536
+        val buf = UnsafeBuffer(initialSize.toLong())
+
+        buf.writeByteArray(ByteArray(2 * 1024 * 1024))
+        assert(buf.allocated >= 2 * 1024 * 1024)
+
+        buf.reset()
+        assertEquals(1024 * 1024, buf.allocated)
+    }
 }


### PR DESCRIPTION
Well, WebSocketWire creates a new buffer for each send anyways, so no shrinkage there. It's supported though.