### PR TITLE
Fix memory leak via ExtWire for stub wires

### DIFF
--- a/rd-net/RdFramework/Base/RdExtBase.cs
+++ b/rd-net/RdFramework/Base/RdExtBase.cs
@@ -202,9 +202,12 @@ namespace JetBrains.Rd.Base
     
     public void Send<TContext>(RdId id, TContext param, Action<TContext, UnsafeWriter> writer)
     {
+      if (RealWire.IsStub)
+        return;
+
       lock (mySendQ)
       {
-        if (!RealWire.IsStub && (mySendQ.Count > 0 || !Connected.Value))
+        if (mySendQ.Count > 0 || !Connected.Value)
         {
           using (var cookie = UnsafeWriter.NewThreadLocalWriter())
           {

--- a/rd-net/RdFramework/Base/RdExtBase.cs
+++ b/rd-net/RdFramework/Base/RdExtBase.cs
@@ -164,6 +164,8 @@ namespace JetBrains.Rd.Base
     
     private readonly Queue<QueueItem> mySendQ = new Queue<QueueItem>();
 
+    public bool IsStub => false;
+
     public ProtocolContexts Contexts
     {
       get => RealWire.Contexts;
@@ -202,7 +204,7 @@ namespace JetBrains.Rd.Base
     {
       lock (mySendQ)
       {
-        if (mySendQ.Count > 0 || !Connected.Value)
+        if (!RealWire.IsStub && (mySendQ.Count > 0 || !Connected.Value))
         {
           using (var cookie = UnsafeWriter.NewThreadLocalWriter())
           {

--- a/rd-net/RdFramework/IWire.cs
+++ b/rd-net/RdFramework/IWire.cs
@@ -11,6 +11,13 @@ namespace JetBrains.Rd
 {
   public interface IWire
   {
+    /// <summary>
+    /// Used to indicate that the wire implementation is not supposed to be used with the remote counterpart.
+    /// These special wires can be used for local protocols instances to support working with the same models both from
+    /// reactive-distributed way and regular in-process synchronous reactive models.
+    /// </summary>
+    bool IsStub { get; }
+
     void Send<TParam>(RdId id, TParam param, [NotNull, InstantHandle] Action<TParam, UnsafeWriter> writer);
     void Advise([NotNull] Lifetime lifetime, [NotNull] IRdWireable entity);
     
@@ -24,6 +31,8 @@ namespace JetBrains.Rd
     private ProtocolContexts myContexts;
     
     private bool myBackwardsCompatibleWireFormat = false;
+
+    public bool IsStub => false;
 
     public ProtocolContexts Contexts
     {


### PR DESCRIPTION
Currently, every ext invocation is recorded and replayed when exts are
connected. For local protocol two exts will never be connected and every
wire packet will be recorded for ages.

To avoid storing these packets for stub wires special property is introduced.