### PR TITLE
Close sockets immediately

### DIFF
--- a/rd-net/RdFramework/Impl/SocketWire.cs
+++ b/rd-net/RdFramework/Impl/SocketWire.cs
@@ -419,6 +419,8 @@ namespace JetBrains.Rd.Impl
               try
               {
                 var s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                Socket = s;
+
                 SetSocketOptions(s);
                 Log.Verbose("{0} : connecting", Id);
                 s.Connect(endPoint);
@@ -433,7 +435,6 @@ namespace JetBrains.Rd.Impl
                   }
                   else
                   {
-                    Socket = s;
                     Log.Verbose("{0} : connected", Id);
                   }
                 }

--- a/rd-net/Test.Lifetimes/LifetimesTestBase.cs
+++ b/rd-net/Test.Lifetimes/LifetimesTestBase.cs
@@ -1,6 +1,6 @@
 using System;
+using System.IO;
 using JetBrains.Diagnostics;
-using JetBrains.Diagnostics.Internal;
 using JetBrains.Lifetimes;
 using NUnit.Framework;
 
@@ -39,7 +39,7 @@ namespace Test.Lifetimes
 
     protected void ThrowLoggedExceptions()
     {
-      TestLogger.Logger.ThrowLoggedExceptions();
+      TestLogger.ExceptionLogger.ThrowLoggedExceptions();
     }
   }
 }

--- a/rd-net/Test.Lifetimes/Test.Lifetimes.csproj
+++ b/rd-net/Test.Lifetimes/Test.Lifetimes.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="nunit" Version="3.11.0" />        
+        <PackageReference Include="nunit" Version="3.12.0" />        
         <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />        
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />        
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.17" />

--- a/rd-net/Test.RdFramework/SocketWireTest.cs
+++ b/rd-net/Test.RdFramework/SocketWireTest.cs
@@ -222,10 +222,12 @@ namespace Test.RdFramework
 
 
     [Test]
+    [Timeout(5000)]
     public void TestClientWithoutServer()
     {
       Lifetime.Using(lifetime =>
       {
+        WithLongTimeout(lifetime);
         SynchronousScheduler.Instance.SetActive(lifetime);
         Client(lifetime, FindFreePort());
       });

--- a/rd-net/Test.RdFramework/SocketWireTest.cs
+++ b/rd-net/Test.RdFramework/SocketWireTest.cs
@@ -182,10 +182,12 @@ namespace Test.RdFramework
 
 
     [Test]
+    [Timeout(5000)]
     public void TestServerWithoutClient()
     {
       Lifetime.Using(lifetime =>
       {
+        WithLongTimeout(lifetime);
         SynchronousScheduler.Instance.SetActive(lifetime);
         Server(lifetime);
       });
@@ -404,6 +406,12 @@ namespace Test.RdFramework
       }
       
       SocketWire.Base.CloseSocket(socketWire.Socket.NotNull());
+    }
+
+    private static void WithLongTimeout(Lifetime lifetime)
+    {
+      var oldValue = SocketWire.Base.TimeoutMs;
+      lifetime.Bracket(() => SocketWire.Base.TimeoutMs = 100_000, () => SocketWire.Base.TimeoutMs = oldValue);
     }
   }
 }

--- a/rd-net/Test.RdFramework/Test.RdFramework.csproj
+++ b/rd-net/Test.RdFramework/Test.RdFramework.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="nunit" Version="3.11.0" />        
+        <PackageReference Include="nunit" Version="3.12.0" />        
         <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.17" />


### PR DESCRIPTION
Motivation: most of the SocketWire tests are completed not due a proper interruption, but after a some magic timeout (you can observe it in test execution time and logs)
These delays became noticeable in the new unit test runner.