### PR TITLE
CI: increase the test timeout

### DIFF
--- a/.github/workflows/build-rd-kt.yml
+++ b/.github/workflows/build-rd-kt.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       GRADLE_USER_HOME: ${{ github.workspace }}/.github/gradle
       TEAMCITY_VERSION: 1 # temporary; to disable cross tests
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
As of now, the tests may usually take up to 10–13 minutes, and with a timeout of 15 minutes, outliers may really fail the tests for no reason. I propose we increase the timeout for now.