### PR TITLE
UnsafeWriter: option to clean thread static ourWriter after execution…

### DIFF
--- a/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
@@ -29,6 +29,11 @@ namespace JetBrains.Serialization
       private readonly int myStart;
 
       [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+      public Cookie(UnsafeWriter writer) : this(writer, null)
+      {
+      }
+
+      [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
       public Cookie(UnsafeWriter writer, Action cleanupAction = null) : this()
       {
         myWriter = writer;

--- a/rd-net/RdFramework/Impl/SocketWire.cs
+++ b/rd-net/RdFramework/Impl/SocketWire.cs
@@ -351,7 +351,7 @@ namespace JetBrains.Rd.Impl
             HeartbeatAlive.Value = false;
           }
 
-          using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+          using (var cookie = UnsafeWriter.NewThreadLocalWriterWithCleanup())
           {
             cookie.Writer.Write(PING_LEN);
             cookie.Writer.Write(myCurrentTimeStamp);

--- a/rd-net/Test.RdFramework/UnsafeWriterTest.cs
+++ b/rd-net/Test.RdFramework/UnsafeWriterTest.cs
@@ -1,0 +1,85 @@
+﻿using JetBrains.Serialization;
+using NUnit.Framework;
+
+namespace Test.RdFramework
+{
+  [TestFixture]
+  public class UnsafeWriterTest
+  {
+    /*
+    private static UnsafeWriter TryGetThreadStaticField()
+    {
+      var ourWriterField = typeof(UnsafeWriter).GetField("ourWriter", BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
+      return (UnsafeWriter) ourWriterField.GetValue(null);
+    }
+    */
+
+    public void TestWriterIsReused01()
+    {
+      UnsafeWriter firstWriter;
+      using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+      {
+        firstWriter = cookie.Writer;
+      }
+
+      UnsafeWriter secondWriter;
+      using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+      {
+        secondWriter = cookie.Writer;
+      }
+
+      Assert.IsTrue(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
+    }
+
+    public void TestWriterIsReused02()
+    {
+      UnsafeWriter firstWriter;
+      using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+      {
+        firstWriter = cookie.Writer;
+      }
+
+      UnsafeWriter secondWriter;
+      using (var cookie = UnsafeWriter.NewThreadLocalWriterWithCleanup())
+      {
+        secondWriter = cookie.Writer;
+      }
+
+      Assert.IsTrue(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
+    }
+
+    public void TestWriterIsNotReused01()
+    {
+      UnsafeWriter firstWriter;
+      using (var cookie = UnsafeWriter.NewThreadLocalWriterWithCleanup())
+      {
+        firstWriter = cookie.Writer;
+      }
+
+      UnsafeWriter secondWriter;
+      using (var cookie = UnsafeWriter.NewThreadLocalWriterWithCleanup())
+      {
+        secondWriter = cookie.Writer;
+      }
+
+      Assert.IsFalse(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
+    }
+
+    public void TestWriterIsNotReused02()
+    {
+      UnsafeWriter firstWriter;
+      using (var cookie = UnsafeWriter.NewThreadLocalWriterWithCleanup())
+      {
+        firstWriter = cookie.Writer;
+      }
+
+      UnsafeWriter secondWriter;
+      using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+      {
+        secondWriter = cookie.Writer;
+      }
+
+      Assert.IsFalse(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
+    }
+  }
+}


### PR DESCRIPTION
…. Fixes memory leak on heartbeat timer's callback that calls to Ping. Reduces memory leaks in RSRP-480566 Native memory leaked in UnsafeWriter