### PR TITLE
Pass exception to invocation side if an error occurred during reading

### DIFF
--- a/rd-net/RdFramework/Tasks/RdCall.cs
+++ b/rd-net/RdFramework/Tasks/RdCall.cs
@@ -73,11 +73,6 @@ namespace JetBrains.Rd.Tasks
     public override void OnWireReceived(UnsafeReader reader)
     {
       var taskId = RdId.Read(reader);
-      var value = ReadRequestDelegate(SerializationContext, reader);
-      if (LogReceived.IsTraceEnabled()) 
-        LogReceived.Trace("endpoint `{0}`::({1}), taskId={2}, request = {3}", Location, RdId, taskId, value.PrintToString());
-
-
       var taskLifetimeDef = myBindLifetime.CreateNested();
       
       //subscribe for lifetime cancellation
@@ -88,6 +83,9 @@ namespace JetBrains.Rd.Tasks
       {
         try
         {
+          var value = ReadRequestDelegate(SerializationContext, reader);
+          if (LogReceived.IsTraceEnabled()) 
+            LogReceived.Trace("endpoint `{0}`::({1}), taskId={2}, request = {3}", Location, RdId, taskId, value.PrintToString());
           rdTask = Handler(taskLifetimeDef.Lifetime, value);
         }
         catch (Exception e)
@@ -95,8 +93,6 @@ namespace JetBrains.Rd.Tasks
           rdTask = RdTask<TRes>.Faulted(e);
         }
       }
-
-      
       
       rdTask.Result.Advise(taskLifetimeDef.Lifetime, result =>
       {

--- a/rd-net/Test.RdFramework/Reflection/ProxyGeneratorAsyncCallsTest.cs
+++ b/rd-net/Test.RdFramework/Reflection/ProxyGeneratorAsyncCallsTest.cs
@@ -206,7 +206,7 @@ namespace Test.RdFramework.Reflection
     private void TestAsyncCalls(Action<IAsyncCallsTest> run) => TestTemplate<AsyncCallsTest, IAsyncCallsTest>(run);
     private void TestSyncCalls(Action<ISyncCallsTest> run) => TestTemplate<SyncCallsTest, ISyncCallsTest>(run);
 
-    private void TestTemplate<TImpl, TInterface>(Action<TInterface> runTest) where TImpl : RdBindableBase where TInterface : class
+    protected void TestTemplate<TImpl, TInterface>(Action<TInterface> runTest) where TImpl : RdBindableBase where TInterface : class
     {
       ClientProtocol.Scheduler.Queue(() =>
       {


### PR DESCRIPTION
When you use reflection serializer you can get runtime exception during read (you can forgot to register your type in types catalog, for example). In that case an exception is thrown on the receiver side, task on the other side will hang forever. 
It would be much more convenient if exception was passed to invocation side. 