### PR TITLE
Remove includes to thirdparty lib 'foonathan'

### DIFF
--- a/rd-cpp/thirdparty/thirdparty.hpp
+++ b/rd-cpp/thirdparty/thirdparty.hpp
@@ -4,17 +4,6 @@
 #include "tsl/ordered_set.h"
 #include "tsl/ordered_map.h"
 
-//region memoory
-/*#include <foonathan/memory/container.hpp>
-#include <foonathan/memory/memory_pool.hpp>
-#include <foonathan/memory/smart_ptr.hpp>
-#include <foonathan/memory/static_allocator.hpp>
-#include <foonathan/memory/temporary_allocator.hpp>
-#include <foonathan/memory/joint_allocator.hpp>
-
-#include <foonathan/memory/namespace_alias.hpp>*/
-//endregion
-
 #if __cplusplus >= 201703L
 
 #include <optional>


### PR DESCRIPTION
For some magical reasons, from time to time, some users log an error in the build where these includes will be evaluated, even though they are commented out.