### PR TITLE
Provide a bit more comprehensive ContentHashCode API

### DIFF
--- a/rd-net/Lifetimes/Collections/CollectionEx.cs
+++ b/rd-net/Lifetimes/Collections/CollectionEx.cs
@@ -15,22 +15,24 @@ namespace JetBrains.Collections
     /// In current implementation polynomial factor is 31.
     /// </summary>
     /// <param name="collection"></param>
+    /// <param name="comparer">If comparer is null then `EqualityComparer.Default` will be used</param>
     /// <typeparam name="T"></typeparam>
-    /// <returns>((seed * factor + collection[0]?.GetHashCode() ?? 0) * factor + collection[1]?.GetHashCode() ?? 0) * factor + ... </returns>
+    /// <returns>((seed * factor + hash(collection[0])) * factor + hash(collection[1])) * factor + ... </returns>
     [Pure, CollectionAccess(CollectionAccessType.Read)]
-    public static int ContentHashCode<T>([CanBeNull] this ICollection<T> collection)
+    public static int ContentHashCode<T>([CanBeNull] this ICollection<T> collection,
+      [CanBeNull] IEqualityComparer<T> comparer = null)
     {
       if (collection == null) return 0;
 
+      comparer ??= EqualityComparer<T>.Default;
       var hashCode = 0x2D2816FE;
       foreach (var item in collection)
       {
-        hashCode = hashCode * 31 + (item == null ? 0 : item.GetHashCode());
+        hashCode = hashCode * 31 + (item == null ? 0 : comparer.GetHashCode(item));
       }
 
       return hashCode;
     }
-
 
     /// <summary>
     /// Dequeue <paramref name="queue"/> if it's not empty (or do nothing).

--- a/rd-net/Test.Lifetimes/Collections/CollectionTest.cs
+++ b/rd-net/Test.Lifetimes/Collections/CollectionTest.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using JetBrains.Collections;
+using NUnit.Framework;
+
+namespace Test.Lifetimes.Collections
+{
+  [TestFixture]
+  public class CollectionTest : LifetimesTestBase
+  {
+    private class ComplexType
+    {
+      public int MagicNumber { get; }
+
+      public ComplexType(int magicNumber) { MagicNumber = magicNumber; }
+
+      public override int GetHashCode() { throw new InvalidOperationException("Use external comparer"); }
+    }
+
+    private sealed class ComplexTypeExternalEqualityComparer : IEqualityComparer<ComplexType>
+    {
+      public static IEqualityComparer<ComplexType> Instance { get; } = new ComplexTypeExternalEqualityComparer();
+
+      public bool Equals(ComplexType x, ComplexType y)
+      {
+        if (ReferenceEquals(x, y)) return true;
+        if (ReferenceEquals(x, null)) return false;
+        if (ReferenceEquals(y, null)) return false;
+        if (x.GetType() != y.GetType()) return false;
+        return x.MagicNumber == y.MagicNumber;
+      }
+
+      public int GetHashCode(ComplexType obj) { return obj.MagicNumber; }
+    }
+
+    [Test]
+    public void ContentHashCode01()
+    {
+      var set = new List<ComplexType>
+      {
+        new ComplexType(42),
+        new ComplexType(666)
+      };
+      
+      // ReSharper disable ReturnValueOfPureMethodIsNotUsed
+      Assert.Throws<InvalidOperationException>(() => set.ContentHashCode());
+      Assert.DoesNotThrow(() => set.ContentHashCode(ComplexTypeExternalEqualityComparer.Instance));
+      // ReSharper restore ReturnValueOfPureMethodIsNotUsed
+    }
+  }
+}


### PR DESCRIPTION
Currently there is no way to use `collection.ContentHashCode<T>()` if `T` doesn't provide hashcode itself (via overriding `GetHashCode()`).
This PR fixes it. `ContentHashCode` now accepts `IEqualityComparer` as an optional parameter.