### PR TITLE
ByteBufferAsyncProcessor: prevent deadlocks on corrupted state exceptions

### DIFF
--- a/rd-net/Lifetimes/Threading/ByteBufferAsyncProcessor.cs
+++ b/rd-net/Lifetimes/Threading/ByteBufferAsyncProcessor.cs
@@ -463,6 +463,9 @@ namespace JetBrains.Threading
     }
 
 
+#if !NET35
+    [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions] // to force myLock to be unlocked even in case of corrupted state exception
+#endif
     [PublicAPI] public void Put(byte* start, int count)
     {
       if (count <= 0) return;


### PR DESCRIPTION
It turns out that some of our code works under `HandleProcessCorruptedStateExceptions` attribute on .NET Framework. This attribute allows the process to proceed execution even in case of memory access violation, but will only execute `catch` and `finally` blocks (including the implicitly generated `finally` in case of a `lock` block) in methods directly marked with the attribute.

So, if `ByteBufferAsyncProcessor.Put` is called from such method, and then a corrupted state exception occurs inside of the `lock` block, the lock will be abandoned in a locked state. This could lead to deadlocks that are hard to detect.

Provided we don't want to change the behavior of all the external code right now, the safest action we could take is to guard the path leading to our logger with the same attribute. It will at least help to preserve the logger functionality even in case of corrupted state exception, which should be helpful.