### PR TITLE
Fix flaky Test.Lifetimes.Collections.Viewable.SchedulerWrapperTest

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/rd-net/Test.Lifetimes/Collections/Viewable/SchedulerWrapperTest.cs
+++ b/rd-net/Test.Lifetimes/Collections/Viewable/SchedulerWrapperTest.cs
@@ -38,9 +38,16 @@ namespace Test.Lifetimes.Collections.Viewable
 
           Assert.AreEqual(0, count);
 
-          await lifetime.Start(TaskScheduler.Default, () => Assert.IsFalse(scheduler.IsActive));
+          await lifetime.Start(TaskScheduler.Default, () =>
+          {
+            Assert.IsFalse(scheduler.IsActive);
+            SpinWait.SpinUntil(() => Volatile.Read(ref count) == 1, TimeSpan.FromSeconds(10));
+            Assert.AreEqual(1, count);
 
-          Assert.AreEqual(1, count);
+            count++;
+          });
+
+          Assert.AreEqual(2, count);
           Assert.IsTrue(scheduler.IsActive);
           Assert.AreEqual(taskScheduler, TaskScheduler.Current);
         }).Wait(TimeSpan.FromSeconds(10));


### PR DESCRIPTION
looks like lifetime.Start(TaskScheduler.Default, () => {...}) may be executed too fast and continuation may be executed instantly (before scheduler.Queue(() => {...})