### PR TITLE
Fix "C++" in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ JetBrains.Rd.Impl.Server and *.Client respectively
 
 com.jetbrains.rd.framework.Server and *.Client respectively
 
-### С++
+### C++
 
 rd::SocketWire::Server and *.Client respectively
 


### PR DESCRIPTION
There was a fake "С" there instead of the real one.