### PR TITLE
Increments myTotalMessagesProcessed as an atomic operation

### DIFF
--- a/rd-net/Lifetimes/Threading/Actor.cs
+++ b/rd-net/Lifetimes/Threading/Actor.cs
@@ -29,7 +29,7 @@ namespace JetBrains.Threading
 
     private readonly AsyncLocal<Unit> myInsideProcessingFlow = new AsyncLocal<Unit>(); 
 
-    private long myTotalMessagesProcessed; //todo maybe someday we run in ARM we need Interlocked.Increment
+    private long myTotalMessagesProcessed;
 
     /// <summary>
     /// You can use this field for composing this actor's channel with other channels.
@@ -125,7 +125,7 @@ namespace JetBrains.Threading
       }
       finally
       {
-        myTotalMessagesProcessed++;
+        Interlocked.Increment(ref myTotalMessagesProcessed);
       }
     }
 


### PR DESCRIPTION
It is a possible fix for ReSharper support case:
```
008fdaa8 7724216c [HelperMethodFrame: 008fdaa8] System.Threading.Thread.SleepInternal(Int32)
008fdb2c 71febe7b System.Threading.Thread.Sleep(Int32)
008fdb34 72084fc6 System.Threading.SpinWait.SpinOnce()
008fdb44 2479e89e JetBrains.Threading.SpinWaitEx.SpinUntil(JetBrains.Lifetimes.Lifetime, Int64, System.Func`1<Boolean>)
008fdb68 2479e801 JetBrains.Threading.SpinWaitEx.SpinUntil(System.Func`1<Boolean>)
008fdb88 2479e6fd JetBrains.Threading.Actor`1[[JetBrains.Rd.Impl.Serializers+ToplevelRegistration, JetBrains.RdFramework]].WaitForEmpty()
008fdb9c 2479e508 JetBrains.Rd.Impl.Serializers.Write[[System.__Canon, mscorlib]](JetBrains.Rd.SerializationCtx, JetBrains.Serialization.UnsafeWriter, System.__Canon)
008fdbd0 2479e4cc JetBrains.Rd.Impl.Polymorphic`1+<>c[[System.__Canon, mscorlib]].<.cctor>b__3_1(JetBrains.Rd.SerializationCtx, JetBrains.Serialization.UnsafeWriter, System.__Canon)
008fdbf0 2479e3eb JetBrains.Rd.Impl.RdProperty`1+<>c__DisplayClass21_0[[System.__Canon, mscorlib]].<Init>b__3(JetBrains.Rd.Impl.SendContext`2<System.__Canon,JetBrains.Rd.Impl.RdProperty`1<System.__Canon>>, JetBrains.Serialization.UnsafeWriter)
008fdc38 2479e15b JetBrains.Rd.Base.ExtWire.Send[[JetBrains.Rd.Impl.SendContext`2[[System.__Canon, mscorlib],[System.__Canon, mscorlib]], JetBrains.RdFramework]]
```