### PR TITLE
SequentialLifetimes: thread-safe implementation, new termination behavior

### DIFF
--- a/rd-kt/rd-core/src/commonMain/kotlin/com/jetbrains/rd/util/PlatformDependent.kt
+++ b/rd-kt/rd-core/src/commonMain/kotlin/com/jetbrains/rd/util/PlatformDependent.kt
@@ -8,6 +8,8 @@ expect fun currentThreadName() : String
 expect class AtomicReference<T> (initial: T) {
     fun get() : T
     fun getAndUpdate(f : (T) -> T) : T
+    fun getAndSet(newValue: T): T
+    fun compareAndSet(expectedValue: T, newValue: T): Boolean
 }
 
 expect class CopyOnWriteArrayList<E>(): MutableList<E>

--- a/rd-kt/rd-core/src/commonMain/kotlin/com/jetbrains/rd/util/lifetime/SequentialLifetimes.kt
+++ b/rd-kt/rd-core/src/commonMain/kotlin/com/jetbrains/rd/util/lifetime/SequentialLifetimes.kt
@@ -1,8 +1,11 @@
 package com.jetbrains.rd.util.lifetime
 
+import com.jetbrains.rd.util.AtomicReference
+import com.jetbrains.rd.util.Logger
+import com.jetbrains.rd.util.error
 
 open class SequentialLifetimes(private val parentLifetime: Lifetime) {
-    private var currentDef = LifetimeDefinition.Terminated
+    private val currentDef = AtomicReference(LifetimeDefinition.Terminated)
 
     init {
         parentLifetime += { setCurrentLifetime(LifetimeDefinition.Terminated) } //todo toRemove
@@ -16,17 +19,47 @@ open class SequentialLifetimes(private val parentLifetime: Lifetime) {
 
     open fun terminateCurrent(): Unit = setCurrentLifetime(LifetimeDefinition.Terminated)
 
-    val isTerminated: Boolean get() = currentDef.isEternal || !currentDef.isAlive //todo toRemove
-
-    open fun defineNext(fNext: (LifetimeDefinition, Lifetime) -> Unit) {
-        setCurrentLifetime(LifetimeDefinition.Terminated)
-        setCurrentLifetime(parentLifetime.createNested { ld -> fNext(ld, ld.lifetime) })
+    val isTerminated: Boolean get() { //todo toRemove
+        val current = currentDef.get()
+        return current.isEternal || !current.isAlive
     }
 
-    protected fun setCurrentLifetime(newDef: LifetimeDefinition) {
-        //todo atomicy
-        val prev = currentDef
-        currentDef = newDef
-        prev.terminate()
+    open fun defineNext(fNext: (LifetimeDefinition, Lifetime) -> Unit) {
+        setCurrentLifetime(parentLifetime.createNested()) { ld ->
+            try {
+                ld.executeIfAlive { fNext(ld, ld.lifetime) }
+            } catch (t: Throwable) {
+                ld.terminate()
+                throw t
+            }
+        }
+    }
+
+    /**
+     * Atomically, assigns the new lifetime and terminates the old one.
+     *
+     * In case of a race condition, when current lifetime is overwritten, new lifetime is terminated.
+     */
+    protected fun setCurrentLifetime(newDef: LifetimeDefinition, action: ((LifetimeDefinition) -> Unit)? = null) {
+        // Temporary lifetime definition that'll be used as a substitutor during current lifetime termination. We cannot
+        // use Lifetime.Terminated here, because we need a distinct instance to use it in atomic operations later.
+        val tempLifetimeDefinition = LifetimeDefinition()
+        tempLifetimeDefinition.terminate()
+
+        val old = currentDef.getAndSet(tempLifetimeDefinition)
+        try {
+            old.terminate(true)
+        } catch (t: Throwable) {
+            Logger.root.error(t)
+        }
+
+        try {
+            action?.invoke(newDef)
+        } finally {
+            if (!currentDef.compareAndSet(tempLifetimeDefinition, newDef)) {
+                // Means someone else has already interrupted us and replaced the current value (a race condition).
+                newDef.terminate(true)
+            }
+        }
     }
 }

--- a/rd-kt/rd-core/src/commonTest/kotlin/com/jetbrains/rd/util/test/cases/SequentialLifetimesTest.kt
+++ b/rd-kt/rd-core/src/commonTest/kotlin/com/jetbrains/rd/util/test/cases/SequentialLifetimesTest.kt
@@ -1,9 +1,6 @@
 package com.jetbrains.rd.util.test.cases
 
-import com.jetbrains.rd.util.lifetime.Lifetime
-import com.jetbrains.rd.util.lifetime.SequentialLifetimes
-import com.jetbrains.rd.util.lifetime.isAlive
-import com.jetbrains.rd.util.lifetime.plusAssign
+import com.jetbrains.rd.util.lifetime.*
 import com.jetbrains.rd.util.test.framework.RdTestBase
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -90,6 +87,36 @@ class SequentialLifetimesTest : RdTestBase()  {
         lfB.terminate()
         assertTrue(accA)
         assertTrue(accB)
+    }
+
+    @Test
+    fun testTerminateCurrent01() {
+        val sequentialLifetimes = SequentialLifetimes(Lifetime.Eternal)
+        sequentialLifetimes.defineNext { _, lifetime ->
+            lifetime.onTermination {
+                assertTrue(lifetime.isNotAlive, "lifetime.isNotAlive")
+                assertTrue(sequentialLifetimes.isTerminated, "sequentialLifetimes.isTerminated")
+            }
+        }
+        sequentialLifetimes.terminateCurrent()
+    }
+
+    @Test
+    fun testTerminateCurrent02() {
+        val sb = StringBuilder()
+        val sequentialLifetimes = SequentialLifetimes(Lifetime.Eternal)
+        sequentialLifetimes.defineNext { _, lifetime ->
+            lifetime.onTermination {
+                sb.append("T1")
+                assertTrue(lifetime.isNotAlive, "lifetime.isNotAlive")
+                assertTrue(sequentialLifetimes.isTerminated, "sequentialLifetimes.isTerminated")
+            }
+        }
+        sequentialLifetimes.defineNext { _, lifetime ->
+            sb.append("N2")
+        }
+
+        assertEquals("T1N2", sb.toString())
     }
 }
 

--- a/rd-kt/rd-core/src/jsMain/kotlin/com/jetbrains/rd/util/PlatformDependent.kt
+++ b/rd-kt/rd-core/src/jsMain/kotlin/com/jetbrains/rd/util/PlatformDependent.kt
@@ -1,7 +1,6 @@
 package com.jetbrains.rd.util
 
 import com.jetbrains.rd.util.collections.QueueImpl
-import kotlin.Exception
 import kotlin.reflect.KClass
 
 actual open class ExecutionException actual constructor (message: String, cause: Throwable?) : Exception(message, cause)
@@ -12,6 +11,19 @@ actual class AtomicReference<T> actual constructor(initial: T) {
     private var impl : T = initial
     actual fun get(): T = impl
     actual fun getAndUpdate(f: (T) -> T): T = impl.also { impl = f(impl) }
+    actual fun getAndSet(newValue: T): T {
+        val old = impl
+        impl = newValue
+        return old
+    }
+    actual fun compareAndSet(expectedValue: T, newValue: T): Boolean {
+        if (impl == expectedValue) {
+            impl = newValue
+            return true
+        }
+
+        return false
+    }
 }
 
 actual class CancellationException(message: String, cause: Throwable?) : IllegalStateException(message, cause) {

--- a/rd-kt/rd-core/src/jvmMain/kotlin/com/jetbrains/rd/util/PlatformDependent.kt
+++ b/rd-kt/rd-core/src/jvmMain/kotlin/com/jetbrains/rd/util/PlatformDependent.kt
@@ -20,7 +20,8 @@ actual class AtomicReference<T> actual constructor(initial: T) {
     private val impl = AtomicReference(initial)
     actual fun get(): T = impl.get()
     actual fun getAndUpdate(f: (T) -> T): T = impl.getAndUpdate(f)
-    fun getAndSet(new: T): T = impl.getAndSet(new)
+    actual fun getAndSet(newValue: T): T = impl.getAndSet(newValue)
+    actual fun compareAndSet(expectedValue: T, newValue: T): Boolean = impl.compareAndSet(expectedValue, newValue)
 }
 
 actual typealias CancellationException = CancellationException


### PR DESCRIPTION
This updates the Kotlin implementation of `SequentialLifetimes` logic according to the .NET logic that was implemented in #155.