### PR TITLE
restore os-independent code generation (EOL style)

### DIFF
--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/cpp/FileSystemPrettyPrinter.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/cpp/FileSystemPrettyPrinter.kt
@@ -19,6 +19,6 @@ class FileSystemPrettyPrinter(val file: File) {
 }
 
 internal fun PrettyPrinter.setUp() = this.apply {
-    eolKind = Eol.osSpecified
+    eolKind = Eol.linux
     step = 4
 }

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/csharp/CSharp50Generator.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/csharp/CSharp50Generator.kt
@@ -293,7 +293,7 @@ open class CSharp50Generator(
         toplevels.forEach { tl ->
             tl.fsPath.bufferedWriter().use { writer ->
                 PrettyPrinter().apply {
-                    eolKind = Eol.osSpecified
+                    eolKind = Eol.linux
                     step = 2
 
                     //actual generation

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/kotlin/Kotlin11Generator.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/kotlin/Kotlin11Generator.kt
@@ -257,7 +257,7 @@ open class Kotlin11Generator(
         toplevels.forEach { tl ->
             tl.fsPath.bufferedWriter().use { writer ->
                 PrettyPrinter().apply {
-                    eolKind = Eol.osSpecified
+                    eolKind = Eol.linux
                     step = 4
 
                     //actual generation


### PR DESCRIPTION
restore os-independent code generation after accidental change in 9a0ed7864c248b875f9ecf849330620b312f4d13

Sets EOL style always to LF