### PR TITLE
Fix threading issue with heavy contexts and exts causing loss of accumulated messages

### DIFF
--- a/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/contexts/DelayedContextWithExtTest.kt
+++ b/rd-kt/rd-framework/src/jvmTest/kotlin/com/jetbrains/rd/framework/test/cases/contexts/DelayedContextWithExtTest.kt
@@ -1,0 +1,76 @@
+package com.jetbrains.rd.framework.test.cases.contexts
+
+import com.jetbrains.rd.framework.RdContext
+import com.jetbrains.rd.framework.test.util.RdAsyncTestBase
+import com.jetbrains.rd.util.threading.SpinWait
+import demo.DemoModel
+import demo.extModel
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.util.concurrent.CyclicBarrier
+
+class DelayedContextWithExtTest : RdAsyncTestBase() {
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun testExtNoFailureOnQueuedNewContextValue(useHeavyContext: Boolean) {
+        println("useHeavyContext: $useHeavyContext")
+        val context = if(useHeavyContext) ContextsTest.TestKeyHeavy else ContextsTest.TestKeyLight
+        clientProtocol.serializers.register(RdContext.marshallerFor(context))
+
+        setWireAutoFlush(true)
+
+        val fireValues = listOf("a", "b", "c")
+
+        val barrier0 = CyclicBarrier(2)
+        val barrier1 = CyclicBarrier(2)
+        val barrier2 = CyclicBarrier(2)
+
+        serverUiScheduler.queue {
+            serverProtocol.contexts.registerContext(context)
+            val serverModel = DemoModel.create(serverLifetime, serverProtocol)
+
+            barrier0.await() // root model also uses ext semantics, so make sure both ends have created it and processed its connection message
+
+            val serverExt = serverModel.extModel
+
+            fireValues.forEach {
+                context.value = it
+                serverExt.checker.fire(Unit)
+                context.value = null
+            }
+
+            barrier1.await()
+        }
+
+        var numReceives = 0
+        val receivedContexts = mutableSetOf<String>()
+
+        clientUiScheduler.queue {
+            val clientModel = DemoModel.create(clientLifetime, clientProtocol)
+
+            barrier0.await()
+            barrier1.await()
+
+            serverUiScheduler.queue {
+                barrier2.await()
+            }
+            barrier2.await()
+
+            val clientExt = clientModel.extModel
+
+            Thread.sleep(500)
+
+            clientExt.checker.advise(clientLifetime) {
+                numReceives++
+                receivedContexts.add(context.value ?: "null")
+            }
+        }
+
+        SpinWait.spinUntil(5_000) { numReceives == 3 }
+
+        assertEquals(3, numReceives)
+        assertEquals(fireValues.toSet(), receivedContexts)
+    }
+}

--- a/rd-net/RdFramework/Base/ISingleContextHandler.cs
+++ b/rd-net/RdFramework/Base/ISingleContextHandler.cs
@@ -8,6 +8,8 @@ namespace JetBrains.Rd.Base
     void PopValue();
     
     void WriteValue(SerializationCtx context, UnsafeWriter writer);
+
+    void RegisterValueInValueSet();
     
     RdContextBase ContextBase { get; }
   }

--- a/rd-net/RdFramework/Base/RdExtBase.cs
+++ b/rd-net/RdFramework/Base/RdExtBase.cs
@@ -215,6 +215,7 @@ namespace JetBrains.Rd.Base
             var storedContext = Contexts.RegisteredContexts
               .Select(it => new KeyValuePair<RdContextBase, object>(it, it.ValueBoxed)).ToArray();
             mySendQ.Enqueue(new QueueItem(id, cookie.CloneData(), storedContext));
+            Contexts.RegisterCurrentValuesInValueSets();
           }
 
           return;

--- a/rd-net/RdFramework/Impl/LightSingleContextHandler.cs
+++ b/rd-net/RdFramework/Impl/LightSingleContextHandler.cs
@@ -22,6 +22,11 @@ namespace JetBrains.Rd.Impl
         Context.WriteDelegate(context, writer, value);
     }
 
+    public void RegisterValueInValueSet()
+    {
+      // no-op
+    }
+
     public T ReadValue(SerializationCtx context, UnsafeReader reader)
     {
       var hasValue = reader.ReadBool();

--- a/rd-net/RdFramework/Impl/ProtocolContexts.cs
+++ b/rd-net/RdFramework/Impl/ProtocolContexts.cs
@@ -203,6 +203,17 @@ namespace JetBrains.Rd.Impl
     }
 
     /// <summary>
+    /// Adds current values of registered contexts to their respective value sets without writing them to the wire
+    /// </summary>
+    [SuppressMessage("ReSharper", "InconsistentlySynchronizedField", Justification = "sync is for atomicity of write/send pairs, not access")]
+    public void RegisterCurrentValuesInValueSets()
+    {
+      var count = myHandlerOrder.Count;
+      for (var i = 0; i < count; i++) 
+        myHandlerOrder[i].RegisterValueInValueSet();
+    }
+
+    /// <summary>
     /// Writes an empty context
     /// </summary>
     public static void WriteEmptyContexts(UnsafeWriter writer)

--- a/rd-net/Test.RdFramework/Contexts/DelayedContextWithExtTest.cs
+++ b/rd-net/Test.RdFramework/Contexts/DelayedContextWithExtTest.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using JetBrains.Collections.Viewable;
+using JetBrains.Rd;
+using NUnit.Framework;
+using Test.RdFramework.Interning;
+
+namespace Test.RdFramework.Contexts
+{
+  public class DelayedContextWithExtTest : RdFrameworkTestBase
+  {
+    protected override IScheduler CreateScheduler(bool isServer)
+    {
+      return SingleThreadScheduler.RunOnSeparateThread(LifetimeDefinition.Lifetime, isServer ? "Server" : "Client");
+    }
+
+    [Datapoint]
+    public static bool TrueValue = true;
+
+    [Datapoint]
+    public static bool FalseValue = false;
+    
+    [Theory]
+    public void TestExtNoFailureOnQueuedNewContextValue(bool useHeavyContext)
+    {
+      var context = useHeavyContext
+        ? RdContextBasicTest.TestKeyHeavy.Instance
+        : (RdContext<string>) RdContextBasicTest.TestKeyLight.Instance;
+      
+      ServerWire.AutoTransmitMode = true;
+      ClientWire.AutoTransmitMode = true;
+
+      var barrier0 = new Barrier(2);
+      var barrier1 = new Barrier(2);
+      var barrier2 = new Barrier(2);
+      
+      var fireValues = new[] { "a", "b", "c" };
+      
+      ServerProtocol.Scheduler.Queue(() =>
+      {
+        context.RegisterOn(ServerProtocol.Contexts);
+        var serverModel = new InterningRoot1(LifetimeDefinition.Lifetime, ServerProtocol);
+        
+        ServerWire.TransmitAllMessages();
+        
+        barrier0.SignalAndWait(); // root model also uses ext semantics, so make sure both ends have created it and processed its connection message
+        
+        var serverExt = serverModel.GetOrCreateExtension("test", () => new InterningExt());
+        foreach (var fireValue in fireValues)
+        {
+          context.Value = fireValue;
+          serverExt.Root.Value = new InterningExtRootModel();
+          context.Value = null;
+        }
+
+        barrier1.SignalAndWait();
+      });
+      
+      var numReceives = 0;
+      var receivedContexts = new HashSet<string>();
+      
+      ClientProtocol.Scheduler.Queue(() =>
+      {
+        context.RegisterOn(ClientProtocol.Serializers);
+        var clientModel = new InterningRoot1(LifetimeDefinition.Lifetime, ClientProtocol);
+
+        barrier0.SignalAndWait();
+
+        barrier1.SignalAndWait();
+        
+        ServerProtocol.Scheduler.Queue(() => barrier2.SignalAndWait());
+        barrier2.SignalAndWait();
+        
+        var clientExt = clientModel.GetOrCreateExtension("test", () => new InterningExt());
+        
+        Thread.Sleep(500);
+        
+        clientExt.Root.AdviseNotNull(LifetimeDefinition.Lifetime, _ =>
+        {
+          numReceives++;
+          receivedContexts.Add(context.Value);
+        });
+      });
+
+      SpinWait.SpinUntil(() => numReceives == 3, TimeSpan.FromMilliseconds(5_000));
+      
+      Assert.AreEqual(3, numReceives);
+      Assert.AreEqual(fireValues, receivedContexts);
+    }
+  }
+}

--- a/rd-net/Test.RdFramework/Contexts/DelayedContextWithExtTest.cs
+++ b/rd-net/Test.RdFramework/Contexts/DelayedContextWithExtTest.cs
@@ -31,6 +31,7 @@ namespace Test.RdFramework.Contexts
       ServerWire.AutoTransmitMode = true;
       ClientWire.AutoTransmitMode = true;
 
+      var barrierRegister = new Barrier(2);
       var barrier0 = new Barrier(2);
       var barrier1 = new Barrier(2);
       var barrier2 = new Barrier(2);
@@ -39,7 +40,10 @@ namespace Test.RdFramework.Contexts
       
       ServerProtocol.Scheduler.Queue(() =>
       {
+        barrierRegister.SignalAndWait();
+        
         context.RegisterOn(ServerProtocol.Contexts);
+
         var serverModel = new InterningRoot1(LifetimeDefinition.Lifetime, ServerProtocol);
         
         ServerWire.TransmitAllMessages();
@@ -63,6 +67,9 @@ namespace Test.RdFramework.Contexts
       ClientProtocol.Scheduler.Queue(() =>
       {
         context.RegisterOn(ClientProtocol.Serializers);
+        
+        barrierRegister.SignalAndWait();
+
         var clientModel = new InterningRoot1(LifetimeDefinition.Lifetime, ClientProtocol);
 
         barrier0.SignalAndWait();

--- a/rd-net/Test.RdFramework/Contexts/RdContextEarlyDeliveryTest.cs
+++ b/rd-net/Test.RdFramework/Contexts/RdContextEarlyDeliveryTest.cs
@@ -108,6 +108,8 @@ namespace Test.RdFramework.Contexts
       myClientWire = clientWire;
       myClientWire.Connection = myServerWire;
       myServerWire.Connection = myClientWire;
+      
+      myClientProtocol = new Protocol(clientIdea, CreateSerializers(), identities, clientDispatcher, clientWire, LifetimeDefinition.Lifetime, key);
 
       myServerWire.AutoTransmitMode = true;
       myClientWire.AutoTransmitMode = true;
@@ -117,8 +119,6 @@ namespace Test.RdFramework.Contexts
       key.Value = "1";
       
       serverSignal.Fire("");
-
-      myClientProtocol = new Protocol(clientIdea, CreateSerializers(), identities, clientDispatcher, clientWire, LifetimeDefinition.Lifetime, key);
 
       var clientSignal = BindToClient(LifetimeDefinition.Lifetime, new RdSignal<string>(), 1);
 


### PR DESCRIPTION
The issue happened if messages were sent to an unconnected ext with heavy context value that was not present in protocol value set. When remote signalled that the counterpart is ready, queued messages were sent from a background thread with stored context values, which threw an exception and broke ext message queue.