### PR TITLE
fix issue #86 | suppress warnings

### DIFF
--- a/rd-cpp/src/rd_framework_cpp/src/main/wire/SocketWire.cpp
+++ b/rd-cpp/src/rd_framework_cpp/src/main/wire/SocketWire.cpp
@@ -165,7 +165,7 @@ std::future<void> SocketWire::Base::start_heartbeat(Lifetime lifetime)
 	return std::async([this, lifetime] {
 		while (!lifetime->is_terminated())
 		{
-			std::this_thread::sleep_for(heartBeatInterval);
+			std::this_thread::sleep_for(heartbeatInterval);
 			ping();
 		}
 	});

--- a/rd-cpp/src/rd_framework_cpp/src/main/wire/SocketWire.h
+++ b/rd-cpp/src/rd_framework_cpp/src/main/wire/SocketWire.h
@@ -55,7 +55,7 @@ public:
 		mutable Buffer ack_buffer{PACKAGE_HEADER_LENGTH};
 
 		/**
-		 * \brief Timestamp of this wire which increases at intervals of [heartBeatInterval].
+		 * \brief Timestamp of this wire which increases at intervals of [heartbeatInterval].
 		 */
 		mutable int32_t current_timestamp = 0;
 
@@ -96,7 +96,7 @@ public:
 
 	public:
 		static constexpr int32_t MaximumHeartbeatDelay = 3;
-		std::chrono::milliseconds heartBeatInterval = std::chrono::milliseconds(500);
+		std::chrono::milliseconds heartbeatInterval = std::chrono::milliseconds(500);
 
 		// region ctor/dtor
 

--- a/rd-cpp/src/rd_framework_cpp/src/test/cases/SocketWireTest.cpp
+++ b/rd-cpp/src/rd_framework_cpp/src/test/cases/SocketWireTest.cpp
@@ -593,7 +593,7 @@ TEST_P(PacketLossTestBase, TestPacketLoss)
 	else
 		proxy.StopServerToClientMessaging();
 
-	auto detectionTimeout = dynamic_cast<SocketWire::Base const*>(clientProtocol.get_wire())->heartBeatInterval *
+	auto detectionTimeout = dynamic_cast<SocketWire::Base const*>(clientProtocol.get_wire())->heartbeatInterval *
 							(SocketWire::Base::MaximumHeartbeatDelay + 3);
 
 	auto detectionTimeoutMs = std::chrono::duration_cast<std::chrono::milliseconds>(detectionTimeout).count();

--- a/rd-kt/rd-framework/build.gradle.kts
+++ b/rd-kt/rd-framework/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.jetbrains.rd.gradle.plugins.applyMultiplatform
-import com.jetbrains.rd.gradle.tasks.CopySourcesTask
 import com.jetbrains.rd.gradle.tasks.creatingCopySourcesTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("multiplatform")
@@ -24,6 +24,10 @@ kotlin {
         }
 
     }
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions.freeCompilerArgs += "-Xuse-experimental=kotlin.Experimental"
 }
 
 val testCopySources by creatingCopySourcesTask(

--- a/rd-kt/rd-framework/build.gradle.kts
+++ b/rd-kt/rd-framework/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.jetbrains.rd.gradle.plugins.applyMultiplatform
 import com.jetbrains.rd.gradle.tasks.creatingCopySourcesTask
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("multiplatform")
@@ -24,10 +23,6 @@ kotlin {
         }
 
     }
-}
-
-tasks.withType<KotlinCompile> {
-    kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
 }
 
 val testCopySources by creatingCopySourcesTask(

--- a/rd-kt/rd-framework/build.gradle.kts
+++ b/rd-kt/rd-framework/build.gradle.kts
@@ -27,7 +27,7 @@ kotlin {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.freeCompilerArgs += "-Xuse-experimental=kotlin.Experimental"
+    kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
 }
 
 val testCopySources by creatingCopySourcesTask(

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/Interfaces.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/Interfaces.kt
@@ -9,9 +9,12 @@ import com.jetbrains.rd.framework.impl.ProtocolContexts
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.reactive.IPropertyView
 import com.jetbrains.rd.util.reactive.IScheduler
+import com.jetbrains.rd.util.reactive.Property
 import com.jetbrains.rd.util.reactive.ViewableSet
 import com.jetbrains.rd.util.string.RName
 import kotlin.reflect.KClass
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
 /**
  * A node in a graph of entities that can be synchronized with its remote copy over a network or a similar connection.
@@ -44,6 +47,13 @@ interface IProtocol : IRdDynamic {
  */
 interface IWire {
     val connected: IPropertyView<Boolean>
+    val heartbeatAlive: Property<Boolean>
+
+    /**
+     * Ping's interval and not actually detection's timeout.
+     */
+    @UseExperimental(ExperimentalTime::class)
+    var heartBeatInterval: Duration
 
     /**
      * Sends a data block with the given [id] and the given [writer] function that can write the data.

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/Interfaces.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/Interfaces.kt
@@ -53,7 +53,7 @@ interface IWire {
      * Ping's interval.
      */
     @UseExperimental(ExperimentalTime::class)
-    var heartBeatInterval: Duration
+    var heartbeatInterval: Duration
 
     /**
      * Sends a data block with the given [id] and the given [writer] function that can write the data.

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/Interfaces.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/Interfaces.kt
@@ -50,7 +50,7 @@ interface IWire {
     val heartbeatAlive: Property<Boolean>
 
     /**
-     * Ping's interval and not actually detection's timeout.
+     * Ping's interval.
      */
     @UseExperimental(ExperimentalTime::class)
     var heartBeatInterval: Duration

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/Interfaces.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/Interfaces.kt
@@ -52,7 +52,7 @@ interface IWire {
     /**
      * Ping's interval.
      */
-    @UseExperimental(ExperimentalTime::class)
+    @OptIn(ExperimentalTime::class)
     var heartbeatInterval: Duration
 
     /**

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/Interfaces.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/Interfaces.kt
@@ -13,8 +13,6 @@ import com.jetbrains.rd.util.reactive.Property
 import com.jetbrains.rd.util.reactive.ViewableSet
 import com.jetbrains.rd.util.string.RName
 import kotlin.reflect.KClass
-import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 
 /**
  * A node in a graph of entities that can be synchronized with its remote copy over a network or a similar connection.
@@ -52,8 +50,7 @@ interface IWire {
     /**
      * Ping's interval.
      */
-    @OptIn(ExperimentalTime::class)
-    var heartbeatInterval: Duration
+    var heartbeatIntervalMs: Long
 
     /**
      * Sends a data block with the given [id] and the given [writer] function that can write the data.

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
@@ -189,7 +189,7 @@ class ExtWire : IWire {
     override val heartbeatAlive
         get() = realWire.heartbeatAlive
 
-    @UseExperimental(ExperimentalTime::class)
+    @OptIn(ExperimentalTime::class)
     override var heartbeatInterval: Duration
         get() = realWire.heartbeatInterval
         set(duration) {

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
@@ -15,8 +15,6 @@ import com.jetbrains.rd.util.reactive.whenTrue
 import com.jetbrains.rd.util.string.printToString
 import com.jetbrains.rd.util.threading.SynchronousScheduler
 import com.jetbrains.rd.util.trace
-import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 
 abstract class RdExtBase : RdReactiveBase() {
     enum class ExtState {
@@ -189,11 +187,10 @@ class ExtWire : IWire {
     override val heartbeatAlive
         get() = realWire.heartbeatAlive
 
-    @OptIn(ExperimentalTime::class)
-    override var heartbeatInterval: Duration
-        get() = realWire.heartbeatInterval
+    override var heartbeatIntervalMs: Long
+        get() = realWire.heartbeatIntervalMs
         set(duration) {
-            realWire.heartbeatInterval = duration
+            realWire.heartbeatIntervalMs = duration
         }
 
 

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
@@ -15,6 +15,8 @@ import com.jetbrains.rd.util.reactive.whenTrue
 import com.jetbrains.rd.util.string.printToString
 import com.jetbrains.rd.util.threading.SynchronousScheduler
 import com.jetbrains.rd.util.trace
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
 abstract class RdExtBase : RdReactiveBase() {
     enum class ExtState {
@@ -181,8 +183,15 @@ class ExtWire : IWire {
         require(newContexts === realWire.contexts) { "Can't replace ProtocolContexts on ExtWire" }
     }
 
+    @Suppress("ArrayInDataClass")
     data class QueueItem(val id: RdId, val msgSize: Int, val payoad: ByteArray, val context: List<Pair<RdContext<Any>, Any?>>)
     override val connected: Property<Boolean> = Property(false)
+    override val heartbeatAlive = connected
+
+    @UseExperimental(ExperimentalTime::class)
+    override var heartBeatInterval: Duration
+        get() = Duration.INFINITE
+        set(_) {}
 
 
     private val sendQ = Queue<QueueItem>()

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
@@ -186,12 +186,15 @@ class ExtWire : IWire {
     @Suppress("ArrayInDataClass")
     data class QueueItem(val id: RdId, val msgSize: Int, val payoad: ByteArray, val context: List<Pair<RdContext<Any>, Any?>>)
     override val connected: Property<Boolean> = Property(false)
-    override val heartbeatAlive = connected
+    override val heartbeatAlive
+        get() = realWire.heartbeatAlive
 
     @UseExperimental(ExperimentalTime::class)
     override var heartbeatInterval: Duration
-        get() = Duration.INFINITE
-        set(_) {}
+        get() = realWire.heartbeatInterval
+        set(duration) {
+            realWire.heartbeatInterval = duration
+        }
 
 
     private val sendQ = Queue<QueueItem>()

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
@@ -189,7 +189,7 @@ class ExtWire : IWire {
     override val heartbeatAlive = connected
 
     @UseExperimental(ExperimentalTime::class)
-    override var heartBeatInterval: Duration
+    override var heartbeatInterval: Duration
         get() = Duration.INFINITE
         set(_) {}
 

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/WireBase.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/WireBase.kt
@@ -1,17 +1,22 @@
 package com.jetbrains.rd.framework.base
 
-import com.jetbrains.rd.framework.*
+import com.jetbrains.rd.framework.AbstractBuffer
+import com.jetbrains.rd.framework.IWire
+import com.jetbrains.rd.framework.MessageBroker
+import com.jetbrains.rd.framework.RdId
 import com.jetbrains.rd.framework.impl.ProtocolContexts
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.reactive.IScheduler
 import com.jetbrains.rd.util.reactive.Property
 import com.jetbrains.rd.util.string.printToString
+import kotlin.time.ExperimentalTime
+import kotlin.time.milliseconds
 
 
 abstract class WireBase(val scheduler: IScheduler) : IWire {
     private lateinit var contextsInternal: ProtocolContexts
     final override val connected = Property(false)
-    val heartbeatAlive = Property(false)
+    override val heartbeatAlive = Property(false)
     protected val messageBroker = MessageBroker(scheduler)
 
     override fun advise(lifetime: Lifetime, entity: IRdWireable) = messageBroker.adviseOn(lifetime, entity)
@@ -20,6 +25,12 @@ abstract class WireBase(val scheduler: IScheduler) : IWire {
 
     override val contexts: ProtocolContexts
         get() = contextsInternal
+
+    /**
+     * Ping's interval and not actually detection's timeout.
+     */
+    @UseExperimental(ExperimentalTime::class)
+    override var heartBeatInterval = 500.milliseconds
 
     abstract override fun send(id: RdId, writer: (AbstractBuffer) -> Unit)
 

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/WireBase.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/WireBase.kt
@@ -28,6 +28,7 @@ abstract class WireBase(val scheduler: IScheduler) : IWire {
 
     /**
      * Ping's interval and not actually detection's timeout.
+     * Its value must be the same on both sides of connection.
      */
     @UseExperimental(ExperimentalTime::class)
     override var heartBeatInterval = 500.milliseconds

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/WireBase.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/WireBase.kt
@@ -31,7 +31,7 @@ abstract class WireBase(val scheduler: IScheduler) : IWire {
      * Its value must be the same on both sides of connection.
      */
     @UseExperimental(ExperimentalTime::class)
-    override var heartBeatInterval = 500.milliseconds
+    override var heartbeatInterval = 500.milliseconds
 
     abstract override fun send(id: RdId, writer: (AbstractBuffer) -> Unit)
 

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/WireBase.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/WireBase.kt
@@ -30,7 +30,7 @@ abstract class WireBase(val scheduler: IScheduler) : IWire {
      * Ping's interval and not actually detection's timeout.
      * Its value must be the same on both sides of connection.
      */
-    @UseExperimental(ExperimentalTime::class)
+    @OptIn(ExperimentalTime::class)
     override var heartbeatInterval = 500.milliseconds
 
     abstract override fun send(id: RdId, writer: (AbstractBuffer) -> Unit)

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/WireBase.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/WireBase.kt
@@ -9,9 +9,6 @@ import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.reactive.IScheduler
 import com.jetbrains.rd.util.reactive.Property
 import com.jetbrains.rd.util.string.printToString
-import kotlin.time.ExperimentalTime
-import kotlin.time.milliseconds
-
 
 abstract class WireBase(val scheduler: IScheduler) : IWire {
     private lateinit var contextsInternal: ProtocolContexts
@@ -30,8 +27,7 @@ abstract class WireBase(val scheduler: IScheduler) : IWire {
      * Ping's interval and not actually detection's timeout.
      * Its value must be the same on both sides of connection.
      */
-    @OptIn(ExperimentalTime::class)
-    override var heartbeatInterval = 500.milliseconds
+    override var heartbeatIntervalMs = 500L
 
     abstract override fun send(id: RdId, writer: (AbstractBuffer) -> Unit)
 

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/impl/RdTask.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/impl/RdTask.kt
@@ -16,7 +16,7 @@ fun<TReq, TRes> IRdCall<TReq, TRes>.startAndAdviseSuccess(request: TReq, onSucce
 }
 
 fun<TReq, TRes> IRdCall<TReq, TRes>.startAndAdviseSuccess(lifetime: Lifetime, request: TReq, onSuccess: (TRes) -> Unit) {
-    start(request).result.advise(lifetime) {
+    start(lifetime, request).result.advise(lifetime) {
         if (it is RdTaskResult.Success<TRes>) onSuccess(it.value)
     }
 }

--- a/rd-kt/rd-framework/src/jvmMain/kotlin/com/jetbrains/rd/framework/SocketWire.kt
+++ b/rd-kt/rd-framework/src/jvmMain/kotlin/com/jetbrains/rd/framework/SocketWire.kt
@@ -20,7 +20,6 @@ import java.time.Duration
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import kotlin.concurrent.thread
-import kotlin.time.ExperimentalTime
 
 private fun InputStream.readByteArray(a : ByteArray): Boolean {
     var pos = 0
@@ -130,10 +129,9 @@ class SocketWire {
             }
         }
 
-        @OptIn(ExperimentalTime::class)
         private fun startHeartbeat() = GlobalScope.launch {
             while (true) {
-                delay(heartbeatInterval.toLongMilliseconds())
+                delay(heartbeatIntervalMs)
                 ping()
             }
         }
@@ -439,7 +437,6 @@ class SocketWire {
     }
 
 
-    @OptIn(ExperimentalTime::class)
     class Server internal constructor(lifetime : Lifetime, scheduler: IScheduler, ss: ServerSocket, optId: String? = null, allowReconnect: Boolean) : Base(optId ?:"ServerSocket", lifetime, scheduler) {
         val port : Int = ss.localPort
 

--- a/rd-kt/rd-framework/src/jvmMain/kotlin/com/jetbrains/rd/framework/SocketWire.kt
+++ b/rd-kt/rd-framework/src/jvmMain/kotlin/com/jetbrains/rd/framework/SocketWire.kt
@@ -20,6 +20,7 @@ import java.time.Duration
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import kotlin.concurrent.thread
+import kotlin.time.ExperimentalTime
 
 private fun InputStream.readByteArray(a : ByteArray): Boolean {
     var pos = 0
@@ -129,9 +130,10 @@ class SocketWire {
             }
         }
 
+        @UseExperimental(ExperimentalTime::class)
         private fun startHeartbeat() = GlobalScope.launch {
             while (true) {
-                delay(heartBeatInterval.toMillis())
+                delay(heartBeatInterval.toLongMilliseconds())
                 ping()
             }
         }
@@ -291,11 +293,6 @@ class SocketWire {
         private val ackPkgHeader = createAbstractBuffer()
 
         /**
-         * Ping's interval and not actually detection's timeout.
-         */
-        var heartBeatInterval: Duration = Duration.ofMillis(500)
-
-        /**
          * Timestamp of this wire which increases at intervals of [heartBeatInterval].
          */
         private var currentTimeStamp = 0
@@ -442,6 +439,7 @@ class SocketWire {
     }
 
 
+    @UseExperimental(ExperimentalTime::class)
     class Server internal constructor(lifetime : Lifetime, scheduler: IScheduler, ss: ServerSocket, optId: String? = null, allowReconnect: Boolean) : Base(optId ?:"ServerSocket", lifetime, scheduler) {
         val port : Int = ss.localPort
 

--- a/rd-kt/rd-framework/src/jvmMain/kotlin/com/jetbrains/rd/framework/SocketWire.kt
+++ b/rd-kt/rd-framework/src/jvmMain/kotlin/com/jetbrains/rd/framework/SocketWire.kt
@@ -130,7 +130,7 @@ class SocketWire {
             }
         }
 
-        @UseExperimental(ExperimentalTime::class)
+        @OptIn(ExperimentalTime::class)
         private fun startHeartbeat() = GlobalScope.launch {
             while (true) {
                 delay(heartbeatInterval.toLongMilliseconds())
@@ -439,7 +439,7 @@ class SocketWire {
     }
 
 
-    @UseExperimental(ExperimentalTime::class)
+    @OptIn(ExperimentalTime::class)
     class Server internal constructor(lifetime : Lifetime, scheduler: IScheduler, ss: ServerSocket, optId: String? = null, allowReconnect: Boolean) : Base(optId ?:"ServerSocket", lifetime, scheduler) {
         val port : Int = ss.localPort
 

--- a/rd-kt/rd-framework/src/jvmMain/kotlin/com/jetbrains/rd/framework/SocketWire.kt
+++ b/rd-kt/rd-framework/src/jvmMain/kotlin/com/jetbrains/rd/framework/SocketWire.kt
@@ -133,7 +133,7 @@ class SocketWire {
         @UseExperimental(ExperimentalTime::class)
         private fun startHeartbeat() = GlobalScope.launch {
             while (true) {
-                delay(heartBeatInterval.toLongMilliseconds())
+                delay(heartbeatInterval.toLongMilliseconds())
                 ping()
             }
         }
@@ -293,7 +293,7 @@ class SocketWire {
         private val ackPkgHeader = createAbstractBuffer()
 
         /**
-         * Timestamp of this wire which increases at intervals of [heartBeatInterval].
+         * Timestamp of this wire which increases at intervals of [heartbeatInterval].
          */
         private var currentTimeStamp = 0
 

--- a/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/wire/SocketProxyTest.kt
+++ b/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/wire/SocketProxyTest.kt
@@ -9,8 +9,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import kotlin.time.ExperimentalTime
 
-
+@UseExperimental(ExperimentalTime::class)
 class SocketProxyTest : TestBase() {
     private val DefaultTimeoutMs = 100L
 

--- a/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/wire/SocketProxyTest.kt
+++ b/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/wire/SocketProxyTest.kt
@@ -9,9 +9,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import kotlin.time.ExperimentalTime
 
-@OptIn(ExperimentalTime::class)
 class SocketProxyTest : TestBase() {
     private val DefaultTimeoutMs = 100L
 

--- a/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/wire/SocketProxyTest.kt
+++ b/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/wire/SocketProxyTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import kotlin.time.ExperimentalTime
 
-@UseExperimental(ExperimentalTime::class)
+@OptIn(ExperimentalTime::class)
 class SocketProxyTest : TestBase() {
     private val DefaultTimeoutMs = 100L
 

--- a/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/wire/SocketWireTest.kt
+++ b/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/wire/SocketWireTest.kt
@@ -335,7 +335,7 @@ class SocketWireTest : TestBase() {
             else
                 proxy.stopServerToClientMessaging()
 
-            val detectionTimeout = clientProtocol.wire.heartBeatInterval.times((SocketWire.maximumHeartbeatDelay + 3))
+            val detectionTimeout = clientProtocol.wire.heartbeatInterval.times((SocketWire.maximumHeartbeatDelay + 3))
 
             Thread.sleep(detectionTimeout.toLongMilliseconds())
 

--- a/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/wire/SocketWireTest.kt
+++ b/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/wire/SocketWireTest.kt
@@ -19,10 +19,8 @@ import org.junit.jupiter.params.provider.ValueSource
 import java.net.InetAddress
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeoutException
-import kotlin.time.ExperimentalTime
 
 
-@ExperimentalTime
 class SocketWireTest : TestBase() {
 
     private fun <T : Any> RdOptionalProperty<T>.waitAndAssert(expected: T, prev: T? = null) {
@@ -313,7 +311,6 @@ class SocketWireTest : TestBase() {
         spinUntil { factory.size == 0 }
     }
 
-    @ExperimentalTime
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
     fun testPacketLoss(isClientToServer: Boolean) {
@@ -335,9 +332,9 @@ class SocketWireTest : TestBase() {
             else
                 proxy.stopServerToClientMessaging()
 
-            val detectionTimeout = clientProtocol.wire.heartbeatInterval.times((SocketWire.maximumHeartbeatDelay + 3))
+            val detectionTimeoutMs = clientProtocol.wire.heartbeatIntervalMs * (SocketWire.maximumHeartbeatDelay + 3)
 
-            Thread.sleep(detectionTimeout.toLongMilliseconds())
+            Thread.sleep(detectionTimeoutMs)
 
             assertTrue(serverWire.connected.value)
             assertTrue(clientWire.connected.value)
@@ -350,7 +347,7 @@ class SocketWireTest : TestBase() {
             else
                 proxy.startServerToClientMessaging()
 
-            Thread.sleep(detectionTimeout.toLongMilliseconds())
+            Thread.sleep(detectionTimeoutMs)
 
             assertTrue(serverWire.connected.value)
             assertTrue(clientWire.connected.value)

--- a/rd-net/RdFramework/Impl/SocketWire.cs
+++ b/rd-net/RdFramework/Impl/SocketWire.cs
@@ -16,48 +16,48 @@ namespace JetBrains.Rd.Impl
   public static class SocketWire
   {
     private static readonly ILog ourStaticLog = Log.GetLog<Base>();
-    
+
     public abstract class Base : WireBase
     {
       /// <summary>
       /// Timeout for <see cref="System.Net.Sockets.Socket.Connect(System.Net.EndPoint)"/>  and for <see cref="System.Net.Sockets.Socket.Receive(byte[],int,System.Net.Sockets.SocketFlags)"/>  from socket (to guarantee read_thread termination if <see cref="System.Net.Sockets.Socket.Close()"/> doesn't
-      /// lead to exception thrown by <see cref="System.Net.Sockets.Socket.Receive(byte[],int,System.Net.Sockets.SocketFlags)"/> 
+      /// lead to exception thrown by <see cref="System.Net.Sockets.Socket.Receive(byte[],int,System.Net.Sockets.SocketFlags)"/>
       /// </summary>
       public static int TimeoutMs = 500;
 
       private const int ACK_MSG_LEN = -1;
       private const int PING_LEN = -2;
-      
+
       /// <summary>
       /// For logging
       /// </summary>
       public readonly string Id;
-      
+
       protected readonly ILog Log;
-      
+
       /// <summary>
       /// Lifetime of this wire. If counterpart disconnects, lifetime is not terminate automatically.
       /// </summary>
       private readonly Lifetime myLifetime;
-      
-      
+
+
       //All operations must be bound to socket (connect or accept) thread.
       protected readonly IViewableProperty<Socket> SocketProvider = new ViewableProperty<Socket> ();
-      
+
       public readonly IViewableProperty<bool> Connected = new ViewableProperty<bool> { Value = false };
       public readonly IViewableProperty<bool> HeartbeatAlive = new ViewableProperty<bool> { Value = false };
 
       protected readonly ByteBufferAsyncProcessor SendBuffer;
       protected readonly object Lock = new object();
-      
+
       public Socket Socket { get; protected set; }
 
       [PublicAPI]
       public long ReadBytesCount;
-      
+
       [PublicAPI]
       public long WrittenBytesCount;
-      
+
       private readonly Actor<long> myAcktor;
       const string DisconnectedPauseReason = "Disconnected";
 
@@ -71,10 +71,10 @@ namespace JetBrains.Rd.Impl
         SendBuffer = new ByteBufferAsyncProcessor(id+"-Sender", Send0);
         SendBuffer.Pause(DisconnectedPauseReason);
         SendBuffer.Start();
-        
+
         Connected.Advise(lifetime, value => HeartbeatAlive.Value = value);
-        
-        
+
+
         //when connected
         SocketProvider.Advise(lifetime, socket =>
         {
@@ -85,8 +85,8 @@ namespace JetBrains.Rd.Impl
 
           SendBuffer.ReprocessUnacknowledged();
           SendBuffer.Resume(DisconnectedPauseReason);
-          
-          scheduler.Queue(() => { Connected.Value = true; });                              
+
+          scheduler.Queue(() => { Connected.Value = true; });
 
           try
           {
@@ -99,11 +99,11 @@ namespace JetBrains.Rd.Impl
             scheduler.Queue(() => {Connected.Value = false;});
 
             SendBuffer.Pause(DisconnectedPauseReason);
-            
+
             timer.Dispose();
-            
+
             CloseSocket(socket);
-          }          
+          }
         });
       }
 
@@ -128,11 +128,11 @@ namespace JetBrains.Rd.Impl
       {
         if (socket == null)
           return;
-        
+
         ourStaticLog.CatchAndDrop(() => socket.Shutdown(SocketShutdown.Both));
-        
+
         //on netcore you can't solely execute Close() - it will hang forever
-        //sometimes on netcoreapp2.1 it could hang forever during <c>Accept()</c> on other thread: https://github.com/dotnet/corefx/issues/26034 
+        //sometimes on netcoreapp2.1 it could hang forever during <c>Accept()</c> on other thread: https://github.com/dotnet/corefx/issues/26034
         //we use zero timeout here to avoid blocking mode with (possible infinite) SpinWait
         // According to reference source, non-zero timeouts (infinite -1 or positive numbers) lead to the problematic code with hanging spin wait.
         // The linked corefx issue gives mixed feedback on when it's fixed (netcore 3/net 5), but we have first-hand evidence for issues on netcore 3.
@@ -141,15 +141,15 @@ namespace JetBrains.Rd.Impl
       }
 
 
-      
+
 
       private BufferWindow myMsgLengthBuffer;
       private BufferWindow myPkg;
       private BufferWindow myPkgBuffer;
       private BufferWindow myPkgHeaderBuffer;
       private BufferWindow mySocketBuffer;
-      
-      
+
+
       private void ReceiverProc(Socket socket)
       {
         myPkg = new BufferWindow(16384);
@@ -157,7 +157,7 @@ namespace JetBrains.Rd.Impl
         mySocketBuffer = new BufferWindow(16384);
         myMsgLengthBuffer = new BufferWindow(4);
         myPkgHeaderBuffer = new BufferWindow(12);
-        
+
         while (myLifetime.IsAlive)
         {
           if (!socket.Connected)
@@ -194,7 +194,7 @@ namespace JetBrains.Rd.Impl
                   "Sometimes it happens because of Timeout property on socket. Your os: {3}.",
                   e.GetType().Name, Id, e.Message, Environment.OSVersion.VersionString);
               }
-              
+
             }
             else
             {
@@ -208,8 +208,8 @@ namespace JetBrains.Rd.Impl
 
       private bool ReadMsg()
       {
-        long maxSeqnAtStart = myMaxReceivedSeqn; 
-        
+        long maxSeqnAtStart = myMaxReceivedSeqn;
+
         myMsgLengthBuffer.Lo = myMsgLengthBuffer.Hi = 0;
         if (!myMsgLengthBuffer.Read(ref myPkgBuffer, ReceiveFromPkgBuffer))
           return false;
@@ -222,20 +222,20 @@ namespace JetBrains.Rd.Impl
           Log.Warn("{0}: Can't read message with len={1} from the wire because connection was shut down", Id, len);
           return false;
         }
-        
+
         if (myMaxReceivedSeqn > maxSeqnAtStart)
           myAcktor.SendAsync(myMaxReceivedSeqn);
-        
+
         Receive(msgBuffer.Data);
         ReadBytesCount += len + sizeof(Int32 /*len*/);
         return true;
       }
 
-      
+
       private int ReceiveFromPkgBuffer(byte[] buffer, int offset, int size)
       {
         //size > 0
-        
+
         if (myPkg.Available > 0)
         {
           var sizeToCopy = Math.Min(size, myPkg.Available);
@@ -258,7 +258,7 @@ namespace JetBrains.Rd.Impl
               Int32 receivedCounterpartTimestamp = UnsafeReader.ReadInt32FromBytes(myPkgHeaderBuffer.Data, sizeof(Int32) + sizeof(Int32));
               myCounterpartTimestamp = receivedTimestamp;
               myCounterpartNotionTimestamp = receivedCounterpartTimestamp;
-              
+
               if (ConnectionEstablished(myCurrentTimeStamp, myCounterpartNotionTimestamp))
               {
                 if (!HeartbeatAlive.Value) // only on change
@@ -272,7 +272,7 @@ namespace JetBrains.Rd.Impl
                 }
                 HeartbeatAlive.Value = true;
               }
-              
+
               continue;
             }
 
@@ -283,7 +283,7 @@ namespace JetBrains.Rd.Impl
             }
             else
             {
-              
+
               myPkg.Clear();
               if (!myPkg.Read(ref mySocketBuffer, ReceiveFromSocket, len))
                 return 0;
@@ -292,7 +292,7 @@ namespace JetBrains.Rd.Impl
               {
                 myMaxReceivedSeqn = seqN; //will be acknowledged when we read whole message
                 Assertion.Assert(myPkg.Available > 0, "myPkgBuffer.Available > 0");
-                
+
                 var sizeToCopy = Math.Min(size, myPkg.Available);
                 myPkg.MoveTo(buffer, offset, sizeToCopy);
                 return sizeToCopy;
@@ -332,7 +332,7 @@ namespace JetBrains.Rd.Impl
           Log.Warn(e, $"{Id}: {e.GetType()} raised during ACK, seqn = {seqN}");
         }
       }
-      
+
       private void Ping()
       {
         if (BackwardsCompatibleWireFormat) return;
@@ -373,9 +373,9 @@ namespace JetBrains.Rd.Impl
           Log.Warn(e, $"{Id}: {e.GetType()} raised during PING");
         }
       }
-      
+
       private readonly object mySocketSendLock = new object();
-      
+
       private int ReceiveFromSocket(byte[] buffer, int offset, int size)
       {
         return Socket.Receive(buffer, offset, size, 0);
@@ -388,23 +388,27 @@ namespace JetBrains.Rd.Impl
       private readonly byte[] mySendPkgHeader = new byte[ PkgHeaderLen];
       private readonly byte[] myAckPkgHeader = new byte[ PkgHeaderLen]; //different threads
 
+      /// <summary>
+      /// Ping's interval and not actually detection's timeout.
+      /// Its value must be the same on both sides of connection.
+      /// </summary>
       public TimeSpan HeartBeatInterval { get; set; } = TimeSpan.FromMilliseconds(500);
-      
+
       /// <summary>
       /// Timestamp of this wire which increases at intervals of <see cref="HeartBeatInterval"/>
       /// </summary>
       private int myCurrentTimeStamp;
-      
+
       /// <summary>
       /// Actual notion about counterpart's <see cref="myCurrentTimeStamp"/>
       /// </summary>
       private int myCounterpartTimestamp;
-      
+
       /// <summary>
       /// The latest received counterpart's notion of this wire's <see cref="myCurrentTimeStamp"/>
       /// </summary>
       private int myCounterpartNotionTimestamp;
-      
+
       internal const int MaximumHeartbeatDelay = 3;
       private readonly byte[] myPingPkgHeader = new byte[ PkgHeaderLen];
 
@@ -440,23 +444,23 @@ namespace JetBrains.Rd.Impl
           {
             Log.Error(e);
           }
-                    
-        }        
+
+        }
       }
 
       protected override void SendPkg(UnsafeWriter.Cookie cookie)
       {
         SendBuffer.Put(cookie);
       }
-      
-      
+
+
       //It's a kind of magic...
       protected static void SetSocketOptions(Socket s)
       {
-        s.NoDelay = true;              
+        s.NoDelay = true;
 
 //        if (!TimeoutForbidden())
-//          s.ReceiveTimeout = TimeoutMs; //sometimes shutdown and close doesn't lead Receive to throw exception 
+//          s.ReceiveTimeout = TimeoutMs; //sometimes shutdown and close doesn't lead Receive to throw exception
 
         //following optimization is under Windows only
 //        if (!PlatformUtil.IsRunningUnderWindows) return;
@@ -477,7 +481,7 @@ namespace JetBrains.Rd.Impl
       }
 
 
-      //can't take socket from mySocketProvider: it could be not set yet 
+      //can't take socket from mySocketProvider: it could be not set yet
       protected void AddTerminationActions([NotNull] Thread receiverThread)
       {
         // ReSharper disable once ImpureMethodCallOnReadonlyValueField
@@ -516,10 +520,10 @@ namespace JetBrains.Rd.Impl
 
     public class Client : Base
     {
-      public Client(Lifetime lifetime, [NotNull] IScheduler scheduler, int port, string optId = null) : 
+      public Client(Lifetime lifetime, [NotNull] IScheduler scheduler, int port, string optId = null) :
         this(lifetime, scheduler, new IPEndPoint(IPAddress.Loopback, port), optId) {}
 
-      public Client(Lifetime lifetime, [NotNull] IScheduler scheduler, [NotNull] IPEndPoint endPoint, string optId = null) : 
+      public Client(Lifetime lifetime, [NotNull] IScheduler scheduler, [NotNull] IPEndPoint endPoint, string optId = null) :
         base("ClientSocket-"+(optId ?? "<noname>"), lifetime, scheduler)
       {
         var thread = new Thread(() =>
@@ -690,8 +694,8 @@ namespace JetBrains.Rd.Impl
         AddTerminationActions(thread);
       }
     }
-    
-    
+
+
     public struct WireParameters
     {
       public readonly IScheduler Scheduler;
@@ -710,16 +714,16 @@ namespace JetBrains.Rd.Impl
       }
     }
 
-    
 
-    
+
+
     public class ServerFactory
     {
       [PublicAPI] public readonly int LocalPort;
       [PublicAPI] public readonly IViewableSet<Server> Connected = new ViewableSet<Server>();
 
-      
-      public ServerFactory(Lifetime lifetime, IScheduler scheduler, IPEndPoint endpoint = null) 
+
+      public ServerFactory(Lifetime lifetime, IScheduler scheduler, IPEndPoint endpoint = null)
         : this(lifetime, () => new WireParameters(scheduler, null), endpoint) {}
 
 
@@ -736,8 +740,8 @@ namespace JetBrains.Rd.Impl
           ourStaticLog.Verbose("closing server socket");
           Base.CloseSocket(serverSocket);
         });
-        LocalPort = ((IPEndPoint) serverSocket.LocalEndPoint).Port; 
-        
+        LocalPort = ((IPEndPoint) serverSocket.LocalEndPoint).Port;
+
         void Rec()
         {
           lifetime.TryExecute(() =>
@@ -762,7 +766,7 @@ namespace JetBrains.Rd.Impl
 
         Rec();
       }
-      
+
     }
   }
 }


### PR DESCRIPTION
Upon moving _heartBeatInterval_ to _IWire_, its type changed to _kotlin.time.Duration_ which marked with annotation _ExperimentalTime_.