### PR TITLE
RdReflection related changes

### DIFF
--- a/rd-net/RdFramework/ISerializers.cs
+++ b/rd-net/RdFramework/ISerializers.cs
@@ -6,7 +6,7 @@ namespace JetBrains.Rd
 {
   public interface ISerializersContainer
   {
-    void Register<T>([NotNull] CtxReadDelegate<T> reader, [NotNull] CtxWriteDelegate<T> writer, int? predefinedType = null);
+    void Register<T>([NotNull] CtxReadDelegate<T> reader, [NotNull] CtxWriteDelegate<T> writer, long? predefinedType = null);
 
     void RegisterEnum<T>() where T :
 #if !NET35

--- a/rd-net/RdFramework/Impl/Serializers.cs
+++ b/rd-net/RdFramework/Impl/Serializers.cs
@@ -219,7 +219,7 @@ namespace JetBrains.Rd.Impl
       Register(ReadEnum<T>, WriteEnum<T>);
     }
 
-    public void Register<T>(CtxReadDelegate<T> reader, CtxWriteDelegate<T> writer, int? predefinedId = null)
+    public void Register<T>(CtxReadDelegate<T> reader, CtxWriteDelegate<T> writer, long? predefinedId = null)
     {
       #if !NET35
       if (!myBackgroundRegistrar.IsInsideProcessing)

--- a/rd-net/RdFramework/RdId.cs
+++ b/rd-net/RdFramework/RdId.cs
@@ -24,6 +24,11 @@ namespace JetBrains.Rd
       return new RdId(id ?? Hash(type.Name));
     }
 
+    public static RdId DefineByFqn(Type type)
+    {
+      return new RdId(Hash(type.FullName));
+    }
+
     public RdId(long value)
     {
       myValue = value;

--- a/rd-net/RdFramework/RdId.cs
+++ b/rd-net/RdFramework/RdId.cs
@@ -14,12 +14,12 @@ namespace JetBrains.Rd
 
     private readonly long myValue;
 
-    public static RdId Define<T>(int? id = null)
+    public static RdId Define<T>(long? id = null)
     {
       return new RdId(id ?? Hash(typeof(T).Name));
     }
 
-    public static RdId Define(Type type, int? id = null)
+    public static RdId Define(Type type, long? id = null)
     {
       return new RdId(id ?? Hash(type.Name));
     }

--- a/rd-net/RdFramework/RdId.cs
+++ b/rd-net/RdFramework/RdId.cs
@@ -24,6 +24,10 @@ namespace JetBrains.Rd
       return new RdId(id ?? Hash(type.Name));
     }
 
+    /// <summary>
+    /// Define an RdId by fully-qualified type name.
+    /// You should use it only in case of C#-C# communication.
+    /// </summary>
     public static RdId DefineByFqn(Type type)
     {
       return new RdId(Hash(type.FullName));

--- a/rd-net/RdFramework/Reflection/Intrinsic.cs
+++ b/rd-net/RdFramework/Reflection/Intrinsic.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Reflection;
+using JetBrains.Annotations;
+using JetBrains.Diagnostics;
+using JetBrains.Util;
+using JetBrains.Util.Util;
+
+namespace JetBrains.Rd.Reflection
+{
+  public static class Intrinsic
+  {
+    [CanBeNull]
+    public static SerializerPair TryGetIntrinsicSerializer(TypeInfo typeInfo, Func<Type, SerializerPair> getInstanceSerializer)
+    {
+      if (ReflectionSerializerVerifier.HasIntrinsicMethods(typeInfo))
+      {
+        var genericArguments = typeInfo.GetGenericArguments();
+        if (genericArguments.Length == 1)
+        {
+          var argument = genericArguments[0];
+          var staticRead = SerializerReflectionUtil.GetReadStaticSerializer(typeInfo, argument);
+          var staticWrite = SerializerReflectionUtil.GetWriteStaticDeserializer(typeInfo);
+          return SerializerPair.CreateFromMethods(staticRead, staticWrite, getInstanceSerializer(argument));
+        }
+
+        if (genericArguments.Length == 0)
+        {
+          var staticRead = SerializerReflectionUtil.GetReadStaticSerializer(typeInfo);
+          var staticWrite = SerializerReflectionUtil.GetWriteStaticDeserializer(typeInfo);
+          return SerializerPair.CreateFromMethods(staticRead, staticWrite);
+        }
+
+        return null;
+      }
+      else if (ReflectionSerializerVerifier.HasIntrinsicFields(typeInfo))
+      {
+        var readField = typeInfo.GetField("Read", BindingFlags.Public | BindingFlags.Static);
+        var writeField = typeInfo.GetField("Write", BindingFlags.Public | BindingFlags.Static);
+        if (readField == null)
+          Assertion.Fail($"Invalid intrinsic serializer for type {typeInfo}. Static field 'Read' with type {typeof(CtxReadDelegate<>).ToString(true)} not found");
+        if (writeField == null)
+          Assertion.Fail($"Invalid intrinsic serializer for type {typeInfo}. Static field 'Write' with type {typeof(CtxWriteDelegate<>).ToString(true)} not found");
+        var reader = readField.GetValue(null);
+        var writer = writeField.GetValue(null);
+        return new SerializerPair(reader, writer);
+      }
+      else if (ReflectionSerializerVerifier.HasIntrinsicAttribute(typeInfo))
+      {
+        var marshallerType = typeInfo.GetCustomAttribute<RdScalarAttribute>().NotNull().Marshaller;
+        var marshaller = Activator.CreateInstance(marshallerType);
+        return (SerializerPair) ReflectionUtil.InvokeStaticGeneric(typeof(SerializerPair), nameof(SerializerPair.FromMarshaller), typeInfo, marshaller);
+      }
+
+      return null;
+    }
+  }
+}

--- a/rd-net/RdFramework/Reflection/ProxyGenerator.cs
+++ b/rd-net/RdFramework/Reflection/ProxyGenerator.cs
@@ -112,8 +112,6 @@ namespace JetBrains.Rd.Reflection
         throw new ArgumentException("Only interfaces are supported.");
 
       var moduleBuilder = myModuleBuilder.Value;
-      // prefix names used to achieve same RdExt for both Proxy & Impl types.
-      // TODO: Horrible hack to determine implementation name. 
       var className = typeof(TInterface).Name.Substring(1);
       var proxyTypeName = "Proxy." + className;
       var typebuilder = moduleBuilder.DefineType(

--- a/rd-net/RdFramework/Reflection/ReflectionRdActivator.cs
+++ b/rd-net/RdFramework/Reflection/ReflectionRdActivator.cs
@@ -12,6 +12,8 @@ using JetBrains.Rd.Base;
 using JetBrains.Rd.Impl;
 using JetBrains.Rd.Tasks;
 using JetBrains.Util;
+using JetBrains.Util.Util;
+
 #if NET35
 using TypeInfo = System.Type;
 #else
@@ -168,8 +170,17 @@ namespace JetBrains.Rd.Reflection
           var memberSetter = ReflectionUtil.GetSetter(mi);
           memberSetter(instance, currentValue);
         }
+        else
+        {
+          var implementingType = ReflectionSerializerVerifier.GetImplementingType(ReflectionUtil.GetReturnType(mi).GetTypeInfo());
+          Assertion.Assert(currentValue.GetType() == implementingType, 
+            "Bindable field {0} was initialized with incompatible type. Expected type {1}, actual {2}", 
+            mi, 
+            implementingType.ToString(true), 
+            currentValue.GetType().ToString(true));
+        }
       }
-
+      
       // Add RdEndpoint for Impl class (counterpart of Proxy)
       var interfaces = typeInfo.GetInterfaces();
       bool isProxy = interfaces.Contains(typeof(IProxyTypeMarker));

--- a/rd-net/RdFramework/Reflection/ReflectionRdActivator.cs
+++ b/rd-net/RdFramework/Reflection/ReflectionRdActivator.cs
@@ -75,7 +75,7 @@ namespace JetBrains.Rd.Reflection
     {
       var instance = Activate<T>();
 
-      var typename = typeof(T).Name;
+      var typename = GetTypeName(typeof(T));
       instance.Identify(protocol.Identities, RdId.Root.Mix(typename));
       instance.Bind(lifetime, protocol, typename);
 
@@ -91,7 +91,7 @@ namespace JetBrains.Rd.Reflection
     {
       var instance = Activate(type);
 
-      var typename = type.Name;
+      var typename = GetTypeName(type);
       var bindable = (RdExtReflectionBindableBase) instance;
       bindable.Identify(protocol.Identities, RdId.Root.Mix(typename));
       bindable.Bind(lifetime, protocol, typename);
@@ -372,6 +372,19 @@ namespace JetBrains.Rd.Reflection
       }
 
       throw new Exception($"Unable to activate generic type: {memberType}");
+    }
+
+    internal static string GetTypeName(Type type)
+    {
+      var typename = type.FullName;
+      if (typeof(RdExtReflectionBindableBase).IsAssignableFrom(type))
+      {
+        var rpcInterface = ReflectionSerializersFactory.GetRpcInterface(type.GetTypeInfo());
+        if (rpcInterface != null)
+          return rpcInterface.FullName;
+      }
+
+      return typename;
     }
   }
 }

--- a/rd-net/RdFramework/Reflection/ReflectionSerializersFacade.cs
+++ b/rd-net/RdFramework/Reflection/ReflectionSerializersFacade.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System.Reflection;
+using JetBrains.Annotations;
 using JetBrains.Lifetimes;
 using JetBrains.Rd.Base;
 
@@ -56,7 +57,7 @@ namespace JetBrains.Rd.Reflection
 
     private static void Bind(IRdBindable instance, Lifetime lifetime, IProtocol protocol)
     {
-      var typename = instance.GetType().Name;
+      var typename = ReflectionRdActivator.GetTypeName(instance.GetType());
       instance.Identify(protocol.Identities, RdId.Root.Mix(typename));
       instance.Bind(lifetime, protocol, typename);
     }

--- a/rd-net/RdFramework/Reflection/ReflectionSerializersFactory.cs
+++ b/rd-net/RdFramework/Reflection/ReflectionSerializersFactory.cs
@@ -400,7 +400,7 @@ namespace JetBrains.Rd.Reflection
         myStore = store;
       }
 
-      public void Register<T>(CtxReadDelegate<T> reader, CtxWriteDelegate<T> writer, int? predefinedType = null)
+      public void Register<T>(CtxReadDelegate<T> reader, CtxWriteDelegate<T> writer, long? predefinedType = null)
       {
         myStore[typeof(T)] = new SerializerPair(reader, writer);
       }

--- a/rd-net/RdFramework/Reflection/ReflectionSerializersFactory.cs
+++ b/rd-net/RdFramework/Reflection/ReflectionSerializersFactory.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using JetBrains.Annotations;
+using JetBrains.Collections.Viewable;
 using JetBrains.Diagnostics;
 using JetBrains.Rd.Base;
 using JetBrains.Rd.Impl;
@@ -334,7 +335,11 @@ namespace JetBrains.Rd.Reflection
     {
       var genericDefinition = implementingType.GetGenericTypeDefinition();
 
-      if (genericDefinition == typeof(RdProperty<>))
+      var intrinsic = Intrinsic.TryGetIntrinsicSerializer(implementingType.GetTypeInfo(), t => GetOrRegisterStaticSerializerInternal(t, true));
+      if (intrinsic != null)
+        return intrinsic;
+
+      if (typeof(IViewableProperty<>).IsAssignableFrom(genericDefinition))
       {
         return CreateStaticReaderSingleGeneric(member, typeInfo.AsType(), implementingType, allowNullable: true);
       }
@@ -350,7 +355,6 @@ namespace JetBrains.Rd.Reflection
       {
         return CreateStaticReaderTwoGeneric(member, typeInfo.AsType(), implementingType);
       }
-
 
       throw new Exception($"Unable to register generic type: {typeInfo}");
     }

--- a/rd-net/RdFramework/Reflection/ScalarSerializer.cs
+++ b/rd-net/RdFramework/Reflection/ScalarSerializer.cs
@@ -342,7 +342,7 @@ namespace JetBrains.Rd.Reflection
       writer = scalarSerializer.GetWriter<T>();
     }
 
-    public void Register<T>(CtxReadDelegate<T> reader, CtxWriteDelegate<T> writer, int? predefinedType = null)
+    public void Register<T>(CtxReadDelegate<T> reader, CtxWriteDelegate<T> writer, long? predefinedType = null)
     {
       myStaticSerializers[typeof(T)] = new SerializerPair(reader, writer);
     }

--- a/rd-net/RdFramework/Reflection/SimpleTypesCatalog.cs
+++ b/rd-net/RdFramework/Reflection/SimpleTypesCatalog.cs
@@ -19,7 +19,7 @@ namespace JetBrains.Rd.Reflection
 
     public void AddType(Type type)
     {
-      myRdIdToTypeMapping[RdId.Define(type)] = type;
+      myRdIdToTypeMapping[RdId.DefineByFqn(type)] = type;
     }
 
     public void Register<T>() => AddType(typeof(T));

--- a/rd-net/RdFramework/Reflection/TypesRegistrar.cs
+++ b/rd-net/RdFramework/Reflection/TypesRegistrar.cs
@@ -33,7 +33,7 @@ namespace JetBrains.Rd.Reflection
     {
       var serializerPair = myReflectionSerializersFactory.GetOrRegisterSerializerPair(type);
       ReflectionUtil.InvokeGenericThis(serializers, nameof(serializers.Register), type,
-        new[] {serializerPair.Reader, serializerPair.Writer, null});
+        new[] {serializerPair.Reader, serializerPair.Writer, RdId.DefineByFqn(type).Value });
     }
   }
 }

--- a/rd-net/SampleGame/SampleGame.csproj
+++ b/rd-net/SampleGame/SampleGame.csproj
@@ -14,11 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Client\" />
-    <Folder Include="Server\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\RdFramework\RdFramework.csproj" />
   </ItemGroup>
 

--- a/rd-net/Test.RdFramework/Reflection/ProxyGeneratorAsyncCallsTest.cs
+++ b/rd-net/Test.RdFramework/Reflection/ProxyGeneratorAsyncCallsTest.cs
@@ -70,14 +70,14 @@ namespace Test.RdFramework.Reflection
     }
 
     [RdRpc]
-    public interface IAsyncModelsTest
+    public interface IAsyncModelsTestDifferentName
     {
       Task<AColor> QueryColor();
       void SetPath(AsyncModelsTest.FileSystemPath animal);
     }
 
     [RdExt]
-    public class AsyncModelsTest : RdExtReflectionBindableBase, IAsyncModelsTest
+    public class AsyncModelsTest : RdExtReflectionBindableBase, IAsyncModelsTestDifferentName
     {
       public Task<AColor> QueryColor()
       {
@@ -173,7 +173,7 @@ namespace Test.RdFramework.Reflection
     [Test]
     public void TestAsyncModels()
     {
-      TestTemplate<AsyncModelsTest, IAsyncModelsTest>(proxy =>
+      TestTemplate<AsyncModelsTest, IAsyncModelsTestDifferentName>(proxy =>
       {
         proxy.SetPath(new AsyncModelsTest.FileSystemPath("C:\\hello"));
         var queryColor = proxy.QueryColor();

--- a/rd-net/Test.RdFramework/Reflection/ProxyGeneratorCornerCasesTests.cs
+++ b/rd-net/Test.RdFramework/Reflection/ProxyGeneratorCornerCasesTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using JetBrains.Collections.Viewable;
+using JetBrains.Diagnostics;
 using JetBrains.Rd.Reflection;
 using NUnit.Framework;
 
@@ -27,5 +29,60 @@ namespace Test.RdFramework.Reflection
     [Test] public void TestInvalid7() { Assert.Throws<NotSupportedException>(() => { CFacade.ProxyGenerator.CreateType<IInvalid7>(); }); }
     [Test] public void TestInvalid8() { Assert.Throws<Exception>(() => { CFacade.ProxyGenerator.CreateType<IInvalid8>(); }); }
     [Test] public void TestInvalid9() { Assert.Throws<Exception>(() => { CFacade.ProxyGenerator.CreateType<IInvalid9>(); }); }
+
+
+    [Test]
+    public void TestIncorrectInitialization()
+    {
+      Assert.Throws<Assertion.AssertionException>(() =>
+      {
+        WithExtsProxy<WrongInitializedTypeTest, IWrongInitialializedTypeTest>((c, s) =>
+        {
+          c.ViewableProperty.Value = "test";
+          Assert.AreEqual(c.ViewableProperty.Value, s.ViewableProperty.Value);
+        });
+      });
+    }
+
+    [Test]
+    public void TestUnexpectedInterfaceType()
+    {
+      Assert.Throws<NullReferenceException>(() =>
+      {
+        WithExtsProxy<UnexpectedInterfaceType, IUnexpectedInterfaceType>((c, s) =>
+        {
+          c.ViewableProperty.Value = "test";
+        });
+      });
+    }
+
+    [RdRpc]
+    public interface IUnexpectedInterfaceType
+    {
+      ViewableProperty<string> ViewableProperty { get; }
+    }
+
+    [RdExt]
+    public class UnexpectedInterfaceType : RdExtReflectionBindableBase, IUnexpectedInterfaceType
+    {
+      public ViewableProperty<string> ViewableProperty { get; }
+    }
+
+    [RdRpc]
+    public interface IWrongInitialializedTypeTest
+    {
+      IViewableProperty<string> ViewableProperty { get; }
+    }
+
+    [RdExt]
+    public class WrongInitializedTypeTest : RdExtReflectionBindableBase, IWrongInitialializedTypeTest
+    {
+      public IViewableProperty<string> ViewableProperty { get; }
+
+      public WrongInitializedTypeTest()
+      {
+        ViewableProperty = new ViewableProperty<string>();
+      }
+    }
   }
 }

--- a/rd-net/Test.RdFramework/Reflection/RdReflectionTestBase.cs
+++ b/rd-net/Test.RdFramework/Reflection/RdReflectionTestBase.cs
@@ -54,6 +54,13 @@ namespace Test.RdFramework.Reflection
       run(c, s);
     }
 
+    protected void WithExtsProxy<T1, T2>(Action<T1, T2> run) where T1 : RdBindableBase where T2 : class 
+    {
+      var c = CFacade.Activator.ActivateBind<T1>(TestLifetime, ClientProtocol);
+      var s = SFacade.ActivateProxy<T2>(TestLifetime, ServerProtocol);
+      run(c, s);
+    }
+
     protected void SaveGeneratedAssembly()
     {
 #if NET35 || NETCOREAPP

--- a/rd-net/Test.RdFramework/Reflection/ScalarTests.cs
+++ b/rd-net/Test.RdFramework/Reflection/ScalarTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Collections.Viewable;
 using JetBrains.Rd.Impl;
@@ -154,6 +155,61 @@ namespace Test.RdFramework.Reflection
       });
     }
 
+    [Test]
+    public void TestEventArgs()
+    {
+      WithExts<EventArgsExt>((c, s) =>
+      {
+        c.Objects.Value = new MyEventArgs<int?>() { Value = 42 };
+        Assert.AreEqual(42, s.Objects.Value.Value);
+      });
+    }
+
+    [Test]
+    public void TestGenericStruct()
+    {
+      WithExts<GenericStructExt>((c, s) =>
+      {
+        c.EnumStruct.Value = new TextControlOverridableValue<MyEnum>(MyEnum.First, MyEnum.Second);
+        c.IntStruct.Value = new TextControlOverridableValue<int>(1,2);
+
+        Assert.AreEqual(MyEnum.First, s.EnumStruct.Value.Original);
+        Assert.AreEqual(MyEnum.Second, s.EnumStruct.Value.Override);
+        Assert.AreEqual(1, s.IntStruct.Value.Original);
+        Assert.AreEqual(2, s.IntStruct.Value.Override);
+      });
+    }
+
+    [RdExt]
+    public class GenericStructExt : RdExtReflectionBindableBase
+    {
+      public IViewableProperty<TextControlOverridableValue<int>> IntStruct { get; }
+      public IViewableProperty<TextControlOverridableValue<MyEnum>> EnumStruct { get; }
+    }
+
+    [RdScalar]
+    public struct TextControlOverridableValue<T>
+    {
+      public TextControlOverridableValue(T original, T @override)
+      {
+        Original = original;
+        Override = @override;
+      }
+      public T Original;
+      public T Override;
+    }
+
+    [RdExt]
+    public class EventArgsExt : RdExtReflectionBindableBase
+    {
+      public IViewableProperty<MyEventArgs<int?>> Objects { get; }
+    }
+
+    [RdScalar]
+    public class MyEventArgs<T> : EventArgs
+    {
+      public T Value;
+    }
 
     [RdExt]
     public class ListInterfacesExt : RdExtReflectionBindableBase


### PR DESCRIPTION
Use FQN in ReflectionSerializers to avoid clashes by Name
ReflectionSerializers: use interface name in RPC to support different names for impl/interface
Intrinsic: support intrinsic for RdModel (mostly for sake of UProperty)