### PR TITLE
Drop an unnecessary heartbeat trace

### DIFF
--- a/rd-net/RdFramework/Impl/SocketWire.cs
+++ b/rd-net/RdFramework/Impl/SocketWire.cs
@@ -114,7 +114,6 @@ namespace JetBrains.Rd.Impl
         void OnTimedEvent(object sender, ElapsedEventArgs e)
         {
           Ping();
-          Log.Trace()?.Log($"{Id}: sent PING");
         }
 
         var timer = new Timer(HeartBeatInterval.TotalMilliseconds){AutoReset = true};


### PR DESCRIPTION
I've already removed its Kotlin counterpart in #95, but forgot about this one.