### PR TITLE
Add special `valueForPerContextEntity` for RdContext 

### DIFF
--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/RdContext.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/RdContext.kt
@@ -52,6 +52,13 @@ abstract class RdContext<T : Any>(val key: String, val heavy: Boolean, val seria
         get() = internalValue.get()
         set(value) = internalValue.set(value)
 
+    /**
+     * Value which is used as a key inside per-context entities like [RdPerContextMap][com.jetbrains.rd.framework.impl.RdPerContextMap]
+     */
+    open var valueForPerContextEntity: T?
+        get() = value
+        set(value) { this.value = value }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if(other == null)

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/impl/RdPerContextMap.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/impl/RdPerContextMap.kt
@@ -47,7 +47,7 @@ class RdPerContextMap<K: Any, V : RdBindableBase> private constructor(override v
     }
 
     override fun getForCurrentContext(): V {
-        val currentId = context.value ?: error("No ${context.key} set for getting value for it")
+        val currentId = context.valueForPerContextEntity ?: error("No ${context.key} set for getting value for it")
         return this[currentId] ?: error("No value in ${this.location} for ${context.key} = $currentId")
     }
 

--- a/rd-net/RdFramework/Impl/RdPerContextMap.cs
+++ b/rd-net/RdFramework/Impl/RdPerContextMap.cs
@@ -51,7 +51,7 @@ namespace JetBrains.Rd.Impl
         
         public V GetForCurrentContext()
         {
-          var currentId = Context.Value;
+          var currentId = Context.ValueForPerContextEntity;
           Assertion.Assert(currentId != null, "No value set for key {0}", Context.Key);
           if (TryGetValue(currentId, out var value))
             return value;

--- a/rd-net/RdFramework/RdContext.cs
+++ b/rd-net/RdFramework/RdContext.cs
@@ -101,6 +101,15 @@ namespace JetBrains.Rd
       set => myValue.Value = value;
     }
 
+    /// <summary>
+    /// Value which is used as a key inside per-context entities like <see cref="RdPerContextMap{K,V}"/>
+    /// </summary>
+    public virtual T ValueForPerContextEntity
+    {
+      get => Value;
+      set => Value = value;
+    }
+
     internal sealed override object ValueBoxed
     {
       get => Value;


### PR DESCRIPTION
Add special `valueForPerContextEntity` for RdContext  to use it inside RdPerContextMap. It allows to override the value for specific context to provide a default one and avoid throwing when accessing RdPerContextMap items