### PR TITLE
Memory leak workaround

### DIFF
--- a/rd-net/RdFramework/Impl/Serializers.cs
+++ b/rd-net/RdFramework/Impl/Serializers.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using JetBrains.Core;
 using JetBrains.Diagnostics;
@@ -50,9 +51,14 @@ namespace JetBrains.Rd.Impl
 #if !NET35
     private readonly Actor<ToplevelRegistration> myBackgroundRegistrar;
 
-    public Serializers()
+    [Obsolete("Provide Lifetime and TaskScheduler. An active Task will leak in case of missing Lifetime (via Actor)", false)]
+    public Serializers() : this(Lifetime.Eternal, null)
     {
-      myBackgroundRegistrar = new Actor<ToplevelRegistration>("RegisterSerializers", Lifetime.Eternal, RegisterToplevelInternal);
+    }
+
+    public Serializers(Lifetime lifetime, [CanBeNull] TaskScheduler scheduler)
+    {
+      myBackgroundRegistrar = new Actor<ToplevelRegistration>("RegisterSerializers", lifetime, RegisterToplevelInternal, scheduler);
       myBackgroundRegistrar.SendBlocking(new ToplevelRegistration(typeof(Serializers), RegisterFrameworkMarshallers));
     }
 #else

--- a/rd-net/RdFramework/Impl/Serializers.cs
+++ b/rd-net/RdFramework/Impl/Serializers.cs
@@ -52,24 +52,25 @@ namespace JetBrains.Rd.Impl
     private readonly Actor<ToplevelRegistration> myBackgroundRegistrar;
 
     [Obsolete("Provide Lifetime and TaskScheduler. An active Task will leak in case of missing Lifetime (via Actor)", false)]
-    public Serializers() : this(Lifetime.Eternal, null)
+    public Serializers() : this(Lifetime.Eternal, null, null)
     {
     }
 
-    public Serializers(Lifetime lifetime, [CanBeNull] TaskScheduler scheduler)
+    public Serializers(Lifetime lifetime, [CanBeNull] TaskScheduler scheduler, [CanBeNull] ITypesRegistrar registrar)
     {
+      myRegistrar = registrar;
       myBackgroundRegistrar = new Actor<ToplevelRegistration>("RegisterSerializers", lifetime, RegisterToplevelInternal, scheduler);
       myBackgroundRegistrar.SendBlocking(new ToplevelRegistration(typeof(Serializers), RegisterFrameworkMarshallers));
     }
 #else
     public Serializers() => RegisterFrameworkMarshallers(this);
-#endif
 
     public Serializers([CanBeNull] ITypesRegistrar registrar)
       : this()
     {
       myRegistrar = registrar;
     }
+#endif
 
     //readers
     public static readonly CtxReadDelegate<byte> ReadByte = (ctx, reader) => reader.ReadByte();

--- a/rd-net/Test.RdFramework/Reflection/ProxyGeneratorSimpleTest.cs
+++ b/rd-net/Test.RdFramework/Reflection/ProxyGeneratorSimpleTest.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Diagnostics;
 using JetBrains.dotMemoryUnit;
+using JetBrains.Rd.Impl;
 using JetBrains.Rd.Reflection;
 using JetBrains.Serialization;
 using NUnit.Framework;
@@ -72,6 +73,18 @@ namespace Test.RdFramework.Reflection
       }
       dotMemory.Check(m => Assert.Less(m.GetDifference(checkpoint).GetNewObjects().SizeInBytes, 128_000));
     }
+
+    [Test, Explicit]
+    public void TestLeaksFromSerializers()
+    {
+      var checkpoint = dotMemory.Check();
+      for (int i = 0; i < 100000; i++)
+      {
+        var serializers = new Serializers();
+      }
+      dotMemory.Check(m => Assert.Less(m.GetDifference(checkpoint).GetNewObjects().SizeInBytes, 128_000));
+    }
+
 
     [RdRpc]
     public interface ISimpleCalls

--- a/rd-net/Test.RdFramework/Reflection/RdReflectionTestBase.cs
+++ b/rd-net/Test.RdFramework/Reflection/RdReflectionTestBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 using JetBrains.Rd.Base;
 using JetBrains.Rd.Impl;
 using JetBrains.Rd.Reflection;
@@ -44,7 +45,7 @@ namespace Test.RdFramework.Reflection
 
     protected override Serializers CreateSerializers(bool isServer)
     {
-      return new Serializers(isServer ? SFacade.Registrar : CFacade.Registrar);
+      return new Serializers(TestLifetime, TaskScheduler.Default, isServer ? SFacade.Registrar : CFacade.Registrar);
     }
 
     protected void WithExts<T>(Action<T,T> run) where T : RdBindableBase

--- a/rd-net/Test.Reflection.App/Program.cs
+++ b/rd-net/Test.Reflection.App/Program.cs
@@ -53,7 +53,7 @@ namespace Test.Reflection.App
       var lifetime = lifetimeDefinition.Lifetime;
 
       var reflectionSerializers = new ReflectionSerializersFacade();
-      var serializers = new Serializers(reflectionSerializers.Registrar);
+      var serializers = new Serializers(lifetime, TaskScheduler.Default, reflectionSerializers.Registrar);
 
       var scheduler = SingleThreadScheduler.RunOnSeparateThread(lifetime, "Scheduler");
       Protocol protocol;


### PR DESCRIPTION
Provide an alternative constructor for Serializers for the following reasons:
1. Avoid memory leak by active task in Actor
2. Give an opportunity to fix deadlock described in in #116

> I believe here is another problem that relates to TaskScheduler (or
> maybe SynchronizationContext) of UI thread.  > E.g. in this call stack
> we can see that TaskScheduler is
> `Microsoft.VisualStudio.Services.TaskSchedulerService.VsUIThreadBlockableTaskScheduler`
> and also we see that UI thread is occupied and doesn't pump messages.
>
> On the other hand, when we've created backgroundRegistrar actor in
>
> https://github.com/JetBrains/rd/blob/7346f3b6c60af78219420b3870dde38d1a844da9/rd-net/RdFramework/Impl/Serializers.cs#L55
>
> we may passed bad implicit scheduler into Actor's contructor:
>
> ```
> Task.Factory.StartNew(async () =>
>         {
>           try
>           {
>             myInsideProcessingFlow.Value = Unit.Instance;
>             while (lifetime.IsAlive)
>               await Process();
>           }
>           finally
>           {
>             Assertion.Assert(IsEmpty, "Not empty: sent items: {0}, processed items: {1}", myChannel.TotalMessagesSent, myTotalMessagesProcessed);
>           }
>         }, lifetime, TaskCreationOptions.None, scheduler ?? TaskScheduler.Current);
> ```
>
> So `await` inside this constructor tries to return to UI thread instead of returning to TaskPool.
>
> My suggestion is to replace `TaskScheduler.Current` inside Actor's
> contructor to `TaskScheduler.Default`. If this is too radical for
> project you may pass scheduler explicitly when creating actor from
> `Serializers`.