### PR TITLE
Fix a flaky rd-gen test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+**/.gradle/
+**/build/
+
+.github/
+.idea/
+rd-cpp/
+rd-net/
+
+.dockerignore
+.editorconfig
+.gitignore
+.gitmodules
+Dockerfile
+LICENSE
+NuGet.Config
+README.md

--- a/.github/workflows/build-rd-kt-container.yml
+++ b/.github/workflows/build-rd-kt-container.yml
@@ -1,0 +1,40 @@
+name: rd-kt-container
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    container: adoptopenjdk/openjdk11:x86_64-ubuntu-jdk-11.0.11_9
+    env:
+      GRADLE_USER_HOME: ${{ github.workspace }}/.github/gradle
+      TEAMCITY_VERSION: 1 # temporary; to disable cross tests
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Gradle Wrapper Cache
+        uses: actions/cache@v1.1.0
+        with:
+          path: ${{ env.GRADLE_USER_HOME }}/wrapper
+          key: ${{ runner.os }}.gradle-wrapper.${{ hashFiles('gradle/**') }}
+      - name: Gradle Cache
+        uses: actions/cache@v1.1.0
+        with:
+          path: ${{ env.GRADLE_USER_HOME }}/caches/modules-2
+          key: ${{ runner.os }}.gradle.${{ hashFiles('**/*.gradle.kts') }}
+
+      - name: Assemble
+        run: ./gradlew assemble
+      - name: Build
+        run: ./gradlew build
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: tests-log.${{ runner.os }}
+          path: "**/reports/*"

--- a/.github/workflows/build-rd-kt.yml
+++ b/.github/workflows/build-rd-kt.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15, ubuntu-20.04, windows-2019]
+        os: [macos-10.15, windows-2019]
     env:
       GRADLE_USER_HOME: ${{ github.workspace }}/.github/gradle
       TEAMCITY_VERSION: 1 # temporary; to disable cross tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM adoptopenjdk/openjdk11:x86_64-ubuntu-jdk-11.0.11_9
+
+WORKDIR /rd
+COPY . .
+
+ENV TEAMCITY_VERSION=1
+RUN ./gradlew assemble
+ENTRYPOINT ./gradlew build

--- a/README.md
+++ b/README.md
@@ -107,6 +107,34 @@ To build packages locally please use: `rd-kt/rd-gen/pack.sh`
 
 *\* Right now it works only on Linux. Please use Docker for Windows or macOS.*
 
+## Run tests (Kotlin part only)
+
+### On a local computer
+
+Don't forget to set `TEAMCITY_VERSION=1` (temporary measure for now) before running any tests.
+
+```console
+$ ./gradlew build
+```
+
+### In a Docker container
+
+```console
+$ docker build . -t rd && docker rm rd && docker run -it --name rd rd
+```
+
+To run particular tests (e.g. `:rd-gen:test`):
+
+```console
+$ docker build . -t rd && docker rm rd && docker run -it --name rd rd --entrypoint ./gradlew :rd-gen:test
+```
+
+To extract test results afterwards:
+
+```console
+$ docker cp rd:/rd/rd-kt/rd-gen/build/reports/ T:\Temp\reports
+```
+
 # How to generate models (stubs)
 
 Generate models in each language you have chosen. 

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/RdGen.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/RdGen.kt
@@ -73,6 +73,9 @@ class RdGen : Kli() {
 //    val sourcePaths = mutableListOf<File>()
 
     private fun compile0(src: List<File>, dst: Path) : String? {
+        if (src.isEmpty()) {
+            throw Exception("Input file list is empty, compilation aborted")
+        }
 
         v("Searching for Kotlin compiler")
         try {

--- a/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/compiler/InterningModelsGenTest.kt
+++ b/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/compiler/InterningModelsGenTest.kt
@@ -21,7 +21,7 @@ class InterningModelsGenTest {
         val files = generateRdModel(classloader, arrayOf("com.jetbrains.rd.generator.test.cases.generator"), true)
         assert(files.isNotEmpty()) { "No files generated, bug?" }
 
-        val rdgen = RdGen()
+        val rdgen = RdGen().apply { verbose *= true }
 
         val rdFrameworkClasspath = classloader.scanForResourcesContaining("com.jetbrains.rd.framework") +
                 classloader.scanForResourcesContaining("com.jetbrains.rd.util")

--- a/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/CallTest.kt
+++ b/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/CallTest.kt
@@ -48,7 +48,7 @@ class CallTest {
         generateRdModel(classloader, arrayOf("com.jetbrains.rd.generator.test.cases.generator"), true)
         val generatedCodeTestFile = classloader.getResource("GeneratedCodeTest.kt").toPath()
 
-        val rdgen = RdGen()
+        val rdgen = RdGen().apply { verbose *= true }
 
         val rdFrameworkClasspath = classloader.scanForResourcesContaining("com.jetbrains.rd.framework") +
                 classloader.scanForResourcesContaining("com.jetbrains.rd.util")

--- a/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/PerClientIdGenTest.kt
+++ b/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/PerClientIdGenTest.kt
@@ -43,7 +43,7 @@ class PerClientIdGenTest {
         val files = generateRdModel(classloader, arrayOf("com.jetbrains.rd.generator.test.cases.generator"), true)
         assert(!files.isEmpty()) { "No files generated, bug?" }
 
-        val rdgen = RdGen()
+        val rdgen = RdGen().apply { verbose *= true }
 
         val rdFrameworkClasspath = classloader.scanForResourcesContaining("com.jetbrains.rd.framework") +
                 classloader.scanForResourcesContaining("com.jetbrains.rd.util")

--- a/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/RdGenTest.kt
+++ b/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/RdGenTest.kt
@@ -14,7 +14,7 @@ enum class Configuration {
 
 
 fun main() {
-    val rdgen = RdGen()
+    val rdgen = RdGen().apply { verbose *= true }
     rdgen.verbose *= true
 //    rdgen.force *= true
     rdgen.clearOutput *= true

--- a/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/SimpleModelTest.kt
+++ b/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/SimpleModelTest.kt
@@ -64,7 +64,7 @@ class SimpleModelTest {
         generateRdModel(classloader, arrayOf("com.jetbrains.rd.generator.test.cases.generator"), true)
         val generatedCodeTestFile = classloader.getResource("GeneratedCodeTest.kt").toPath()
 
-        val rdgen = RdGen()
+        val rdgen = RdGen().apply { verbose *= true }
 
         val rdFrameworkClasspath = classloader.scanForResourcesContaining("com.jetbrains.rd.framework") +
                 classloader.scanForResourcesContaining("com.jetbrains.rd.util")

--- a/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/example/ExampleModel.kt
+++ b/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/example/ExampleModel.kt
@@ -136,6 +136,7 @@ class TestExample {
             classloader.scanForResourcesContaining("com.jetbrains.rd.util") +
             classloader.scanForResourcesContaining("org.jetbrains.annotations")
 
+        rdgen.verbose *= true
         rdgen.classpath *= rdFrameworkClasspath.joinToString(File.pathSeparator)
 
         val generatedSources = File(kotlinGeneratedSourcesDir).walk().toList()

--- a/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/example/ExampleModel.kt
+++ b/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/example/ExampleModel.kt
@@ -128,7 +128,7 @@ class TestExample {
         val files = generateRdModel(classloader, arrayOf("com.jetbrains.rd.generator.test.cases.generator.example"), true)
         assert(files.isNotEmpty()) { "No files generated, bug?" }
 
-        val rdgen = RdGen()
+        val rdgen = RdGen().apply { verbose *= true }
 
         val rdFrameworkClasspath = classloader.scanForResourcesContaining("com.jetbrains.rd.framework") +
             classloader.scanForResourcesContaining("com.jetbrains.rd.util") +

--- a/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/example/ExampleModel.kt
+++ b/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/example/ExampleModel.kt
@@ -10,8 +10,10 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.io.File
 
+val outputKotlinDir = "build/exampleModelGenerated/testOutputKotlin"
+
 object ExampleRootNova : Root(
-        Kotlin11Generator(FlowTransform.AsIs, "org.example", File("build/exampleModelGenerated/testOutputKotlin")),
+        Kotlin11Generator(FlowTransform.AsIs, "org.example", File(outputKotlinDir)),
         Cpp17Generator(FlowTransform.AsIs, "org.example", File("build/exampleModelGenerated/testOutputCpp")),
         CSharp50Generator(FlowTransform.AsIs, "org.example", File("build/exampleModelGenerated/testOutputCSharp"))
 )
@@ -110,10 +112,6 @@ object ExampleModelNova : Ext(ExampleRootNova) {
 
 class TestExample {
 
-    companion object {
-        val kotlinGeneratedSourcesDir = "build/testOutputKotlin"
-    }
-
     //    @Test
     fun test() {
         val pkg1 = javaClass.`package`.name.apply { println(this) }
@@ -139,7 +137,7 @@ class TestExample {
         rdgen.verbose *= true
         rdgen.classpath *= rdFrameworkClasspath.joinToString(File.pathSeparator)
 
-        val generatedSources = File(kotlinGeneratedSourcesDir).walk().toList()
+        val generatedSources = File(outputKotlinDir).walk().toList()
         val compiledClassesLoader = rdgen.compileDsl(generatedSources)
         Assertions.assertNotNull(compiledClassesLoader, "Failed to compile generated sources: ${rdgen.error}")
     }


### PR DESCRIPTION
1. This fixes the test failures [like this one](https://github.com/JetBrains/rd/runs/2865407895), when `com.jetbrains.rd.generator.test.cases.generator.example.TestExample` fails on Linux with an error "org.opentest4j.AssertionFailedError: Failed to compile generated sources: Compilation failed. Return code: 1(COMPILATION_ERROR)", with the following written to stderr:

   > error: unable to run REPL, no scripting plugin loaded

   The issue turns out to be about the generated Kotlin output directory.
   
2. For more clearer error messages about this in the future, I've added an explicit input file count check before Kotlin compiler invocation.
3. Linux tests are migrated to Docker, because without it I wasn't able to reliably reproduce the issue.
4. `RdGen` output is now `verbose` in all the rd-gen tests.