### PR TITLE
Don't override RdSignal scheduler if it was bound after advise

### DIFF
--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/impl/RdSignal.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/impl/RdSignal.kt
@@ -46,7 +46,8 @@ class RdSignal<T>(val valueSerializer: ISerializer<T> = Polymorphic<T>()) : RdRe
     override fun init(lifetime: Lifetime) {
         super.init(lifetime)
         serializationContext = super.serializationContext
-        wireScheduler = defaultScheduler
+        if (!this::wireScheduler.isInitialized)
+            wireScheduler = defaultScheduler
         wire.advise(lifetime, this)
 
     }


### PR DESCRIPTION
C# side doesn't have this issue as it's implemented slightly differently