### PR TITLE
Qx unsafe writer

### DIFF
--- a/rd-net/Lifetimes/Collections/Viewable/SingleThreadScheduler.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/SingleThreadScheduler.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using JetBrains.Diagnostics;
 using JetBrains.Lifetimes;
+using JetBrains.Serialization;
 using JetBrains.Threading;
 
 namespace JetBrains.Collections.Viewable
@@ -139,6 +140,7 @@ namespace JetBrains.Collections.Viewable
       {
         try
         {
+          UnsafeWriter.AllowUnsafeWriterCaching = true;
           while (true)
           {
             ExecuteOneAction(blockIfNoActionAvailable: true);
@@ -150,6 +152,10 @@ namespace JetBrains.Collections.Viewable
         catch (Exception e)
         {
           myLog.Error(e, $"Abnormal termination of {this}");
+        }
+        finally
+        {
+          UnsafeWriter.AllowUnsafeWriterCaching = false;
         }
       }
     }

--- a/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
@@ -62,11 +62,6 @@ namespace JetBrains.Serialization
         return res;
       }
 
-      public void WriteIntLengthToCookieStart(int length)
-      {
-        *(int*) Data = length;
-      }
-
       public void CopyTo(byte[] dst, [Optional] int dstOffset, [Optional] int? count)
       {
         CopyTo(dst, dstOffset, count ?? Count);
@@ -115,7 +110,7 @@ namespace JetBrains.Serialization
       /// </summary>
       public void WriteIntLength()
       {
-        *(int*) Data = myStart - sizeof(int);
+        *(int*) Data = myWriter.Count - myStart - sizeof(int);
       }
 
       public void WriteIntLength(int length)

--- a/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
@@ -62,14 +62,6 @@ namespace JetBrains.Serialization
         return res;
       }
 
-      /// <summary>
-      /// Writes `<see cref="Count"/><c> - sizeof(int)</c>` into the <see cref="Data"/> pointer. Cookie must be prepared by invoking `<see cref="UnsafeWriter.Write(int)"/><c>(0)</c>` as first cookie call.
-      /// </summary>
-      public void WriteIntLengthToCookieStart()
-      {
-        *(int*) Data = Count - sizeof(int);
-      }
-
       public void WriteIntLengthToCookieStart(int length)
       {
         *(int*) Data = length;
@@ -98,6 +90,37 @@ namespace JetBrains.Serialization
           myWriter?.FreeMemory();
         else 
           myWriter?.Reset(myStart);
+      }
+    }
+
+    public struct Bookmark
+    {
+      private readonly UnsafeWriter myWriter;
+      private readonly int myStart;
+
+      public Bookmark(UnsafeWriter writer)
+      {
+        myWriter = writer;
+        myStart = myWriter.Count;
+      }
+
+      public byte* Data
+      {
+        [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+        get => myWriter.Data + myStart;
+      }
+
+      /// <summary>
+      /// Writes `<see cref="Count"/><c> - sizeof(int)</c>` into the <see cref="Data"/> pointer. Cookie must be prepared by invoking `<see cref="UnsafeWriter.Write(int)"/><c>(0)</c>` as first cookie call.
+      /// </summary>
+      public void WriteIntLength()
+      {
+        *(int*) Data = myStart - sizeof(int);
+      }
+
+      public void WriteIntLength(int length)
+      {
+        *(int*) Data = length;
       }
     }
 

--- a/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
@@ -127,6 +127,7 @@ namespace JetBrains.Serialization
       {
         cleanupAction = () =>
         {
+          ourWriter.FreeMemory();
           ourWriter = null;
         };
       }
@@ -158,13 +159,22 @@ namespace JetBrains.Serialization
 
     ~UnsafeWriter()
     {
+      FreeMemory();
+    }
+
+    private void FreeMemory()
+    {
       // See TMLN-925 Timeline crashes during closing
       //ourLogger.Verbose("Removing UnsafeWriter, {0:N0} bytes are being free", myCurrentAllocSize);
       if (myStartPtr != null) 
         LogLog.Catch(() => 
         {
           lock (myLock)
-            if (myStartPtr != null) Marshal.FreeHGlobal(new IntPtr(myStartPtr));
+            if (myStartPtr != null)
+            {
+              Marshal.FreeHGlobal(new IntPtr(myStartPtr));
+              myStartPtr = null;
+            }
         });
     }
     

--- a/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
@@ -103,10 +103,22 @@ namespace JetBrains.Serialization
 
     private const string LogCategory = "UnsafeWriter";
 
+
+    [ThreadStatic] private static bool ourAllowUnsafeWriterCaching;
+
     /// <summary>
     /// Whether <see cref="UnsafeWriter"/> can be cached for the specific thread.
     /// </summary>
-    [ThreadStatic] public static bool AllowUnsafeWriterCaching;
+    public static bool AllowUnsafeWriterCaching
+    {
+      get => ourAllowUnsafeWriterCaching;
+      set
+      {
+        ourAllowUnsafeWriterCaching = value;
+        if (!ourAllowUnsafeWriterCaching)
+          ourWriter = null;
+      }
+    }
 
     /// <summary>
     /// Cached <see cref="UnsafeWriter"/> for reuse
@@ -520,6 +532,7 @@ namespace JetBrains.Serialization
     public static readonly WriteDelegate<byte[]> ByteArrayDelegate = (writer, x) => writer.Write(x);
     public static readonly WriteDelegate<int[]> IntArrayDelegate = (writer, x) => writer.Write(x);
     public static readonly WriteDelegate<string[]> StringArrayDelegate = (writer, x) => writer.Write(StringDelegate, x);
+
     #endregion
 
 

--- a/rd-net/Lifetimes/Serialization/UnsafeWriterStatistics.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriterStatistics.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using JetBrains.Annotations;
+
+namespace JetBrains.Serialization
+{
+  public static class UnsafeWriterStatistics
+  {
+    public static int ReportAllocationOnNonCachedThreadThreshold = 1 << 20;
+    public static int ReportAccessCounterThreshold = 1000;
+    public static int ReportOnOfN = 1000;
+
+    // thread data
+    [ThreadStatic] private static bool ourThreadIsUsed = false;
+    [ThreadStatic] private static int ourThreadReentrancyCounter = 0;
+    [ThreadStatic] private static int ourThreadAccessCounter = 0;
+    [ThreadStatic] private static int ourThreadMaxAllocatedSize = 0;
+
+    private static readonly IList<Event> ourEvents = new List<Event>();
+    private static int ourThreadCount = 0;
+    private static int ourMaxAllocatedSize = 0;
+
+    public static IList<Event> GetEvents()
+    {
+      lock (ourEvents)
+        return ourEvents.ToArray();
+    }
+
+    public static int GetThreadCount() => ourThreadCount;
+    public static int GetMaxAllocatedSize() => ourMaxAllocatedSize;
+
+    public static void AddEvent(Event @event)
+    {
+      lock(ourEvents)
+        ourEvents.Add(@event);
+    }
+
+    public static void ClearEvents()
+    {
+      lock(ourEvents)
+        ourEvents.Clear();
+    }
+
+    public class Event
+    {
+      public EventType Type { get; }
+      [CanBeNull] public String Stacktrace { get; }
+      [CanBeNull] public string Message { get; }
+
+      public Event(EventType type, [CanBeNull] string message, [CanBeNull] string stacktrace)
+      {
+        Type = type;
+        Stacktrace = stacktrace;
+        Message = message;
+      }
+    }
+
+    public enum EventType
+    {
+      REENTRANCY,
+      ACCESS_COUNTER,
+      MEMORY_ALLOCATION
+    }
+
+
+    private static void ReportEvent(EventType type, [CanBeNull] string message)
+    {
+      var @event = new Event(type, message, Environment.StackTrace);
+      AddEvent(@event);
+    }
+
+    public static void OnCookieCreated()
+    {
+      if (!ourThreadIsUsed)
+      {
+        Interlocked.Increment(ref ourThreadCount);
+        ourThreadIsUsed = true;
+      }
+
+      ourThreadReentrancyCounter++;
+      // if (ourThreadReentrancyCounter > 1)
+      //   ReportEvent(EventType.REENTRANCY, null);
+
+      ourThreadAccessCounter++;
+      if (!UnsafeWriter.AllowUnsafeWriterCaching && ourThreadAccessCounter > ReportAccessCounterThreshold)
+      {
+        if (ourThreadAccessCounter % ReportOnOfN == 0)
+          ReportEvent(EventType.ACCESS_COUNTER, $"{ourThreadAccessCounter} UnsafeWriter calls on thread without caching");
+      }
+    }
+
+    public static void OnCookieDisposing(int initialAllocSize, int currentSize)
+    {
+      ourThreadReentrancyCounter--;
+      if (!UnsafeWriter.AllowUnsafeWriterCaching)
+      {
+        if (currentSize > ReportAllocationOnNonCachedThreadThreshold)
+          ReportEvent(EventType.MEMORY_ALLOCATION, $"{currentSize} bytes allocated on thread without caching");
+      }
+
+      if (currentSize > ourThreadMaxAllocatedSize)
+      {
+        ourThreadMaxAllocatedSize = currentSize;
+        while (ourThreadMaxAllocatedSize > ourMaxAllocatedSize)
+          Interlocked.CompareExchange(ref ourMaxAllocatedSize, ourThreadMaxAllocatedSize, ourMaxAllocatedSize);
+      }
+    }
+  }
+}

--- a/rd-net/Lifetimes/Serialization/UnsafeWriterStatistics.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriterStatistics.cs
@@ -11,6 +11,7 @@ namespace JetBrains.Serialization
     public static int ReportAllocationOnNonCachedThreadThreshold = 1 << 20;
     public static int ReportAccessCounterThreshold = 1000;
     public static int ReportOnOfN = 1000;
+    public static bool ReportReentrancy = false;
 
     // thread data
     [ThreadStatic] private static bool ourThreadIsUsed = false;
@@ -81,7 +82,7 @@ namespace JetBrains.Serialization
       }
 
       ourThreadReentrancyCounter++;
-      if (ourThreadReentrancyCounter > 1)
+      if (ourThreadReentrancyCounter > 1 && ReportReentrancy)
       {
         if (ourThreadReentrancyStacks == null)
           ourThreadReentrancyStacks = new List<string>();

--- a/rd-net/Lifetimes/Threading/ByteBufferAsyncProcessor.cs
+++ b/rd-net/Lifetimes/Threading/ByteBufferAsyncProcessor.cs
@@ -204,13 +204,18 @@ namespace JetBrains.Threading
     {
       try
       {
+        UnsafeWriter.AllowUnsafeWriterCaching = true;
         ThreadProc();
       }
       catch (ThreadAbortException e)
       {
         LogLog.Info($"ByteBufferProcessor {Id} was stopped by Thread.Abort rather than by normal Stop(): {0}", e);
-          
+
         Thread.ResetAbort();
+      }
+      finally
+      {
+        UnsafeWriter.AllowUnsafeWriterCaching = false;
       }
     }
     
@@ -263,71 +268,80 @@ namespace JetBrains.Threading
     
     private void ThreadProc()
     {
-      while (true)
+      UnsafeWriter.AllowUnsafeWriterCaching = true;
+      try
       {
-        lock (myLock)
-        {
-          if (State >= StateKind.Terminating) return;
 
-          while (myAllDataProcessed || myPauseReasons.Count > 0)
-          {
-            if (State >= StateKind.Stopping) return;
-            Monitor.Wait(myLock);
-            if (State >= StateKind.Terminating) return;
-          }
-
-          //In case of only put requests, we could write Assertion.Assert(chunk.Ptr > 0, "chunk.Ptr > 0"); 
-          //But in case of clear, we could get "Wait + Put(full)  + Clear + Put" before this line and 'chunkToProcess' will point to empty chunk. 
-          //RIDER-15223
-          while (myChunkToProcess.CheckEmpty(this)) //should never be endless, because `myAllDataProcessed` is 'false', that means that we MUST have ptr > 0 somewhere
-            myChunkToProcess = myChunkToProcess.Next;
-
-          if (myChunkToFill == myChunkToProcess)
-          {
-            //it's possible that next chuck is occupied by entry with seqN > acknowledgedSeqN
-            GrowConditionally();
-            
-            myChunkToFill = myChunkToProcess.Next;
-          }
-
-          ShrinkConditionally(myChunkToProcess);
-          
-          Assertion.Assert(myChunkToProcess.Ptr > 0, "chunkToProcess.Ptr > 0");
-          Assertion.Assert(myChunkToFill != myChunkToProcess && myChunkToFill.IsNotProcessed, "myChunkToFill != chunkToProcess && myChunkToFill.IsNotProcessed");
-
-          myProcessing = true;
-        }
-
-        
-        long seqN = myChunkToProcess.IsNotProcessed ? 0 : myChunkToProcess.SeqN;
-        try
-        {
-          myProcessor(myChunkToProcess.Data, 0, myChunkToProcess.Ptr, ref seqN);
-        }
-        catch (Exception e)
-        {
-          LogLog.Error(e);
-        }
-        finally
+        while (true)
         {
           lock (myLock)
           {
-            myProcessing = false;
+            if (State >= StateKind.Terminating) return;
 
-            if (myChunkToProcess == null)
+            while (myAllDataProcessed || myPauseReasons.Count > 0)
             {
-              LogLog.Error($"{nameof(myChunkToProcess)} is null. State: {State}");
+              if (State >= StateKind.Stopping) return;
+              Monitor.Wait(myLock);
+              if (State >= StateKind.Terminating) return;
             }
-            else
-            {
-              myChunkToProcess.SeqN = seqN;
+
+            //In case of only put requests, we could write Assertion.Assert(chunk.Ptr > 0, "chunk.Ptr > 0"); 
+            //But in case of clear, we could get "Wait + Put(full)  + Clear + Put" before this line and 'chunkToProcess' will point to empty chunk. 
+            //RIDER-15223
+            while (myChunkToProcess.CheckEmpty(this)) //should never be endless, because `myAllDataProcessed` is 'false', that means that we MUST have ptr > 0 somewhere
               myChunkToProcess = myChunkToProcess.Next;
-//            Assertion.Assert(myChunkToProcess.IsNotProcessed, "chunkToProcess.IsNotProcessed"); not true in case of reprocessing
-              if (myChunkToProcess.Ptr == 0)
-                myAllDataProcessed = true;
+
+            if (myChunkToFill == myChunkToProcess)
+            {
+              //it's possible that next chuck is occupied by entry with seqN > acknowledgedSeqN
+              GrowConditionally();
+
+              myChunkToFill = myChunkToProcess.Next;
+            }
+
+            ShrinkConditionally(myChunkToProcess);
+
+            Assertion.Assert(myChunkToProcess.Ptr > 0, "chunkToProcess.Ptr > 0");
+            Assertion.Assert(myChunkToFill != myChunkToProcess && myChunkToFill.IsNotProcessed, "myChunkToFill != chunkToProcess && myChunkToFill.IsNotProcessed");
+
+            myProcessing = true;
+          }
+
+
+          long seqN = myChunkToProcess.IsNotProcessed ? 0 : myChunkToProcess.SeqN;
+          try
+          {
+            myProcessor(myChunkToProcess.Data, 0, myChunkToProcess.Ptr, ref seqN);
+          }
+          catch (Exception e)
+          {
+            LogLog.Error(e);
+          }
+          finally
+          {
+            lock (myLock)
+            {
+              myProcessing = false;
+
+              if (myChunkToProcess == null)
+              {
+                LogLog.Error($"{nameof(myChunkToProcess)} is null. State: {State}");
+              }
+              else
+              {
+                myChunkToProcess.SeqN = seqN;
+                myChunkToProcess = myChunkToProcess.Next;
+                //            Assertion.Assert(myChunkToProcess.IsNotProcessed, "chunkToProcess.IsNotProcessed"); not true in case of reprocessing
+                if (myChunkToProcess.Ptr == 0)
+                  myAllDataProcessed = true;
+              }
             }
           }
         }
+      }
+      finally
+      {
+        UnsafeWriter.AllowUnsafeWriterCaching = false;
       }
     }
 

--- a/rd-net/RdFramework/IWire.cs
+++ b/rd-net/RdFramework/IWire.cs
@@ -20,7 +20,7 @@ namespace JetBrains.Rd
   public abstract class WireBase : IWire
   {    
     protected readonly MessageBroker MessageBroker;
-    private IScheduler myScheduler;
+    protected IScheduler Scheduler { get; }
     private ProtocolContexts myContexts;
     
     private bool myBackwardsCompatibleWireFormat = false;
@@ -50,7 +50,7 @@ namespace JetBrains.Rd
     {
       if (scheduler == null) throw new ArgumentNullException(nameof(scheduler));
 
-      myScheduler = scheduler;
+      Scheduler = scheduler;
       MessageBroker = new MessageBroker(scheduler);
     }
 

--- a/rd-net/RdFramework/IWire.cs
+++ b/rd-net/RdFramework/IWire.cs
@@ -82,13 +82,14 @@ namespace JetBrains.Rd
 
       using (var cookie = UnsafeWriter.NewThreadLocalWriter())
       {
+        var bookmark = new UnsafeWriter.Bookmark(cookie.Writer);
         cookie.Writer.Write(0); //placeholder for length
 
         id.Write(cookie.Writer);
         if (!myBackwardsCompatibleWireFormat)
           this.WriteContext(cookie.Writer);
         writer(param, cookie.Writer);
-        cookie.WriteIntLengthToCookieStart();
+        bookmark.WriteIntLength();
 
         SendPkg(cookie);
       }

--- a/rd-net/RdFramework/Impl/Serializers.cs
+++ b/rd-net/RdFramework/Impl/Serializers.cs
@@ -337,14 +337,14 @@ namespace JetBrains.Rd.Impl
       typeId.Write(writer);
 
       // Don't dispose this cookie, otherwise it will delete all written data
-      var cookie = new UnsafeWriter.Cookie(writer);
+      var bookmark = new UnsafeWriter.Bookmark(writer);
       writer.Write(0);
       CtxWriteDelegate<object> writerDelegate;
       lock (myLock)
         writerDelegate = myWriters[typeId];
       writerDelegate(ctx, writer, value);
 
-      cookie.WriteIntLengthToCookieStart();
+      bookmark.WriteIntLength();
     }
 
     

--- a/rd-net/RdFramework/Impl/SerializersEx.cs
+++ b/rd-net/RdFramework/Impl/SerializersEx.cs
@@ -46,9 +46,8 @@ namespace JetBrains.Rd.Impl
         return;
       }
 
-      // // Don't dispose this cookie, otherwise it will delete all written data
-      var cookie = new UnsafeWriter.Cookie(writer);
-      cookie.Writer.Write(-1); // length
+      var cookie = new UnsafeWriter.Bookmark(writer);
+      writer.Write(-1); // length
       int i = 0;
       foreach (var item in value)
       {
@@ -56,7 +55,7 @@ namespace JetBrains.Rd.Impl
         itemWriter(ctx, writer, item);
       }
 
-      cookie.WriteIntLengthToCookieStart(i);
+      cookie.WriteIntLength(i);
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]

--- a/rd-net/Test.Lifetimes/Serialization/UnsafeMarshallersTest.cs
+++ b/rd-net/Test.Lifetimes/Serialization/UnsafeMarshallersTest.cs
@@ -9,68 +9,76 @@ namespace Test.Lifetimes.Serialization
     [Test]
     public void Test1()
     {
-      UnsafeReader reader;
-      using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+      UnsafeWriter.AllowUnsafeWriterCaching = true;
+      try
       {
-        cookie.Writer.Write(false);
-        cookie.Writer.Write(true);
-        cookie.Writer.Write((byte) 0);
-        cookie.Writer.Write((byte) 10);
-        cookie.Writer.Write('y');
-        cookie.Writer.Write('й');
-        cookie.Writer.Write(1234.5678m);
-        cookie.Writer.Write(1234.5678d);
-        cookie.Writer.Write((short) 1000);
-        cookie.Writer.Write((int) 1001);
-        cookie.Writer.Write((long) -1002);
-        
-        
-        cookie.Writer.Write((string) null);
-        cookie.Writer.Write("");
-        cookie.Writer.Write("abcd = yй");
-        
-        cookie.Writer.Write((int[]) (null));
-        cookie.Writer.Write(new int[0]);
-        cookie.Writer.Write(new[] {1, 2, 3});
-        
-        cookie.Writer.Write(UnsafeWriter.StringDelegate, (string[]) null);
-        cookie.Writer.Write(UnsafeWriter.StringDelegate, new string[0]);
-        cookie.Writer.Write(UnsafeWriter.StringDelegate, new[] {"a", "b", "c"});
-        
-        cookie.Writer.Write(UnsafeWriter.StringDelegate, (List<string>) null);
-        cookie.Writer.Write(UnsafeWriter.StringDelegate, new List<string>());
-        cookie.Writer.Write(UnsafeWriter.StringDelegate, new List<string> {"d", "e"});
-        
-        reader = UnsafeReader.CreateReader(cookie.Data, cookie.Count);
+        UnsafeReader reader;
+        using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+        {
+          cookie.Writer.Write(false);
+          cookie.Writer.Write(true);
+          cookie.Writer.Write((byte) 0);
+          cookie.Writer.Write((byte) 10);
+          cookie.Writer.Write('y');
+          cookie.Writer.Write('й');
+          cookie.Writer.Write(1234.5678m);
+          cookie.Writer.Write(1234.5678d);
+          cookie.Writer.Write((short) 1000);
+          cookie.Writer.Write((int) 1001);
+          cookie.Writer.Write((long) -1002);
+
+
+          cookie.Writer.Write((string) null);
+          cookie.Writer.Write("");
+          cookie.Writer.Write("abcd = yй");
+
+          cookie.Writer.Write((int[]) (null));
+          cookie.Writer.Write(new int[0]);
+          cookie.Writer.Write(new[] {1, 2, 3});
+
+          cookie.Writer.Write(UnsafeWriter.StringDelegate, (string[]) null);
+          cookie.Writer.Write(UnsafeWriter.StringDelegate, new string[0]);
+          cookie.Writer.Write(UnsafeWriter.StringDelegate, new[] {"a", "b", "c"});
+
+          cookie.Writer.Write(UnsafeWriter.StringDelegate, (List<string>) null);
+          cookie.Writer.Write(UnsafeWriter.StringDelegate, new List<string>());
+          cookie.Writer.Write(UnsafeWriter.StringDelegate, new List<string> {"d", "e"});
+
+          reader = UnsafeReader.CreateReader(cookie.Data, cookie.Count);
+        }
+
+        Assert.False(reader.ReadBoolean());
+        Assert.True(reader.ReadBoolean());
+        Assert.AreEqual(0, reader.ReadByte());
+        Assert.AreEqual(10, reader.ReadByte());
+        Assert.AreEqual('y', reader.ReadChar());
+        Assert.AreEqual('й', reader.ReadChar());
+        Assert.AreEqual(1234.5678m, reader.ReadDecimal());
+        Assert.AreEqual(1234.5678d, reader.ReadDouble(), 1e-6);
+        Assert.AreEqual(1000, reader.ReadInt16());
+        Assert.AreEqual(1001, reader.ReadInt32());
+        Assert.AreEqual(-1002, reader.ReadInt64());
+
+        Assert.Null(reader.ReadString());
+        Assert.AreEqual("", reader.ReadString());
+        Assert.AreEqual("abcd = yй", reader.ReadString());
+
+        Assert.Null(reader.ReadIntArray());
+        Assert.AreEqual(new int[0], reader.ReadIntArray());
+        Assert.AreEqual(new[] {1, 2, 3}, reader.ReadIntArray());
+
+        Assert.Null(reader.ReadArray(UnsafeReader.StringDelegate));
+        Assert.AreEqual(new string[0], reader.ReadArray(UnsafeReader.StringDelegate));
+        Assert.AreEqual(new[] {"a", "b", "c"}, reader.ReadArray(UnsafeReader.StringDelegate));
+
+        Assert.Null(reader.ReadCollection(UnsafeReader.StringDelegate, n => new List<string>(n)));
+        CollectionAssert.AreEqual(new List<string>(), reader.ReadCollection(UnsafeReader.StringDelegate, n => new List<string>(n)));
+        CollectionAssert.AreEqual(new List<string> {"d", "e"}, reader.ReadCollection(UnsafeReader.StringDelegate, n => new List<string>(n)));
       }
-
-      Assert.False(reader.ReadBoolean());
-      Assert.True(reader.ReadBoolean());
-      Assert.AreEqual(0, reader.ReadByte());
-      Assert.AreEqual(10, reader.ReadByte());
-      Assert.AreEqual('y', reader.ReadChar());
-      Assert.AreEqual('й', reader.ReadChar());
-      Assert.AreEqual(1234.5678m, reader.ReadDecimal());
-      Assert.AreEqual(1234.5678d, reader.ReadDouble(), 1e-6);
-      Assert.AreEqual(1000, reader.ReadInt16());
-      Assert.AreEqual(1001, reader.ReadInt32());
-      Assert.AreEqual(-1002, reader.ReadInt64());
-      
-      Assert.Null(reader.ReadString());
-      Assert.AreEqual("", reader.ReadString());
-      Assert.AreEqual("abcd = yй", reader.ReadString());
-
-      Assert.Null(reader.ReadIntArray());
-      Assert.AreEqual(new int[0], reader.ReadIntArray());
-      Assert.AreEqual(new []{1,2,3}, reader.ReadIntArray());
-
-      Assert.Null(reader.ReadArray(UnsafeReader.StringDelegate));
-      Assert.AreEqual(new string[0], reader.ReadArray(UnsafeReader.StringDelegate));
-      Assert.AreEqual(new[] { "a", "b", "c" }, reader.ReadArray(UnsafeReader.StringDelegate));
-
-      Assert.Null(reader.ReadCollection(UnsafeReader.StringDelegate, n => new List<string>(n)));
-      CollectionAssert.AreEqual(new List<string>(), reader.ReadCollection(UnsafeReader.StringDelegate, n => new List<string>(n)));
-      CollectionAssert.AreEqual(new List<string> { "d", "e" }, reader.ReadCollection(UnsafeReader.StringDelegate, n => new List<string>(n)));
+      finally
+      {
+        UnsafeWriter.AllowUnsafeWriterCaching = false;
+      }
     }
   }
 }

--- a/rd-net/Test.RdFramework/UnsafeWriterTest.cs
+++ b/rd-net/Test.RdFramework/UnsafeWriterTest.cs
@@ -1,4 +1,6 @@
-﻿using JetBrains.Serialization;
+﻿using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Serialization;
 using NUnit.Framework;
 
 namespace Test.RdFramework
@@ -13,7 +15,7 @@ namespace Test.RdFramework
       return (UnsafeWriter) ourWriterField.GetValue(null);
     }
     */
-
+    [Test]
     public void TestWriterIsReused01()
     {
       UnsafeWriter firstWriter;
@@ -31,6 +33,7 @@ namespace Test.RdFramework
       Assert.IsTrue(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
     }
 
+    [Test]
     public void TestWriterIsReused02()
     {
       UnsafeWriter firstWriter;
@@ -48,38 +51,50 @@ namespace Test.RdFramework
       Assert.IsTrue(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
     }
 
+    [Test]
     public void TestWriterIsNotReused01()
     {
-      UnsafeWriter firstWriter;
-      using (var cookie = UnsafeWriter.NewThreadLocalWriterWithCleanup())
+      var thread = new Thread(() =>
       {
-        firstWriter = cookie.Writer;
-      }
+        UnsafeWriter firstWriter;
+        using (var cookie = UnsafeWriter.NewThreadLocalWriterWithCleanup())
+        {
+          firstWriter = cookie.Writer;
+        }
 
-      UnsafeWriter secondWriter;
-      using (var cookie = UnsafeWriter.NewThreadLocalWriterWithCleanup())
-      {
-        secondWriter = cookie.Writer;
-      }
+        UnsafeWriter secondWriter;
+        using (var cookie = UnsafeWriter.NewThreadLocalWriterWithCleanup())
+        {
+          secondWriter = cookie.Writer;
+        }
 
-      Assert.IsFalse(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
+        Assert.IsFalse(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
+      });
+      thread.Start();
+      thread.Join();
     }
 
+    [Test]
     public void TestWriterIsNotReused02()
     {
-      UnsafeWriter firstWriter;
-      using (var cookie = UnsafeWriter.NewThreadLocalWriterWithCleanup())
+      var thread = new Thread(() =>
       {
-        firstWriter = cookie.Writer;
-      }
+        UnsafeWriter firstWriter;
+        using (var cookie = UnsafeWriter.NewThreadLocalWriterWithCleanup())
+        {
+          firstWriter = cookie.Writer;
+        }
 
-      UnsafeWriter secondWriter;
-      using (var cookie = UnsafeWriter.NewThreadLocalWriter())
-      {
-        secondWriter = cookie.Writer;
-      }
+        UnsafeWriter secondWriter;
+        using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+        {
+          secondWriter = cookie.Writer;
+        }
 
-      Assert.IsFalse(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
+        Assert.IsFalse(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
+      });
+      thread.Start();
+      thread.Join();
     }
   }
 }

--- a/rd-net/Test.RdFramework/UnsafeWriterTest.cs
+++ b/rd-net/Test.RdFramework/UnsafeWriterTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Linq;
+using System.Threading;
 using JetBrains.Serialization;
 using NUnit.Framework;
 
@@ -7,93 +8,165 @@ namespace Test.RdFramework
   [TestFixture]
   public class UnsafeWriterTest
   {
-    /*
-    private static UnsafeWriter TryGetThreadStaticField()
-    {
-      var ourWriterField = typeof(UnsafeWriter).GetField("ourWriter", BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
-      return (UnsafeWriter) ourWriterField.GetValue(null);
-    }
-    */
     [Test]
     public void TestWriterIsReused01()
     {
-      UnsafeWriter firstWriter;
-      using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+      UnsafeWriter firstWriter = null, secondWriter = null;
+      var thread = new Thread(() =>
       {
-        firstWriter = cookie.Writer;
-      }
+        UnsafeWriter.AllowUnsafeWriterCaching = true;
+        try
+        {
+          using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+          {
+            firstWriter = cookie.Writer;
+          }
 
-      UnsafeWriter secondWriter;
-      using (var cookie = UnsafeWriter.NewThreadLocalWriter())
-      {
-        secondWriter = cookie.Writer;
-      }
-
+          using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+          {
+            secondWriter = cookie.Writer;
+          }
+        }
+        finally
+        {
+          UnsafeWriter.AllowUnsafeWriterCaching = false;
+        }
+      });
+      thread.Start();
+      thread.Join();
+      Assert.IsNotNull(firstWriter, "firstWriter != null");
+      Assert.IsNotNull(secondWriter, "secondWriter != null");
       Assert.IsTrue(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
     }
 
     [Test]
     public void TestWriterIsReused02()
     {
-      UnsafeWriter firstWriter;
-      using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+      UnsafeWriter firstWriter = null, secondWriter = null;
+      var thread = new Thread(() =>
       {
-        firstWriter = cookie.Writer;
-      }
+        UnsafeWriter.AllowUnsafeWriterCaching = true;
+        try
+        {
+          using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+          {
+            firstWriter = cookie.Writer;
+          }
 
-      UnsafeWriter secondWriter;
-      using (var cookie = UnsafeWriter.NewThreadLocalWriterWithCleanup())
-      {
-        secondWriter = cookie.Writer;
-      }
+          using (var cookie = UnsafeWriter.NewThreadLocalWriterNoCaching())
+          {
+            secondWriter = cookie.Writer;
+          }
 
+        }
+        finally
+        {
+          UnsafeWriter.AllowUnsafeWriterCaching = false;
+        }
+      });
+
+      thread.Start();
+      thread.Join();
+      Assert.IsNotNull(firstWriter, "firstWriter != null");
+      Assert.IsNotNull(secondWriter, "secondWriter != null");
       Assert.IsTrue(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
     }
 
     [Test]
     public void TestWriterIsNotReused01()
     {
+      UnsafeWriter firstWriter = null, secondWriter = null;
       var thread = new Thread(() =>
       {
-        UnsafeWriter firstWriter;
-        using (var cookie = UnsafeWriter.NewThreadLocalWriterWithCleanup())
+        using (var cookie = UnsafeWriter.NewThreadLocalWriterNoCaching())
         {
           firstWriter = cookie.Writer;
         }
 
-        UnsafeWriter secondWriter;
-        using (var cookie = UnsafeWriter.NewThreadLocalWriterWithCleanup())
+        using (var cookie = UnsafeWriter.NewThreadLocalWriterNoCaching())
         {
           secondWriter = cookie.Writer;
         }
 
-        Assert.IsFalse(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
       });
       thread.Start();
       thread.Join();
+      Assert.IsNotNull(firstWriter, "firstWriter != null");
+      Assert.IsNotNull(secondWriter, "secondWriter != null");
+      Assert.IsFalse(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
     }
 
     [Test]
     public void TestWriterIsNotReused02()
     {
+      UnsafeWriter firstWriter = null, secondWriter = null;
       var thread = new Thread(() =>
       {
-        UnsafeWriter firstWriter;
-        using (var cookie = UnsafeWriter.NewThreadLocalWriterWithCleanup())
+        using (var cookie = UnsafeWriter.NewThreadLocalWriterNoCaching())
         {
           firstWriter = cookie.Writer;
         }
 
-        UnsafeWriter secondWriter;
         using (var cookie = UnsafeWriter.NewThreadLocalWriter())
         {
           secondWriter = cookie.Writer;
         }
-
-        Assert.IsFalse(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
       });
       thread.Start();
       thread.Join();
+      Assert.IsNotNull(firstWriter, "firstWriter != null");
+      Assert.IsNotNull(secondWriter, "secondWriter != null");
+      Assert.IsFalse(ReferenceEquals(firstWriter, secondWriter), "object.ReferenceEquals(firstWriter, secondWriter)");
+    }
+
+    [Test]
+    public void TestReportAccessCounter()
+    {
+      var thread = new Thread(() =>
+      {
+        for (int i = 0; i < UnsafeWriterStatistics.ReportAccessCounterThreshold + UnsafeWriterStatistics.ReportOnOfN; ++i)
+        {
+          using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+          {
+          }
+        }
+      });
+      thread.Start();
+      thread.Join();
+      var accessCounterEvent = UnsafeWriterStatistics.GetEvents().First(@event => @event.Type == UnsafeWriterStatistics.EventType.ACCESS_COUNTER);
+    }
+
+    [Test]
+    public void ReportAllocationOnNonCachedThread()
+    {
+      var thread = new Thread(() =>
+      {
+        using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+        {
+          for (int i=0; i<UnsafeWriterStatistics.ReportAllocationOnNonCachedThreadThreshold+1; ++i)
+            cookie.Writer.Write(0);
+        }
+      });
+      thread.Start();
+      thread.Join();
+      var memoryAllocationEvent = UnsafeWriterStatistics.GetEvents().First(@event => @event.Type == UnsafeWriterStatistics.EventType.MEMORY_ALLOCATION);
+    }
+
+    [Test, Ignore("Temporarily not reported")]
+    public void ReportReentrancy()
+    {
+      var thread = new Thread(() =>
+      {
+        UnsafeWriter.AllowUnsafeWriterCaching = true;
+        using (var cookie = UnsafeWriter.NewThreadLocalWriter())
+        {
+          using (var nestedCookie = UnsafeWriter.NewThreadLocalWriter())
+            cookie.Writer.Write(0);
+        }
+      });
+      thread.Start();
+      thread.Join();
+      var reentrancyEvent = UnsafeWriterStatistics.GetEvents().First(@event => @event.Type == UnsafeWriterStatistics.EventType.REENTRANCY);
     }
   }
 }

--- a/rd-net/Test.RdFramework/UnsafeWriterTest.cs
+++ b/rd-net/Test.RdFramework/UnsafeWriterTest.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Serialization;
 using NUnit.Framework;
 

--- a/rd-net/Test.RdFramework/UnsafeWriterTest.cs
+++ b/rd-net/Test.RdFramework/UnsafeWriterTest.cs
@@ -124,6 +124,7 @@ namespace Test.RdFramework
     {
       var thread = new Thread(() =>
       {
+        UnsafeWriterStatistics.ClearEvents();
         for (int i = 0; i < UnsafeWriterStatistics.ReportAccessCounterThreshold + UnsafeWriterStatistics.ReportOnOfN; ++i)
         {
           using (var cookie = UnsafeWriter.NewThreadLocalWriter())
@@ -141,6 +142,7 @@ namespace Test.RdFramework
     {
       var thread = new Thread(() =>
       {
+        UnsafeWriterStatistics.ClearEvents();
         using (var cookie = UnsafeWriter.NewThreadLocalWriter())
         {
           for (int i=0; i<UnsafeWriterStatistics.ReportAllocationOnNonCachedThreadThreshold+1; ++i)
@@ -152,12 +154,13 @@ namespace Test.RdFramework
       var memoryAllocationEvent = UnsafeWriterStatistics.GetEvents().First(@event => @event.Type == UnsafeWriterStatistics.EventType.MEMORY_ALLOCATION);
     }
 
-    [Test, Ignore("Temporarily not reported")]
+    [Test]
     public void ReportReentrancy()
     {
       var thread = new Thread(() =>
       {
         UnsafeWriter.AllowUnsafeWriterCaching = true;
+        UnsafeWriterStatistics.ClearEvents();
         using (var cookie = UnsafeWriter.NewThreadLocalWriter())
         {
           using (var nestedCookie = UnsafeWriter.NewThreadLocalWriter())
@@ -167,6 +170,7 @@ namespace Test.RdFramework
       thread.Start();
       thread.Join();
       var reentrancyEvent = UnsafeWriterStatistics.GetEvents().First(@event => @event.Type == UnsafeWriterStatistics.EventType.REENTRANCY);
+      Assert.IsTrue(reentrancyEvent.Stacktraces.Count == 2, "reentrancyEvent.Stacktraces.Count == 2");
     }
   }
 }


### PR DESCRIPTION
Refactored UnsafeWriter to cache the writer only on specifically marked threads. Whenr UnsafeWriter is used from a different thread its intial size reduced to 4KB. UnsafeWriterStatistics added. 