### PR TITLE
 Fix race in Serializers

### DIFF
--- a/rd-net/RdFramework/Impl/Serializers.cs
+++ b/rd-net/RdFramework/Impl/Serializers.cs
@@ -236,14 +236,6 @@ namespace JetBrains.Rd.Impl
 
     public void Register<T>(CtxReadDelegate<T> reader, CtxWriteDelegate<T> writer, long? predefinedId = null)
     {
-      #if !NET35
-      if (!myBackgroundRegistrar.IsInsideProcessing)
-      {
-        myBackgroundRegistrar.SendBlocking(new ToplevelRegistration(typeof(T), szr => szr.Register(reader, writer, predefinedId)));
-        myBackgroundRegistrar.WaitForEmpty();
-      }
-      #endif
-        
       var typeId = RdId.Define<T>(predefinedId);
       RdId existing;
       if (myTypeMapping.TryGetValue(typeof(T), out existing))


### PR DESCRIPTION
Current synchronization method has several drawbacks:
1. It does not work at all in NET3.5
2. Only actors implementation details protect against simultaneous write
3. It may lead to thread pool starvation

Because types can be registered in `ITypesRegistrar.TryRegister` method
during Read invocation, all others Read invocation on
ThreadScheduler.Default are forced to wait until Actor's queue is empty.

When many Reads are using TryRegister on many threads it may leads to
significant slow down during SpinWait on another threads which leads to
thread starvation sometimes (which is already happened on TeamCity)
