### PR TITLE
Fix upperbound check in EnumUtil.parseFromFlags()

### DIFF
--- a/rd-kt/rd-core/src/commonMain/kotlin/com/jetbrains/rd/util/EnumUtil.kt
+++ b/rd-kt/rd-core/src/commonMain/kotlin/com/jetbrains/rd/util/EnumUtil.kt
@@ -9,7 +9,7 @@ inline fun <reified T:Enum<T>> parseFromOrdinal(ordinal: Int) : T {
 
 inline fun <reified T:Enum<T>> parseFromFlags(flags: Int) : EnumSet<T> {
     enumValues<T>().let { values ->
-        require(flags in 0..(1 shl (values.size))) {"'$flags' not in range of ${T::class.simpleName} enum set: [0..${(1 shl (values.size - 1))})"}
+        require(flags in 0 until (1 shl values.size)) {"'$flags' not in range of ${T::class.simpleName} enum set: [0..${(1 shl values.size)})"}
         val res = mutableSetOf<T>()
         var x = flags
         var i = 0

--- a/rd-kt/rd-core/src/commonMain/kotlin/com/jetbrains/rd/util/EnumUtil.kt
+++ b/rd-kt/rd-core/src/commonMain/kotlin/com/jetbrains/rd/util/EnumUtil.kt
@@ -9,7 +9,7 @@ inline fun <reified T:Enum<T>> parseFromOrdinal(ordinal: Int) : T {
 
 inline fun <reified T:Enum<T>> parseFromFlags(flags: Int) : EnumSet<T> {
     enumValues<T>().let { values ->
-        require(flags in 0..(1 shl (values.size - 1))) {"'$flags' not in range of ${T::class.simpleName} enum set: [0..${(1 shl (values.size - 1))})"}
+        require(flags in 0..(1 shl (values.size))) {"'$flags' not in range of ${T::class.simpleName} enum set: [0..${(1 shl (values.size - 1))})"}
         val res = mutableSetOf<T>()
         var x = flags
         var i = 0

--- a/rd-kt/rd-core/src/jvmTest/kotlin/com/jetbrains/rd/util/test/cases/EnumUtilTest.kt
+++ b/rd-kt/rd-core/src/jvmTest/kotlin/com/jetbrains/rd/util/test/cases/EnumUtilTest.kt
@@ -21,4 +21,17 @@ class EnumUtilTest {
         assertTrue(flags.contains(TestEnum.One))
         assertFalse(flags.contains(TestEnum.Two))
     }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testParseFromFlags_outOfRange() {
+        val enumCombinedVal = (1 shl 3)
+        parseFromFlags<TestEnum>(enumCombinedVal)
+    }
+
+    @Test
+    fun testParseFromFlags_maxPossibleValue() {
+        val enumCombinedVal = (1 shl 3) - 1
+        val flags = parseFromFlags<TestEnum>(enumCombinedVal)
+        assertTrue(flags.size == 3)
+    }
 }

--- a/rd-kt/rd-core/src/jvmTest/kotlin/com/jetbrains/rd/util/test/cases/EnumUtilTest.kt
+++ b/rd-kt/rd-core/src/jvmTest/kotlin/com/jetbrains/rd/util/test/cases/EnumUtilTest.kt
@@ -1,0 +1,24 @@
+package com.jetbrains.rd.util.test.cases
+
+import com.jetbrains.rd.util.parseFromFlags
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EnumUtilTest {
+
+    enum class TestEnum {
+        One,
+        Two,
+        Three
+    }
+
+    @Test
+    fun testParseFromFlags() {
+        val enumCombinedVal = (1 shl 2) or (1 shl 0) // like in C# TestEnum.Three | TestEnum.One
+        val flags = parseFromFlags<TestEnum>(enumCombinedVal)
+        assertTrue(flags.contains(TestEnum.Three))
+        assertTrue(flags.contains(TestEnum.One))
+        assertFalse(flags.contains(TestEnum.Two))
+    }
+}


### PR DESCRIPTION
Fix upperbound check in EnumUtil.parseFromFlags(). It was failing when trying to deserialize combination of last value in enum with some other value (see the test) 