### PR TITLE
Better handle context saving in RdExtBase

### DIFF
--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/ISingleContextHandler.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/base/ISingleContextHandler.kt
@@ -11,4 +11,6 @@ internal interface ISingleContextHandler<T: Any> {
     fun writeValue(ctx: SerializationCtx, buffer: AbstractBuffer)
 
     fun readValue(ctx: SerializationCtx, buffer: AbstractBuffer): T?
+
+    fun registerValueInValueSet()
 }

--- a/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/impl/LightSingleContextHandler.kt
+++ b/rd-kt/rd-framework/src/commonMain/kotlin/com/jetbrains/rd/framework/impl/LightSingleContextHandler.kt
@@ -26,4 +26,6 @@ internal class LightSingleContextHandler<T: Any>(override val context: RdContext
         if(!hasValue) return null
         return context.serializer.read(ctx, buffer)
     }
+
+    override fun registerValueInValueSet() = Unit
 }


### PR DESCRIPTION
This PR contains fixes for two cases:
 * Using `async` entities inside of a non-connected ext - previously this caused issues in Kotlin implementation due to unconditional `valueSet.add`.
 * SendWithoutContexts was summarily ignored by ExtWire, which could have led to issues in certain cases