### PR TITLE
Build: use SNAPSHOT version outside the TeamCity builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,10 @@ val clean by tasks.getting(Delete::class) {
     delete(rootProject.buildDir)
 }
 
+if (System.getenv("TEAMCITY_VERSION") == null) {
+    version = "SNAPSHOT"
+}
+
 tasks {
     val nuGetTargetDir = buildDir.resolve("artifacts").resolve("nuget")
     val publishingGroup = "publishing"


### PR DESCRIPTION
This way, `./gradlew publishToMavenLocal` will use the same `SNAPSHOT` directory by default (for local development) as earlier.