### PR TITLE
Update setup-dotnet to v1.7.2

### DIFF
--- a/.github/workflows/build-rd-net.yml
+++ b/.github/workflows/build-rd-net.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v1.4.0
+      uses: actions/setup-dotnet@v1.7.2
       with:
         dotnet-version: '3.1.302'
     - name: Restore


### PR DESCRIPTION
This is to avoid errors when calling `set-env` and `add-path`, see
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/