### PR TITLE
Disable unstable SocketProxyTest

### DIFF
--- a/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/wire/SocketProxyTest.kt
+++ b/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/wire/SocketProxyTest.kt
@@ -7,6 +7,7 @@ import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.threading.SpinWait
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 
@@ -14,6 +15,7 @@ class SocketProxyTest : TestBase() {
     private val DefaultTimeoutMs = 100L
 
     @Test
+    @Disabled("Unstable")
     fun testSimple() {
         // using val factory = Log.UsingLogFactory( TextWriterLogFactory(Console.Out, LoggingLevel.TRACE))
         Lifetime.using { lifetime ->


### PR DESCRIPTION
Later, I'll investigate what's wrong with it. For now, it does more wrong than good for the overall ecosystem.