### PR TITLE
Improvement for RIDER-48322

### DIFF
--- a/rd-kt/rd-core/src/jvmMain/kotlin/com/jetbrains/rd/util/PlatformDependent.kt
+++ b/rd-kt/rd-core/src/jvmMain/kotlin/com/jetbrains/rd/util/PlatformDependent.kt
@@ -19,15 +19,7 @@ actual fun currentThreadName() : String = Thread.currentThread().run { "$id:$nam
 actual class AtomicReference<T> actual constructor(initial: T) {
     private val impl = AtomicReference(initial)
     actual fun get(): T = impl.get()
-    actual fun getAndUpdate(f: (T) -> T): T {
-        var prev: T
-        var next: T
-        do {
-            prev = impl.get()
-            next = f(prev)
-        } while (!impl.compareAndSet(prev, next))
-        return prev
-    }
+    actual fun getAndUpdate(f: (T) -> T): T = impl.getAndUpdate(f)
     fun getAndSet(new: T): T = impl.getAndSet(new)
 }
 

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/impl/RdSignal.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/impl/RdSignal.kt
@@ -46,7 +46,6 @@ class RdSignal<T>(val valueSerializer: ISerializer<T> = Polymorphic<T>()) : RdRe
         wireScheduler = defaultScheduler
         wire.advise(lifetime, this)
 
-        signal.debugId = location.toString()
     }
 
     override fun fire(value: T) {


### PR DESCRIPTION
Roll back #130; log stack trace when 10k handlers are added.

It turns out that JDK wasn't the culprit of issue described in #130. After a dicussion, we've decided to roll these changes back, but keep the diagnostic about 10k handlers, and even call `log.error` in such a case, to print the stack trace to the log.