### PR TITLE
change rd-gen dependency from org.jetbrains.kotlin:kotlin-compiler to…

### DIFF
--- a/rd-kt/rd-gen/build.gradle.kts
+++ b/rd-kt/rd-gen/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     compile(project(":rd-core:"))
     implementation(gradleApi())
     testImplementation(project(":rd-framework"))
-    implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:${kotlinVersion}")
+    compile("org.jetbrains.kotlin:kotlin-compiler-embeddable:${kotlinVersion}")
     implementation("org.jetbrains.kotlin:kotlin-script-runtime:${kotlinVersion}")
 }
 

--- a/rd-kt/rd-gen/build.gradle.kts
+++ b/rd-kt/rd-gen/build.gradle.kts
@@ -17,7 +17,8 @@ dependencies {
     compile(project(":rd-core:"))
     implementation(gradleApi())
     testImplementation(project(":rd-framework"))
-    compile("org.jetbrains.kotlin:kotlin-compiler:${kotlinVersion}")
+    implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:${kotlinVersion}")
+    implementation("org.jetbrains.kotlin:kotlin-script-runtime:${kotlinVersion}")
 }
 
 val fatJar = task<Jar>("fatJar") {


### PR DESCRIPTION
… org.jetbrains.kotlin:kotlin-compiler-embeddable

Solves the following problem:
> rd-gen plugin depends on org.jetbrains.kotlin:kotlin-compiler:1.3.50. This is an incorrect way to depend on the Kotlin compiler, as it will bring the (unshaded) IJ platform classes as well as some other dependencies on the classpath
https://jetbrains.slack.com/archives/C0288G57R/p1597843597048000?thread_ts=1597761704.041400&cid=C0288G57R
