### PR TITLE
Used Assembly.FullName instead of Assembly.GetName() to avoid failure…

### DIFF
--- a/rd-net/Lifetimes/Util/RuntimeInfo.cs
+++ b/rd-net/Lifetimes/Util/RuntimeInfo.cs
@@ -20,8 +20,7 @@ namespace JetBrains.Util
         Environment.OSVersion.Platform == PlatformID.Win32Windows ||
         Environment.OSVersion.Platform == PlatformID.WinCE;
       
-      IsRunningOnCore = string.Equals(
-        typeof(string).Assembly.GetName().Name,
+      IsRunningOnCore = typeof(string).Assembly.FullName.StartsWith(
         "System.Private.CoreLib",
         StringComparison.Ordinal);
 


### PR DESCRIPTION
… on systems without ICU package