### PR TITLE
Nullable reference types

### DIFF
--- a/.github/workflows/build-rd-net.yml
+++ b/.github/workflows/build-rd-net.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1.7.2
       with:
-        dotnet-version: '3.1.302'
+        dotnet-version: '5.0.x'
     - name: Restore
       run: cd rd-net && dotnet restore
     - name: Compile

--- a/README.md
+++ b/README.md
@@ -174,4 +174,6 @@ Look at cross tests
 * _Test.RdCross_ at C# side
 * _rd::cross_ at C++ side
 
- 
+## License
+
+Rd is licensed under the [Apache 2.0](LICENSE) license. Rd distributions may include third-party software licensed separately; see [THIRD-PARTY-NOTICES](THIRD-PARTY-NOTICES.TXT) for details.

--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -1,0 +1,272 @@
+License notice for rd-net/Lifetimes/Annotations/NullableAttributes.cs
+-----------------------------
+https://github.com/dotnet/runtime/blob/39b9607807f29e48cae4652cd74735182b31182e/LICENSE.TXT
+
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+License notice for rd-net/RdFramework/Impl/WebSocketSharp
+-----------------------------
+
+The MIT License
+
+Copyright (c) 2012-2016 sta.blockhead
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+License notice for rd-cpp/thirdparty/ordered-map
+-----------------------------
+
+MIT License
+
+Copyright (c) 2017 Tessil
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+License notice for rd-cpp/thirdparty/countdownlatch
+-----------------------------
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Nipun Talukdar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+License notice for rd-cpp/thirdparty/CTPL
+-----------------------------
+
+Copyright (C) 2014 by Vitaliy Vitsentiy
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+License notice for rd-cpp/thirdparty/string-view-lite
+-----------------------------
+
+Boost Software License - Version 1.0 - August 17th, 2003
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+License notice for rd-cpp/thirdparty/variant
+-----------------------------
+
+Boost Software License - Version 1.0 - August 17th, 2003
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+License notice for rd-net/Lifetimes/Annotations/CodeAnnotations.cs
+-----------------------------
+
+MIT License
+
+Copyright (c) 2016 JetBrains http://www.jetbrains.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+License notice for rd-cpp/thirdparty/clsocket
+-----------------------------
+
+ActiveSocket.h - Active Socket Decleration
+Author : Mark Carrier (mark@carrierlabs.com)
+
+Copyright (c) 2007-2009 CarrierLabs, LLC.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+4. The name "CarrierLabs" must not be used to
+   endorse or promote products derived from this software without
+   prior written permission. For written permission, please contact
+   mark@carrierlabs.com.
+
+THIS SOFTWARE IS PROVIDED BY MARK CARRIER ``AS IS'' AND ANY
+EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL MARK CARRIER OR
+ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+License notice for rd-cpp/PrecompiledHeader.cmake, rd-kt/rd-gen/src/main/resources/cpp/PrecompiledHeader.cmake
+-----------------------------
+
+Copyright (C) 2009-2017 Lars Christensen <larsch@belunktum.dk>
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation files
+(the 'Software') deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/rd-net/Directory.Build.props
+++ b/rd-net/Directory.Build.props
@@ -4,7 +4,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\key.snk</AssemblyOriginatorKeyFile>
     <AssemblyVersion>777.0.0</AssemblyVersion>
     <FileVersion>777.0.0</FileVersion>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Condition="'$(TargetFramework)' == 'net461'" Version="1.0.2">

--- a/rd-net/Directory.Build.props
+++ b/rd-net/Directory.Build.props
@@ -15,5 +15,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <None Include="$(MSBuildThisFileDirectory)\..\THIRD-PARTY-NOTICES.TXT" Pack="true" PackagePath=""/>
   </ItemGroup>
 </Project>

--- a/rd-net/Directory.Build.props
+++ b/rd-net/Directory.Build.props
@@ -5,6 +5,7 @@
     <AssemblyVersion>777.0.0</AssemblyVersion>
     <FileVersion>777.0.0</FileVersion>
     <LangVersion>9.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Condition="'$(TargetFramework)' == 'net461'" Version="1.0.2">

--- a/rd-net/Lifetimes/Annotations/CodeAnnotations.cs
+++ b/rd-net/Lifetimes/Annotations/CodeAnnotations.cs
@@ -200,8 +200,7 @@ namespace JetBrains.Annotations
             ParameterName = parameterName;
         }
 
-        [CanBeNull]
-        public string ParameterName { get; private set; }
+        public string? ParameterName { get; private set; }
     }
 
     /// <summary>
@@ -431,8 +430,7 @@ namespace JetBrains.Annotations
             Comment = comment;
         }
 
-        [CanBeNull]
-        public string Comment { get; private set; }
+        public string? Comment { get; private set; }
     }
 
     /// <summary>
@@ -469,8 +467,7 @@ namespace JetBrains.Annotations
             Justification = justification;
         }
 
-        [CanBeNull]
-        public string Justification { get; private set; }
+        public string? Justification { get; private set; }
     }
 
     /// <summary>
@@ -506,8 +503,7 @@ namespace JetBrains.Annotations
             BasePath = basePath;
         }
 
-        [CanBeNull]
-        public string BasePath { get; private set; }
+        public string? BasePath { get; private set; }
     }
     
 

--- a/rd-net/Lifetimes/Annotations/NullableAttributes.cs
+++ b/rd-net/Lifetimes/Annotations/NullableAttributes.cs
@@ -1,0 +1,150 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This was copied from https://github.com/dotnet/runtime/blob/39b9607807f29e48cae4652cd74735182b31182e/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+// and updated to have the scope of the attributes be internal.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+#if !NETCOREAPP
+
+    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class AllowNullAttribute : Attribute { }
+
+    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class DisallowNullAttribute : Attribute { }
+
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class MaybeNullAttribute : Attribute { }
+
+    /// <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class NotNullAttribute : Attribute { }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class MaybeNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter may be null.
+        /// </param>
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    internal sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class DoesNotReturnAttribute : Attribute { }
+
+    /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified parameter value.</summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+        /// the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+        /// <summary>Gets the condition parameter value.</summary>
+        public bool ParameterValue { get; }
+    }
+
+#endif
+
+#if !NETCOREAPP || NETCOREAPP3_1
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed class MemberNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with a field or property member.</summary>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(string member) => Members = new[] { member };
+
+        /// <summary>Initializes the attribute with the list of field and property members.</summary>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(params string[] members) => Members = members;
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = new[] { member };
+        }
+
+        /// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+
+#endif
+}

--- a/rd-net/Lifetimes/Collections/CollectionEx.cs
+++ b/rd-net/Lifetimes/Collections/CollectionEx.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 
 namespace JetBrains.Collections
@@ -19,8 +20,8 @@ namespace JetBrains.Collections
     /// <typeparam name="T"></typeparam>
     /// <returns>((seed * factor + hash(collection[0])) * factor + hash(collection[1])) * factor + ... </returns>
     [Pure, CollectionAccess(CollectionAccessType.Read)]
-    public static int ContentHashCode<T>([CanBeNull] this ICollection<T> collection,
-      [CanBeNull] IEqualityComparer<T> comparer = null)
+    public static int ContentHashCode<T>(this ICollection<T>? collection,
+      IEqualityComparer<T>? comparer = null)
     {
       if (collection == null) return 0;
 
@@ -41,7 +42,7 @@ namespace JetBrains.Collections
     /// <param name="res"><see cref="Queue{T}.Dequeue"/> if <paramref name="queue"/>.Count > 0 at method start, `default{T}` otherwise</param>
     /// <typeparam name="T"></typeparam>
     /// <returns>`true` if <paramref name="queue"/>.Count > 0 at method start, `false` otherwise</returns>
-    public static bool TryDequeue<T>(this Queue<T> queue, out T res)
+    public static bool TryDequeue<T>(this Queue<T> queue, [MaybeNullWhen(false)] out T res)
     {
       if (queue.Count > 0)
       {

--- a/rd-net/Lifetimes/Collections/CompactList.cs
+++ b/rd-net/Lifetimes/Collections/CompactList.cs
@@ -15,11 +15,11 @@ namespace JetBrains.Collections
   /// <typeparam name="T"></typeparam>
   public struct CompactList<T> : IEnumerable<T>
   {
-    internal static readonly List<T> SingleMarker = new List<T>();
+    internal static readonly List<T?> SingleMarker = new List<T?>();
 
-    private T mySingleValue;
+    private T? mySingleValue;
     // or or
-    private List<T> myMultipleValues;    
+    private List<T?>? myMultipleValues;
     
     public CompactListEnumerator<T> GetEnumerator()
     {
@@ -54,10 +54,11 @@ namespace JetBrains.Collections
           myMultipleValues = SingleMarker;
           break;
         case 1: 
-          myMultipleValues = new List<T> { mySingleValue, item };
+          myMultipleValues = new List<T?> { mySingleValue, item };
           mySingleValue = default(T);
           break;
-        default: 
+        default:
+          Assertion.Assert(myMultipleValues != null, "myMultipleValues != null");
           myMultipleValues.Add(item);
           break;
       }
@@ -69,13 +70,14 @@ namespace JetBrains.Collections
       myMultipleValues = null;
     }
 
-    public int LastIndexOf(T item, IEqualityComparer<T> comparer)
+    public int LastIndexOf(T item, IEqualityComparer<T?> comparer)
     {
       switch (Count)      
       {
         case 0: return -1;
         case 1: return comparer.Equals(mySingleValue, item) ? 0 : -1;          
         default:
+          Assertion.Assert(myMultipleValues != null, "myMultipleValues != null");
           for (var i = myMultipleValues.Count - 1; i >= 0; i--)
           {
             if (comparer.Equals(myMultipleValues[i], item)) return i;
@@ -97,17 +99,19 @@ namespace JetBrains.Collections
           return true;
           
         case 2:
+          Assertion.Assert(myMultipleValues != null, "myMultipleValues != null");
           mySingleValue = myMultipleValues[1-index];
           myMultipleValues = SingleMarker;
           return true;
             
         default:
+          Assertion.Assert(myMultipleValues != null, "myMultipleValues != null");
           myMultipleValues.RemoveAt(index);
           return true;
       }      
     }
 
-    public T[] ToArray()
+    public T?[] ToArray()
     {
       switch (Count)      
       {
@@ -116,11 +120,12 @@ namespace JetBrains.Collections
         case 1:
           return new [] {mySingleValue};
         default:
+          Assertion.Assert(myMultipleValues != null, "myMultipleValues != null");
           return myMultipleValues.ToArray();
       }
     }
     
-    public T this[int index]
+    public T? this[int index]
     {
       get
       {
@@ -139,24 +144,24 @@ namespace JetBrains.Collections
     }        
   }
   
-  public struct CompactListEnumerator<T> : IEnumerator<T>
+  public struct CompactListEnumerator<T> : IEnumerator<T?>
   {
-    private readonly T mySingleValue;
-    private readonly List<T> myMultipleValues;
+    private readonly T? mySingleValue;
+    private readonly List<T?>? myMultipleValues;
     private int myIndex;
-    private T myCurrent;
+    private T? myCurrent;
       
-    internal CompactListEnumerator(T singleValue, List<T> multipleValues)
+    internal CompactListEnumerator(T? singleValue, List<T?>? multipleValues)
     {
       mySingleValue = singleValue;
       myMultipleValues = multipleValues;
       myIndex = -1;
-      myCurrent = default(T);
+      myCurrent = default;
     }
 
-    object IEnumerator.Current => myCurrent;
+    object? IEnumerator.Current => myCurrent;
       
-    public T Current => myCurrent;
+    public T? Current => myCurrent;
 
     public bool MoveNext()
     {

--- a/rd-net/Lifetimes/Collections/EmptyArray.cs
+++ b/rd-net/Lifetimes/Collections/EmptyArray.cs
@@ -10,7 +10,7 @@ namespace JetBrains.Util
   [DebuggerDisplay("Length = 0")]
   public static class EmptyArray<T>
   {
-    [NotNull] public static readonly T[] Instance = new T[0];
+    public static readonly T[] Instance = new T[0];
   }
 
   /// <summary>
@@ -19,7 +19,7 @@ namespace JetBrains.Util
   public static class EmptyArray
   {
     /// <summary>Synonym for <see cref="EmptyArray{T}.Instance"/></summary>
-    [NotNull, Pure]
+    [Pure]
     public static T[] GetInstance<T>()
     {
       return EmptyArray<T>.Instance;

--- a/rd-net/Lifetimes/Collections/EmptyEnumerator.cs
+++ b/rd-net/Lifetimes/Collections/EmptyEnumerator.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using JetBrains.Annotations;
 
 namespace JetBrains.Collections
 {
@@ -11,11 +10,11 @@ namespace JetBrains.Collections
   /// <typeparam name="T"></typeparam>
   public sealed class EmptyEnumerator<T> : IEnumerator<T> 
   {
-    [NotNull] public static readonly EmptyEnumerator<T> Instance = new EmptyEnumerator<T>();
+    public static readonly EmptyEnumerator<T> Instance = new EmptyEnumerator<T>();
 
     public T Current => throw new InvalidOperationException($"{nameof(EmptyEnumerator<T>)}.{nameof(Current)} is undefined");
 
-    object IEnumerator.Current => Current;
+    object? IEnumerator.Current => Current;
 
     public bool MoveNext() => false;
 
@@ -23,6 +22,6 @@ namespace JetBrains.Collections
 
     public void Dispose() { }
 
-    [NotNull] public IEnumerator<T> GetEnumerator() => this;
+    public IEnumerator<T> GetEnumerator() => this;
   }
 }

--- a/rd-net/Lifetimes/Collections/JetPriorityQueue.cs
+++ b/rd-net/Lifetimes/Collections/JetPriorityQueue.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using JetBrains.Annotations;
@@ -21,8 +22,8 @@ namespace JetBrains.Collections
   {
     new int Count { get; }
 
-    bool TryExtract(out T res);
-    bool TryPeek(out T res);
+    bool TryExtract(out T? res);
+    bool TryPeek(out T? res);
   }
 
   /// <summary>
@@ -32,18 +33,18 @@ namespace JetBrains.Collections
   public class JetPriorityQueue<T> : IPriorityQueue<T>
   {
     public const int DefaultCapacity = 10;
-    private readonly List<T> myStorage;
+    private readonly List<T?> myStorage;
     private readonly List<long> myVersions;
-    private readonly IComparer<T> myComparer;
+    private readonly IComparer<T?> myComparer;
     private long myVersionAcc;
     
 
-    public JetPriorityQueue(int initialCapacity = DefaultCapacity, IComparer<T> comparer = null)
+    public JetPriorityQueue(int initialCapacity = DefaultCapacity, IComparer<T?>? comparer = null)
     {
       if (initialCapacity <= 0) initialCapacity = DefaultCapacity;
-      myStorage = new List<T>(initialCapacity + 1) { default(T) }; //first elem is always false to simplify `left` and `right`
+      myStorage = new List<T?>(initialCapacity + 1) { default(T) }; //first elem is always false to simplify `left` and `right`
       myVersions = new List<long>(initialCapacity + 1) {0};
-      myComparer = comparer ?? Comparer<T>.Default;
+      myComparer = comparer ?? Comparer<T?>.Default;
     }
 
     #region ICollection implementation
@@ -99,7 +100,7 @@ namespace JetBrains.Collections
     #region Priority related methods
 
 
-    public bool TryExtract(out T res)
+    public bool TryExtract(out T? res)
     {
       if (!TryPeek(out res)) return false;
 
@@ -115,7 +116,7 @@ namespace JetBrains.Collections
       return true;
     }
 
-    public bool TryPeek(out T res)
+    public bool TryPeek(out T? res)
     {
       if (myStorage.Count <= 1)
       {
@@ -202,7 +203,7 @@ namespace JetBrains.Collections
     private readonly JetPriorityQueue<T> myQueue;
     private readonly object mySentry = new object();
 
-    public BlockingPriorityQueue(Lifetime lifetime, int initialCapacity = JetPriorityQueue<T>.DefaultCapacity, IComparer<T> comparer = null)
+    public BlockingPriorityQueue(Lifetime lifetime, int initialCapacity = JetPriorityQueue<T>.DefaultCapacity, IComparer<T?>? comparer = null)
     {
       myLifetime = lifetime;
       myQueue = new JetPriorityQueue<T>(initialCapacity, comparer);
@@ -254,17 +255,17 @@ namespace JetBrains.Collections
     public int Count { get { lock (mySentry) return myQueue.Count; }  }
     public bool IsReadOnly { get { lock (mySentry) return myQueue.IsReadOnly; } }
 
-    public bool TryExtract(out T res)
+    public bool TryExtract(out T? res)
     {
       lock (mySentry) return myQueue.TryExtract(out res);
     }
 
-    public bool TryPeek(out T res)
+    public bool TryPeek(out T? res)
     {
       lock (mySentry) return myQueue.TryPeek(out res);
     }
 
-    [PublicAPI] public bool TryExtract(out T res, int intervalMs)
+    [PublicAPI] public bool TryExtract(out T? res, int intervalMs)
     {
       lock (mySentry)
       {
@@ -291,7 +292,7 @@ namespace JetBrains.Collections
       }
     }
 
-    [PublicAPI] public bool TryPeek(out T res, int intervalMs)
+    [PublicAPI] public bool TryPeek(out T? res, int intervalMs)
     {      
       lock (mySentry)
       {
@@ -323,7 +324,7 @@ namespace JetBrains.Collections
     /// Returns first element from queue or waits until it appears. In case of lifetime termination throws PCE.
     /// </summary>
     /// <returns>First element in queue</returns>
-    [PublicAPI] public T ExtractOrBlock()
+    [PublicAPI] public T? ExtractOrBlock()
     {
       lock (mySentry)
       {
@@ -380,12 +381,12 @@ namespace JetBrains.Collections
     }
   
 
-    [PublicAPI] public static T ExtractOrDefault<T>(this IPriorityQueue<T> queue)
+    [PublicAPI] public static T? ExtractOrDefault<T>(this IPriorityQueue<T> queue)
     {
       return !queue.TryExtract(out var res) ? default(T) : res;
     }
 
-    [PublicAPI] public static T Extract<T>(this IPriorityQueue<T> queue)
+    [PublicAPI] public static T? Extract<T>(this IPriorityQueue<T> queue)
     {
       if (!queue.TryExtract(out var res))
       {
@@ -394,7 +395,7 @@ namespace JetBrains.Collections
       return res;
     }
 
-    [PublicAPI] public static T Peek<T>(this IPriorityQueue<T> queue)
+    [PublicAPI] public static T? Peek<T>(this IPriorityQueue<T> queue)
     {
       if (!queue.TryPeek(out var res))
       {

--- a/rd-net/Lifetimes/Collections/ReferenceEqualityComparer.cs
+++ b/rd-net/Lifetimes/Collections/ReferenceEqualityComparer.cs
@@ -12,14 +12,13 @@ namespace JetBrains.Collections
   public sealed class ReferenceEqualityComparer<T> : IEqualityComparer<T>
     where T : class
   {
-    [NotNull] private static readonly ReferenceEqualityComparer<T> ourDefault = new ReferenceEqualityComparer<T>();
+    private static readonly ReferenceEqualityComparer<T> ourDefault = new ReferenceEqualityComparer<T>();
     private ReferenceEqualityComparer() { }
 
     public bool Equals(T x, T y) => ReferenceEquals(x, y);
 
     public int GetHashCode(T obj) => RuntimeHelpers.GetHashCode(obj);
 
-    [NotNull]
     public static IEqualityComparer<T> Default => ourDefault;
   }
 }

--- a/rd-net/Lifetimes/Collections/SingletonEnumerator.cs
+++ b/rd-net/Lifetimes/Collections/SingletonEnumerator.cs
@@ -33,6 +33,6 @@ namespace JetBrains.Collections
 
     public T Current { get; }
 
-    object IEnumerator.Current => Current;
+    object? IEnumerator.Current => Current;
   }
 }

--- a/rd-net/Lifetimes/Collections/Synchronized/SynchronizedList.cs
+++ b/rd-net/Lifetimes/Collections/Synchronized/SynchronizedList.cs
@@ -14,7 +14,7 @@ namespace JetBrains.Collections.Synchronized
   {
     private readonly List<T> myList;
 
-    public SynchronizedList(IEnumerable<T> values = null, int capacity = 0)
+    public SynchronizedList(IEnumerable<T>? values = null, int capacity = 0)
     {
       myList = new List<T>(capacity > 0 ? capacity : 10);
       if (values != null) 

--- a/rd-net/Lifetimes/Collections/Synchronized/SynchronizedSet.cs
+++ b/rd-net/Lifetimes/Collections/Synchronized/SynchronizedSet.cs
@@ -30,7 +30,7 @@ namespace JetBrains.Collections.Synchronized
     public SynchronizedSet() : this(null, null) {}
     public SynchronizedSet(IEnumerable<T> values) : this(values, null) {}
     public SynchronizedSet(IEqualityComparer<T> comparer) : this(null, comparer) {}
-    public SynchronizedSet(IEnumerable<T> values, IEqualityComparer<T> comparer)
+    public SynchronizedSet(IEnumerable<T>? values, IEqualityComparer<T>? comparer)
     {
       mySet = new HashSet<T>(comparer);
       if (values == null) return;
@@ -234,12 +234,11 @@ namespace JetBrains.Collections.Synchronized
       }
     }
     
-    [CanBeNull]
-    public T ExtractOneOrDefault()
+    public T? ExtractOneOrDefault()
     {
       lock (mySet)
       {
-        if (mySet.Count == 0) return default(T);
+        if (mySet.Count == 0) return default;
 
         var item = mySet.First();
         mySet.Remove(item);

--- a/rd-net/Lifetimes/Collections/Viewable/ISignal.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/ISignal.cs
@@ -11,7 +11,7 @@ namespace JetBrains.Collections.Viewable
     /// Currently all subscribers gets events on the same thread that <see cref="Fire"/> happened.
     /// This scheduler is reserved for future use.
     /// </summary>
-    IScheduler Scheduler { get; set; }
+    IScheduler? Scheduler { get; set; }
     
     /// <summary>
     /// Fires value that will be seen by all handlers who subscribed by <see cref="ISource{T}.Advise"/>

--- a/rd-net/Lifetimes/Collections/Viewable/ISource.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/ISource.cs
@@ -21,6 +21,6 @@ namespace JetBrains.Collections.Viewable
     /// </summary>
     /// <param name="lifetime">if lifetime <see cref="Lifetime.IsNotAlive"/> then no subscription will be done</param>
     /// <param name="handler">handler of events</param>
-    void Advise(Lifetime lifetime, [NotNull] Action<T> handler);
+    void Advise(Lifetime lifetime, Action<T> handler);
   }
 }

--- a/rd-net/Lifetimes/Collections/Viewable/IViewableList.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/IViewableList.cs
@@ -14,7 +14,7 @@ namespace JetBrains.Collections.Viewable
   /// </remarks> 
   /// </summary>
   /// <typeparam name="T"></typeparam>
-  public interface IViewableList<T> : IList<T>, ISource<ListEvent<T>>
+  public interface IViewableList<T> : IList<T>, ISource<ListEvent<T>> where T : notnull
   {
     /// <summary>
     /// Advise this source if you don't want synchronous execution of <c>handler</c> on existing

--- a/rd-net/Lifetimes/Collections/Viewable/IViewableMap.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/IViewableMap.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using JetBrains.Annotations;
+using System.Diagnostics.CodeAnalysis;
 
 namespace JetBrains.Collections.Viewable
 {
@@ -15,16 +15,16 @@ namespace JetBrains.Collections.Viewable
   /// </summary>
   /// <typeparam name="K"></typeparam>
   /// <typeparam name="V"></typeparam>
-  public interface IViewableMap<K, V> : IDictionary<K, V>, ISource<MapEvent<K, V>>
+  public interface IViewableMap<K, V> : IDictionary<K, V>, ISource<MapEvent<K, V>> where K : notnull
   {
     ISource<MapEvent<K, V>> Change { get; }
 
     // note: solve interface ambiguity
     new int Count { get; }
-    [NotNull] new ICollection<K> Keys { get; }
-    [NotNull] new ICollection<V> Values { get; }
-    new bool ContainsKey([NotNull] K key);
-    new V this[[NotNull] K key] { get; set; }
-    new bool TryGetValue([NotNull] K key, out V value);
+    new ICollection<K> Keys { get; }
+    new ICollection<V> Values { get; }
+    new bool ContainsKey(K key);
+    new V this[K key] { get; set; }
+    new bool TryGetValue(K key, out V value);
   }
 }

--- a/rd-net/Lifetimes/Collections/Viewable/IViewableSet.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/IViewableSet.cs
@@ -16,6 +16,7 @@ namespace JetBrains.Collections.Viewable
     #else
       ISet<T>
     #endif
+  where T: notnull
   {
     ISource<SetEvent<T>> Change { get; }
   }

--- a/rd-net/Lifetimes/Collections/Viewable/ListEvent.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/ListEvent.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 
 namespace JetBrains.Collections.Viewable
@@ -6,14 +7,14 @@ namespace JetBrains.Collections.Viewable
   /// Event of <see cref="IViewableList{T}"/>
   /// </summary>
   /// <typeparam name="V"></typeparam>
-  public struct ListEvent<V>
-  {    
+  public struct ListEvent<V> where V : notnull
+  {
     public AddUpdateRemove Kind { get; private set; }
     public int Index { get; private set; }
-    public V OldValue { [CanBeNull] get; private set; }
-    public V NewValue { [CanBeNull] get; private set; }
+    public V? OldValue { get; private set; }
+    public V? NewValue { get; private set; }
 
-    private ListEvent(AddUpdateRemove kind, int index, [CanBeNull] V oldValue, [CanBeNull] V newValue)
+    private ListEvent(AddUpdateRemove kind, int index, V? oldValue, V? newValue)
       : this()
     {
       Kind = kind;
@@ -22,17 +23,17 @@ namespace JetBrains.Collections.Viewable
       NewValue = newValue;
     }
 
-    public static ListEvent<V> Add(int index, [NotNull] V newValue)
+    public static ListEvent<V> Add(int index, V newValue)
     {
       return new ListEvent<V>(AddUpdateRemove.Add, index, default(V), newValue);
     }
 
-    public static ListEvent<V> Update(int index, [NotNull] V oldValue, [NotNull] V newValue)
+    public static ListEvent<V> Update(int index, V oldValue, V newValue)
     {
       return new ListEvent<V>(AddUpdateRemove.Update, index, oldValue, newValue);
     }
 
-    public static ListEvent<V> Remove(int index, [NotNull] V oldValue)
+    public static ListEvent<V> Remove(int index, V oldValue)
     {
       return new ListEvent<V>(AddUpdateRemove.Remove, index, oldValue, default(V));
     }

--- a/rd-net/Lifetimes/Collections/Viewable/MapEvent.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/MapEvent.cs
@@ -1,4 +1,4 @@
-using JetBrains.Annotations;
+using System.Diagnostics.CodeAnalysis;
 
 namespace JetBrains.Collections.Viewable
 {
@@ -7,14 +7,24 @@ namespace JetBrains.Collections.Viewable
   /// </summary>
   /// <typeparam name="K"></typeparam>
   /// <typeparam name="V"></typeparam>
-  public struct MapEvent<K, V>
+  public struct MapEvent<K, V> where K : notnull
   {    
     public AddUpdateRemove Kind { get; private set; }
-    public K Key { [NotNull] get; private set; }
-    public V OldValue { [CanBeNull] get; private set; }
-    public V NewValue { [CanBeNull] get; private set; }
+    public K Key { get; private set; }
+    public V? OldValue { get; private set; }
+    public V? NewValue { get; private set; }
 
-    private MapEvent(AddUpdateRemove kind, [NotNull] K key, [CanBeNull] V oldValue, [CanBeNull] V newValue)
+    [MemberNotNullWhen(true, nameof(NewValue))]
+    public bool IsAdd => Kind == AddUpdateRemove.Add;
+
+    [MemberNotNullWhen(true, nameof(NewValue))]
+    [MemberNotNullWhen(true, nameof(OldValue))]
+    public bool IsUpdate => Kind == AddUpdateRemove.Update;
+
+    [MemberNotNullWhen(true, nameof(OldValue))]
+    public bool IsRemove => Kind == AddUpdateRemove.Remove;
+
+    private MapEvent(AddUpdateRemove kind, K key, V oldValue, V newValue)
       : this()
     {
       Kind = kind;
@@ -23,19 +33,19 @@ namespace JetBrains.Collections.Viewable
       NewValue = newValue;
     }
 
-    public static MapEvent<K, V> Add([NotNull] K key, [NotNull] V newValue)
+    public static MapEvent<K, V> Add(K key, V newValue)
     {
-      return new MapEvent<K, V>(AddUpdateRemove.Add, key, default(V), newValue);
+      return new MapEvent<K, V>(AddUpdateRemove.Add, key, default!, newValue);
     }
 
-    public static MapEvent<K, V> Update([NotNull] K key, [NotNull] V oldValue, [NotNull] V newValue)
+    public static MapEvent<K, V> Update(K key, V oldValue, V newValue)
     {
       return new MapEvent<K, V>(AddUpdateRemove.Update, key, oldValue, newValue);
     }
 
-    public static MapEvent<K, V> Remove([NotNull] K key, [NotNull] V oldValue)
+    public static MapEvent<K, V> Remove(K key, V oldValue)
     {
-      return new MapEvent<K, V>(AddUpdateRemove.Remove, key, oldValue, default(V));
+      return new MapEvent<K, V>(AddUpdateRemove.Remove, key, oldValue, default!);
     }
 
     public override string ToString()

--- a/rd-net/Lifetimes/Collections/Viewable/ModificationCookieViewableSet.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/ModificationCookieViewableSet.cs
@@ -11,7 +11,7 @@ namespace JetBrains.Collections.Viewable
   /// </summary>
   /// <typeparam name="T"></typeparam>
   /// <typeparam name="TCookie"></typeparam>
-  public class ModificationCookieViewableSet<T, TCookie> : IViewableSet<T> where TCookie: struct, IDisposable
+  public class ModificationCookieViewableSet<T, TCookie> : IViewableSet<T> where T: notnull where TCookie: struct, IDisposable
   {
     private readonly Func<TCookie> myCookieFactory;
     private readonly IViewableSet<T> myBackingSet;

--- a/rd-net/Lifetimes/Collections/Viewable/SchedulerEx.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/SchedulerEx.cs
@@ -9,7 +9,7 @@ namespace JetBrains.Collections.Viewable
 {
   public static class SchedulerEx
   {
-    public static void AssertThread(this IScheduler scheduler, object debugInfo = null)
+    public static void AssertThread(this IScheduler scheduler, object? debugInfo = null)
     {
       if (!scheduler.IsActive)
         Log.Root.Error("Illegal scheduler for current action, must be: {0}, current thread: {1}{2}", scheduler, Thread.CurrentThread.ToThreadString(), 

--- a/rd-net/Lifetimes/Collections/Viewable/SchedulerWrapper.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/SchedulerWrapper.cs
@@ -39,8 +39,8 @@ namespace JetBrains.Collections.Viewable
         SynchronizationContext.SetSynchronizationContext(old);
       }
     }
-
-    protected override IEnumerable<Task> GetScheduledTasks() => null;
+    
+    protected override IEnumerable<Task> GetScheduledTasks() => new Task[0];
     
     private class SyncContext : SynchronizationContext
     {

--- a/rd-net/Lifetimes/Collections/Viewable/SequentialScheduler.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/SequentialScheduler.cs
@@ -24,7 +24,7 @@ namespace JetBrains.Collections.Viewable
       return new SequentialScheduler(id, lifetime, scheduler as TaskScheduler ?? new SchedulerWrapper(scheduler));
     }
 
-    public SequentialScheduler(string id, Lifetime lifetime, TaskScheduler scheduler = null)
+    public SequentialScheduler(string id, Lifetime lifetime, TaskScheduler? scheduler = null)
     {
       myLifetime = lifetime;
       mySyncContext = new SyncContext(this);
@@ -61,7 +61,7 @@ namespace JetBrains.Collections.Viewable
     }
 
     protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
-    protected override IEnumerable<Task> GetScheduledTasks() => null;
+    protected override IEnumerable<Task> GetScheduledTasks() => Array.Empty<Task>();
 
     private class SyncContext : SynchronizationContext
     {
@@ -90,7 +90,7 @@ namespace JetBrains.Collections.Viewable
 
       protected override void QueueTask(Task task) => myScheduler.Queue(() => TryExecuteTask(task));
       protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
-      protected override IEnumerable<Task> GetScheduledTasks() => null;
+      protected override IEnumerable<Task> GetScheduledTasks() => Array.Empty<Task>();
     }
   }
 #endif

--- a/rd-net/Lifetimes/Collections/Viewable/Signal.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/Signal.cs
@@ -35,7 +35,7 @@ namespace JetBrains.Collections.Viewable
 
 
         //todo for future use
-        public IScheduler Scheduler { get; set; }
+        public IScheduler? Scheduler { get; set; }
 
         
         public virtual void Fire(T value)

--- a/rd-net/Lifetimes/Collections/Viewable/SingleThreadScheduler.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/SingleThreadScheduler.cs
@@ -16,7 +16,7 @@ namespace JetBrains.Collections.Viewable
     public const int NormalPriority = 0;
     public const int LowPriority = -32;
     
-    public PrioritizedAction([NotNull] Action action, int priority = NormalPriority)
+    public PrioritizedAction(Action action, int priority = NormalPriority)
     {
       Priority = priority;
       Action = action ?? throw new ArgumentNullException(nameof(action));
@@ -25,7 +25,7 @@ namespace JetBrains.Collections.Viewable
     public int Priority { get; }
     public Action Action { get; }
 
-    public int CompareTo(PrioritizedAction other)
+    public int CompareTo(PrioritizedAction? other)
     {
       if (ReferenceEquals(this, other)) return 0;
       if (ReferenceEquals(null, other)) return 1;
@@ -55,12 +55,16 @@ namespace JetBrains.Collections.Viewable
     
     public string Name { get; }        
     public int ActionPriority { get; }
-    public Thread Thread { get; private set; }
+
+    /// <summary>
+    /// Thread is expected to be initialized from factory methods
+    /// </summary>
+    public Thread Thread { get; private set; } = null!;
 
     private ActionQueue myQueue;
 
 
-    private SingleThreadScheduler([NotNull] string name, [NotNull] ActionQueue queue, int actionPriority = PrioritizedAction.NormalPriority)
+    private SingleThreadScheduler(string name, ActionQueue queue, int actionPriority = PrioritizedAction.NormalPriority)
     {
       myQueue = queue ?? throw new ArgumentNullException(nameof(queue));
       Name = name ?? throw new ArgumentNullException(nameof(name));
@@ -72,7 +76,7 @@ namespace JetBrains.Collections.Viewable
 
 
     [PublicAPI]
-    public static void RunInCurrentStackframe([NotNull] Lifetime lifetime, [NotNull] string name, Action<SingleThreadScheduler> beforeStart = null)
+    public static void RunInCurrentStackframe([NotNull] Lifetime lifetime, string name, Action<SingleThreadScheduler>? beforeStart = null)
     {
       var res = new SingleThreadScheduler(name, new ActionQueue(lifetime)) { Thread = Thread.CurrentThread };
 
@@ -82,7 +86,7 @@ namespace JetBrains.Collections.Viewable
     }
 
     [PublicAPI]
-    public static SingleThreadScheduler RunOnSeparateThread([NotNull] Lifetime lifetime, [NotNull] string name, Action<SingleThreadScheduler> beforeStart = null)
+    public static SingleThreadScheduler RunOnSeparateThread([NotNull] Lifetime lifetime, string name, Action<SingleThreadScheduler>? beforeStart = null)
     {
 
       var res = new SingleThreadScheduler(name, new ActionQueue(lifetime));
@@ -96,7 +100,7 @@ namespace JetBrains.Collections.Viewable
     }
 
 
-    public static SingleThreadScheduler CreateOverExisting([NotNull] SingleThreadScheduler existingScheduler, [NotNull] string name, int actionPriority = PrioritizedAction.NormalPriority)
+    public static SingleThreadScheduler CreateOverExisting(SingleThreadScheduler existingScheduler, string name, int actionPriority = PrioritizedAction.NormalPriority)
     {
       if (existingScheduler == null) throw new ArgumentNullException(nameof(existingScheduler));
       if (name == null) throw new ArgumentNullException(nameof(name));
@@ -114,7 +118,7 @@ namespace JetBrains.Collections.Viewable
     {
       Assertion.AssertCurrentThread(Thread);
 
-      PrioritizedAction prioritizedAction = blockIfNoActionAvailable ? myQueue.Storage.ExtractOrBlock() : myQueue.Storage.ExtractOrDefault();
+      PrioritizedAction? prioritizedAction = blockIfNoActionAvailable ? myQueue.Storage.ExtractOrBlock() : myQueue.Storage.ExtractOrDefault();
 
       if (prioritizedAction == null) return;
       var action = prioritizedAction.Action;
@@ -191,7 +195,7 @@ namespace JetBrains.Collections.Viewable
       return $"Scheduler: '{Name}' on thread `{Thread.ToThreadString()}`";
     }
 
-    public void Queue([NotNull] Action action)
+    public void Queue(Action action)
     {
       if (action == null) throw new ArgumentNullException(nameof(action));
 

--- a/rd-net/Lifetimes/Collections/Viewable/SingleThreadScheduler.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/SingleThreadScheduler.cs
@@ -76,7 +76,7 @@ namespace JetBrains.Collections.Viewable
 
 
     [PublicAPI]
-    public static void RunInCurrentStackframe([NotNull] Lifetime lifetime, string name, Action<SingleThreadScheduler>? beforeStart = null)
+    public static void RunInCurrentStackframe(Lifetime lifetime, string name, Action<SingleThreadScheduler>? beforeStart = null)
     {
       var res = new SingleThreadScheduler(name, new ActionQueue(lifetime)) { Thread = Thread.CurrentThread };
 
@@ -86,7 +86,7 @@ namespace JetBrains.Collections.Viewable
     }
 
     [PublicAPI]
-    public static SingleThreadScheduler RunOnSeparateThread([NotNull] Lifetime lifetime, string name, Action<SingleThreadScheduler>? beforeStart = null)
+    public static SingleThreadScheduler RunOnSeparateThread(Lifetime lifetime, string name, Action<SingleThreadScheduler>? beforeStart = null)
     {
 
       var res = new SingleThreadScheduler(name, new ActionQueue(lifetime));

--- a/rd-net/Lifetimes/Collections/Viewable/ViewableList.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/ViewableList.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using JetBrains.Collections.Synchronized;
 using JetBrains.Diagnostics;
@@ -12,7 +13,7 @@ namespace JetBrains.Collections.Viewable
   /// Default implementation if <see cref="IViewableList{T}"/>. 
   /// </summary>
   /// <typeparam name="T"></typeparam>
-  public class ViewableList<T> : IViewableList<T>
+  public class ViewableList<T> : IViewableList<T> where T : notnull
   {
     private readonly IList<T> myStorage;
     private readonly Signal<ListEvent<T>> myChange = new Signal<ListEvent<T>>();
@@ -43,8 +44,12 @@ namespace JetBrains.Collections.Viewable
       return GetEnumerator();
     }
 
-    // ReSharper disable once AnnotationConflictInHierarchy
-    public void Add([NotNull] T item)
+    void ICollection<T>.Add(T item)
+    {
+      Add(item!);
+    }
+
+    public void Add([DisallowNull] T item)
     {
       if (item == null) throw new ArgumentNullException(nameof(item));
       myStorage.Add(item);
@@ -88,7 +93,6 @@ namespace JetBrains.Collections.Viewable
     }
     
 
-    [NotNull]
     public T this[int index]
     {
       get => myStorage[index];
@@ -125,8 +129,7 @@ namespace JetBrains.Collections.Viewable
       return myStorage.IndexOf(item);
     }
 
-    // ReSharper disable once AnnotationConflictInHierarchy
-    public void Insert(int index, [NotNull] T item)
+    public void Insert(int index, T item)
     {
       if (item == null) 
         throw new ArgumentNullException(nameof(item));

--- a/rd-net/Lifetimes/Collections/Viewable/ViewableMap.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/ViewableMap.cs
@@ -14,13 +14,13 @@ namespace JetBrains.Collections.Viewable
   /// </summary>
   /// <typeparam name="TK"></typeparam>
   /// <typeparam name="TV"></typeparam>
-  public class ViewableMap<TK, TV> : IViewableMap<TK, TV>
+  public class ViewableMap<TK, TV> : IViewableMap<TK, TV> where TK : notnull
   {
-    [NotNull] private readonly IDictionary<TK, TV> myStorage;
-    [NotNull] private readonly IEqualityComparer<TV> myValueComparer;
-    [NotNull] private readonly Signal<MapEvent<TK, TV>> myChange = new Signal<MapEvent<TK, TV>>();
+    private readonly IDictionary<TK, TV> myStorage;
+    private readonly IEqualityComparer<TV> myValueComparer;
+    private readonly Signal<MapEvent<TK, TV>> myChange = new Signal<MapEvent<TK, TV>>();
 
-    [NotNull] public ISource<MapEvent<TK, TV>> Change => myChange;
+    public ISource<MapEvent<TK, TV>> Change => myChange;
     
     [PublicAPI] public ViewableMap() : this(new Dictionary<TK, TV>()) {}
 
@@ -31,7 +31,7 @@ namespace JetBrains.Collections.Viewable
     /// </summary>
     /// <param name="storage"></param>
     /// <param name="valueComparer"></param>
-    [PublicAPI] public ViewableMap([NotNull] IDictionary<TK, TV> storage, [CanBeNull] IEqualityComparer<TV> valueComparer = null)
+    [PublicAPI] public ViewableMap(IDictionary<TK, TV> storage, IEqualityComparer<TV>? valueComparer = null)
     {
       myStorage = storage ?? throw new ArgumentNullException(nameof(storage));
       myValueComparer = valueComparer ?? EqualityComparer<TV>.Default;

--- a/rd-net/Lifetimes/Collections/Viewable/ViewableSet.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/ViewableSet.cs
@@ -11,8 +11,8 @@ namespace JetBrains.Collections.Viewable
   /// Default implementation for <see cref="IViewableSet{T}"/>
   /// </summary>
   /// <typeparam name="T"></typeparam>
-    public class ViewableSet<T> : IViewableSet<T>
-    {
+    public class ViewableSet<T> : IViewableSet<T> where T : notnull
+  {
         private readonly Signal<SetEvent<T>> myChange = new Signal<SetEvent<T>>();
 #if !NET35
     private readonly ISet<T> myStorage;

--- a/rd-net/Lifetimes/Collections/Viewable/ViewableSet.cs
+++ b/rd-net/Lifetimes/Collections/Viewable/ViewableSet.cs
@@ -29,7 +29,7 @@ namespace JetBrains.Collections.Viewable
         /// Special delegating constructor that accepts storage backend (e.g. <see cref="JetBrains.Collections.Synchronized.SynchronizedSet{T}"/>)
         /// </summary>
         /// <param name="storage"></param>
-        [PublicAPI] public ViewableSet([NotNull]
+        [PublicAPI] public ViewableSet(
 #if !NET35
             ISet<T> storage
 #else

--- a/rd-net/Lifetimes/Core/Maybe.cs
+++ b/rd-net/Lifetimes/Core/Maybe.cs
@@ -30,7 +30,7 @@ namespace JetBrains.Core
       }
     }
 
-    public T ValueOrDefault => !HasValue ? default : myValue;
+    public T? ValueOrDefault => !HasValue ? default : myValue;
 
     public Maybe(T value) : this()
     {

--- a/rd-net/Lifetimes/Core/Result.cs
+++ b/rd-net/Lifetimes/Core/Result.cs
@@ -10,6 +10,7 @@ using JetBrains.Threading;
 #if !NET35
 using System.Runtime.ExceptionServices;
 #endif
+#nullable disable
 
 namespace JetBrains.Core
 {

--- a/rd-net/Lifetimes/Core/Unit.cs
+++ b/rd-net/Lifetimes/Core/Unit.cs
@@ -18,7 +18,7 @@ namespace JetBrains.Core
 
     public bool Equals(Unit other) => true;
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
       if (ReferenceEquals(null, obj)) return false;
       if (ReferenceEquals(this, obj)) return true;
@@ -28,12 +28,12 @@ namespace JetBrains.Core
     public override int GetHashCode() => 0; 
     
 
-    public static bool operator ==(Unit left, Unit right)
+    public static bool operator ==(Unit? left, Unit? right)
     {
       return Equals(left, right);
     }
 
-    public static bool operator !=(Unit left, Unit right)
+    public static bool operator !=(Unit? left, Unit? right)
     {
       return !Equals(left, right);
     }

--- a/rd-net/Lifetimes/Diagnostics/Assertion.cs
+++ b/rd-net/Lifetimes/Diagnostics/Assertion.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Threading;
 using JetBrains.Annotations;
 using JetBrains.Threading;
 using JetBrains.Util;
+using System.Diagnostics.CodeAnalysis;
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 
 namespace JetBrains.Diagnostics
 {
@@ -16,7 +17,7 @@ namespace JetBrains.Diagnostics
     [ContractAnnotation("condition:false=>void")]
     [AssertionMethod]
     [Conditional("JET_MODE_ASSERT")]
-    public static void Assert(bool condition, [NotNull] string message)
+    public static void Assert([DoesNotReturnIf(false)] bool condition, string message)
     {
       if (!condition)
       {
@@ -26,7 +27,7 @@ namespace JetBrains.Diagnostics
 
     [AssertionMethod]
     [Conditional("JET_MODE_ASSERT")]
-    public static void AssertCurrentThread([NotNull] Thread thread)
+    public static void AssertCurrentThread(Thread thread)
     {
       if (Thread.CurrentThread != thread)
       {
@@ -37,18 +38,18 @@ namespace JetBrains.Diagnostics
     [ContractAnnotation("condition:false=>void")]
     [AssertionMethod, StringFormatMethod("message")]
     [Conditional("JET_MODE_ASSERT")]
-    public static void Assert<T>(bool condition, [NotNull] string message, T arg)
+    public static void Assert<T>([DoesNotReturnIf(false)] bool condition, string message, T? arg)
     {
       if (!condition)
       {
         Fail(message, arg);
       }
     }
-
+    
     [ContractAnnotation("condition:false=>void")]
     [AssertionMethod, StringFormatMethod("message")]
     [Conditional("JET_MODE_ASSERT")]
-    public static void Assert<T1,T2>(bool condition, [NotNull] string message, T1 arg1, T2 arg2)
+    public static void Assert<T1,T2>([DoesNotReturnIf(false)] bool condition, string message, T1? arg1, T2? arg2)
     {
       if (!condition)
       {
@@ -59,7 +60,7 @@ namespace JetBrains.Diagnostics
     [ContractAnnotation("condition:false=>void")]
     [AssertionMethod, StringFormatMethod("message")]
     [Conditional("JET_MODE_ASSERT")]
-    public static void Assert<T1, T2, T3>(bool condition, [NotNull] string message, T1 arg1, T2 arg2, T3 arg3)
+    public static void Assert<T1, T2, T3>([DoesNotReturnIf(false)] bool condition, string message, T1? arg1, T2? arg2, T3? arg3)
     {
       if (!condition)
       {
@@ -70,7 +71,7 @@ namespace JetBrains.Diagnostics
     [ContractAnnotation("condition:false=>void")]
     [AssertionMethod, StringFormatMethod("message")]
     [Conditional("JET_MODE_ASSERT")]
-    public static void Assert<T1, T2, T3, T4>(bool condition, [NotNull] string message, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+    public static void Assert<T1, T2, T3, T4>([DoesNotReturnIf(false)] bool condition, string message, T1? arg1, T2? arg2, T3? arg3, T4? arg4)
     {
       if (!condition)
       {
@@ -81,7 +82,7 @@ namespace JetBrains.Diagnostics
     [ContractAnnotation("condition:false=>void")]
     [AssertionMethod, StringFormatMethod("message")]
     [Conditional("JET_MODE_ASSERT")]
-    public static void Assert(bool condition, [NotNull] string message, params object[] args)
+    public static void Assert([DoesNotReturnIf(false)] bool condition, string message, params object?[] args)
     {
       if (!condition)
       {
@@ -91,35 +92,40 @@ namespace JetBrains.Diagnostics
 
     [ContractAnnotation("=>void")]
     [AssertionMethod]
-    public static void Fail([NotNull] string message)
+    [DoesNotReturn]
+    public static void Fail(string message)
     {
       throw new AssertionException(message);
     }
 
     [ContractAnnotation("=>void")]
     [AssertionMethod, StringFormatMethod("message")]
-    public static void Fail([NotNull] string message, object arg)
+    [DoesNotReturn]
+    public static void Fail(string message, object? arg)
     {
       Fail(string.Format(message, arg));
     }
 
     [ContractAnnotation("=>void")]
     [AssertionMethod, StringFormatMethod("message")]
-    public static void Fail([NotNull] string message, object arg1, object arg2)
+    [DoesNotReturn]
+    public static void Fail(string message, object? arg1, object? arg2)
     {
       Fail(string.Format(message, arg1, arg2));
     }
 
     [ContractAnnotation("=>void")]
     [AssertionMethod, StringFormatMethod("message")]
-    public static void Fail([NotNull] string message, object arg1, object arg2, object arg3)
+    [DoesNotReturn]
+    public static void Fail(string message, object? arg1, object? arg2, object? arg3)
     {
       Fail(string.Format(message, arg1, arg2, arg3));
     }
 
     [ContractAnnotation("=>void")]
     [AssertionMethod, StringFormatMethod("message")]
-    public static void Fail([NotNull] string message, params object[] args)
+    [DoesNotReturn]
+    public static void Fail(string message, params object?[] args)
     {
       Fail(args == null || args.Length == 0 ? message : String.Format(message, args));
     }
@@ -127,7 +133,7 @@ namespace JetBrains.Diagnostics
     [ContractAnnotation("condition:null=>void")]
     [AssertionMethod]
     [Conditional("JET_MODE_ASSERT")]
-    public static void AssertNotNull(object condition, [NotNull] string message)
+    public static void AssertNotNull([CodeAnalysis.NotNull] object? condition, string message)
     {
       if (condition == null)
       {
@@ -139,7 +145,7 @@ namespace JetBrains.Diagnostics
     [ContractAnnotation("condition:null=>void")]
     [AssertionMethod, StringFormatMethod("message")]
     [Conditional("JET_MODE_ASSERT")]
-    public static void AssertNotNull(object condition, [NotNull] string message, object arg)
+    public static void AssertNotNull([CodeAnalysis.NotNull] object? condition, string message, object? arg)
     {
       if (condition == null)
       {
@@ -150,7 +156,7 @@ namespace JetBrains.Diagnostics
     [ContractAnnotation("condition:null=>void")]
     [AssertionMethod, StringFormatMethod("message")]
     [Conditional("JET_MODE_ASSERT")]
-    public static void AssertNotNull(object condition, [NotNull] string message, object arg1, object arg2)
+    public static void AssertNotNull([CodeAnalysis.NotNull] object? condition, string message, object? arg1, object? arg2)
     {
       if (condition == null)
       {
@@ -161,7 +167,7 @@ namespace JetBrains.Diagnostics
     [ContractAnnotation("condition:null=>void")]
     [AssertionMethod, StringFormatMethod("message")]
     [Conditional("JET_MODE_ASSERT")]
-    public static void AssertNotNull(object condition, [NotNull] string message, object arg1, object arg2, object arg3)
+    public static void AssertNotNull([CodeAnalysis.NotNull] object? condition, string message, object? arg1, object? arg2, object? arg3)
     {
       if (condition == null)
       {
@@ -172,7 +178,7 @@ namespace JetBrains.Diagnostics
     [ContractAnnotation("condition:null=>void")]
     [AssertionMethod, StringFormatMethod("message")]
     [Conditional("JET_MODE_ASSERT")]
-    public static void AssertNotNull(object condition, [NotNull] string message, params object[] args)
+    public static void AssertNotNull([CodeAnalysis.NotNull] object? condition, string message, params object?[] args)
     {
       if (condition == null)
       {
@@ -182,7 +188,7 @@ namespace JetBrains.Diagnostics
 
     [ContractAnnotation("value:null => void; => value:notnull, notnull")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public static T NotNull<T>(this T value, [NotNull] object debugMessage) where T : class
+    public static T NotNull<T>(this T? value, object debugMessage) where T : class
     {
       if (value == null)
       {
@@ -194,7 +200,7 @@ namespace JetBrains.Diagnostics
 
     [ContractAnnotation("value:null => void; => value:notnull, notnull")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public static T NotNull<T>(this T value, [NotNull] string message) where T : class
+    public static T NotNull<T>(this T? value, string message) where T : class
     {
       if (value == null)
       {
@@ -207,7 +213,7 @@ namespace JetBrains.Diagnostics
     [ContractAnnotation("value:null => void; => value:notnull, notnull")]
     [StringFormatMethod("args")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public static T NotNull<T>(this T value, [NotNull] string message, params object[] args) where T : class
+    public static T NotNull<T>(this T? value, string message, params object?[] args) where T : class
     {
       if (value == null)
       {
@@ -219,7 +225,7 @@ namespace JetBrains.Diagnostics
 
     [ContractAnnotation("value:null => void; => value:notnull, notnull")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public static T NotNull<T>(this T value) where T : class
+    public static T NotNull<T>(this T? value) where T : class
     {
       if (value == null)
       {
@@ -231,7 +237,7 @@ namespace JetBrains.Diagnostics
 
     [ContractAnnotation("value:null => void; => value:notnull")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public static T NotNull<T>(this T? value, [NotNull] string message) where T : struct
+    public static T NotNull<T>(this T? value, string message) where T : struct
     {
       if (value == null)
       {
@@ -254,7 +260,7 @@ namespace JetBrains.Diagnostics
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining), StringFormatMethod("message"), AssertionMethod]
-    public static void Require(bool value, [NotNull] string message)
+    public static void Require([DoesNotReturnIf(false)] bool value, string message)
     {
       if (!value)
       {
@@ -263,7 +269,7 @@ namespace JetBrains.Diagnostics
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining), StringFormatMethod("message"), AssertionMethod]
-    public static void Require(bool value, [NotNull] string message, object arg1)
+    public static void Require([DoesNotReturnIf(false)] bool value, string message, object? arg1)
     {
       if (!value)
       {
@@ -272,7 +278,7 @@ namespace JetBrains.Diagnostics
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining), StringFormatMethod("message"), AssertionMethod]
-    public static void Require(bool value, [NotNull] string message, object arg1, object arg2)
+    public static void Require([DoesNotReturnIf(false)] bool value, string message, object? arg1, object? arg2)
     {
       if (!value)
       {
@@ -281,7 +287,7 @@ namespace JetBrains.Diagnostics
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining), StringFormatMethod("message"), AssertionMethod]
-    public static void Require(bool value, [NotNull] string message, params object[] args)
+    public static void Require([DoesNotReturnIf(false)] bool value, string message, params object?[] args)
     {
       if (!value)
       {

--- a/rd-net/Lifetimes/Diagnostics/FirstChanceExceptionInterceptor.cs
+++ b/rd-net/Lifetimes/Diagnostics/FirstChanceExceptionInterceptor.cs
@@ -19,7 +19,7 @@ namespace JetBrains.Diagnostics
   /// </summary>
   public static class FirstChanceExceptionInterceptor
   {
-    [ThreadStatic] private static Stack ourThreadLocalDebugInfo;
+    [ThreadStatic] private static Stack? ourThreadLocalDebugInfo;
 
     public const string ExceptionDataKey = "ThreadLocalDebugInfo"; 
     
@@ -54,7 +54,6 @@ namespace JetBrains.Diagnostics
       }
     }
 
-    [NotNull]
     private static object[] GetThreadLocalDebugInfo()
     {
       var info = ourThreadLocalDebugInfo;

--- a/rd-net/Lifetimes/Diagnostics/ILog.cs
+++ b/rd-net/Lifetimes/Diagnostics/ILog.cs
@@ -18,8 +18,8 @@ namespace JetBrains.Diagnostics
   /// </summary>
   public interface ILog
   {    
-    [NotNull] string Category { get; }
+    string Category { get; }
     bool IsEnabled(LoggingLevel level);
-    void Log(LoggingLevel level, [CanBeNull] string message, [CanBeNull] Exception exception = null);
+    void Log(LoggingLevel level, string? message, Exception? exception = null);
   }
 }

--- a/rd-net/Lifetimes/Diagnostics/ILogFactory.cs
+++ b/rd-net/Lifetimes/Diagnostics/ILogFactory.cs
@@ -9,7 +9,6 @@ namespace JetBrains.Diagnostics
   /// </summary>
   public interface ILogFactory
   {
-    [NotNull]
     ILog GetLog(string category);
   }
 }

--- a/rd-net/Lifetimes/Diagnostics/Internal/LogBase.cs
+++ b/rd-net/Lifetimes/Diagnostics/Internal/LogBase.cs
@@ -1,5 +1,4 @@
 using System;
-using JetBrains.Annotations;
 
 namespace JetBrains.Diagnostics.Internal
 {
@@ -18,11 +17,11 @@ namespace JetBrains.Diagnostics.Internal
 
   public abstract class LogBase : ILog
   {
-    public event Action<LeveledMessage> Handlers;
+    public event Action<LeveledMessage>? Handlers;
     public string Category { get; }
     public LoggingLevel EnabledLevel { get; set; }
 
-    protected LogBase([NotNull] string category, LoggingLevel enabledLevel = LoggingLevel.INFO)
+    protected LogBase(string category, LoggingLevel enabledLevel = LoggingLevel.INFO)
     {
       Category = category ?? throw new ArgumentNullException(nameof(category));
       EnabledLevel = enabledLevel;
@@ -33,9 +32,9 @@ namespace JetBrains.Diagnostics.Internal
       return EnabledLevel >= level;
     }
 
-    protected abstract string Format(LoggingLevel level, string message, Exception exception);
+    protected abstract string Format(LoggingLevel level, string? message, Exception? exception);
 
-    public virtual void Log(LoggingLevel level, string message, Exception exception = null)
+    public virtual void Log(LoggingLevel level, string? message, Exception? exception = null)
     {
       if (!IsEnabled(level))
         return;
@@ -51,7 +50,7 @@ namespace JetBrains.Diagnostics.Internal
 
   public abstract class LogFactoryBase : ILogFactory
   {
-    public event Action<LeveledMessage> Handlers;
+    public event Action<LeveledMessage>? Handlers;
 
     public ILog GetLog(string category)
     {

--- a/rd-net/Lifetimes/Diagnostics/Internal/NullLog.cs
+++ b/rd-net/Lifetimes/Diagnostics/Internal/NullLog.cs
@@ -16,6 +16,6 @@ namespace JetBrains.Diagnostics.Internal
       return false;
     }
 
-    void ILog.Log(LoggingLevel level, string message, Exception exception) {}
+    void ILog.Log(LoggingLevel level, string? message, Exception? exception) {}
   }
 }

--- a/rd-net/Lifetimes/Diagnostics/Internal/TextWriterLog.cs
+++ b/rd-net/Lifetimes/Diagnostics/Internal/TextWriterLog.cs
@@ -12,12 +12,12 @@ namespace JetBrains.Diagnostics.Internal
   {
     [PublicAPI] public TextWriter Writer { get; }
 
-    protected override string Format(LoggingLevel level, string message, Exception exception)
+    protected override string Format(LoggingLevel level, string? message, Exception? exception)
     {
       return Diagnostics.Log.DefaultFormat(DateTime.Now, level, Category, Thread.CurrentThread, message, exception);      
     }
                
-    public TextWriterLog([NotNull] TextWriter writer, [NotNull] string category, LoggingLevel enabledLevel = LoggingLevel.VERBOSE) : base(category, enabledLevel)
+    public TextWriterLog(TextWriter writer, string category, LoggingLevel enabledLevel = LoggingLevel.VERBOSE) : base(category, enabledLevel)
     {
       Writer = TextWriter.Synchronized(writer ?? throw new ArgumentNullException(nameof(writer)));
       Handlers += WriteMessage;
@@ -39,7 +39,7 @@ namespace JetBrains.Diagnostics.Internal
     public LoggingLevel EnabledLevel { get; }
     public TextWriter Writer { get; }
     
-    public TextWriterLogFactory([NotNull] TextWriter writer, LoggingLevel enabledLevel = LoggingLevel.VERBOSE)
+    public TextWriterLogFactory(TextWriter writer, LoggingLevel enabledLevel = LoggingLevel.VERBOSE)
     {
       EnabledLevel = enabledLevel;
       Writer = writer ?? throw new ArgumentNullException(nameof(writer));

--- a/rd-net/Lifetimes/Diagnostics/Log.cs
+++ b/rd-net/Lifetimes/Diagnostics/Log.cs
@@ -25,7 +25,6 @@ namespace JetBrains.Diagnostics
     #region Set factory settings via Statics helpers
 
     private static readonly StaticsForType<ILogFactory> ourStatics = Statics.For<ILogFactory>();
-    [NotNull]
     private static volatile ILogFactory ourCurrentFactory;
 
     
@@ -74,7 +73,7 @@ namespace JetBrains.Diagnostics
     /// <param name="factory">Factory to use as global  util returned object is not disposed</param>
     /// <returns>IDisposable, that should be disposed to return old logger factory. </returns>
     /// <exception cref="ArgumentNullException"></exception>
-    public static IDisposable UsingLogFactory([NotNull]ILogFactory factory)
+    public static IDisposable UsingLogFactory(ILogFactory factory)
     {
       if (factory == null) throw new ArgumentNullException(nameof(factory));
 
@@ -94,7 +93,7 @@ namespace JetBrains.Diagnostics
     /// </summary>
     /// <param name="category"></param>
     /// <returns></returns>
-    public static ILog GetLog([NotNull]string category)
+    public static ILog GetLog(string category)
     {
       return new SwitchingLog(category);
     }
@@ -134,43 +133,35 @@ namespace JetBrains.Diagnostics
 
       private 
         // todo volatile : think about it when we target ARM  
-        ILogFactory myFactory;
+        ILogFactory? myFactory;
 
-      private ILog myLog;
+      private ILog? myLog;
 
       public SwitchingLog(string category)
       {
         myCategory = category;
       }
 
-      public string Category
-      {
-        get
-        {
-          CheckImplementationSwitched();
-          return myLog.Category;
-        }
-      }
+      public string Category => CheckImplementationSwitched().Category;
 
       bool ILog.IsEnabled(LoggingLevel level)
       {
-        CheckImplementationSwitched();
-        return myLog.IsEnabled(level);
+        return CheckImplementationSwitched().IsEnabled(level);
       }
 
-      void ILog.Log(LoggingLevel level, string message, Exception exception)
+      void ILog.Log(LoggingLevel level, string? message, Exception? exception)
       {
-        CheckImplementationSwitched();
-        myLog.Log(level, message, exception);
+        CheckImplementationSwitched().Log(level, message, exception);
       }
 
       [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-      private void CheckImplementationSwitched()
+      private ILog CheckImplementationSwitched()
       {
-        if (myFactory == ourCurrentFactory) return;
+        if (myFactory == ourCurrentFactory) return myLog!;
 
         myLog = ourCurrentFactory.GetLog(myCategory).NotNull("Logger mustn't be null!");
         myFactory = ourCurrentFactory;
+        return myLog;
       }
     }
     #endregion
@@ -198,12 +189,12 @@ namespace JetBrains.Diagnostics
     /// <param name="exception"></param>
     /// <returns></returns>
     public static string DefaultFormat(
-      [CanBeNull] DateTime? date,
+      DateTime? date,
       LoggingLevel loggingLevel,
-      [CanBeNull] string category,
-      [CanBeNull] Thread thread,
-      [CanBeNull] string message,
-      [CanBeNull] Exception exception = null
+      string? category,
+      Thread? thread,
+      string? message,
+      Exception? exception = null
     )
     {
       var builder = new StringBuilder();
@@ -257,7 +248,7 @@ namespace JetBrains.Diagnostics
     /// <returns>created factory</returns>
     /// <exception cref="Exception"></exception>
     /// <exception cref="IOException"></exception>
-    public static TextWriterLogFactory CreateFileLogFactory([NotNull]Lifetime lifetime, [NotNull]string path, bool append = false, LoggingLevel enabledLevel = LoggingLevel.VERBOSE)
+    public static TextWriterLogFactory CreateFileLogFactory([NotNull]Lifetime lifetime, string path, bool append = false, LoggingLevel enabledLevel = LoggingLevel.VERBOSE)
     {      
       Assertion.Assert(lifetime.IsAlive, "lifetime.IsTerminated");
       

--- a/rd-net/Lifetimes/Diagnostics/Log.cs
+++ b/rd-net/Lifetimes/Diagnostics/Log.cs
@@ -248,7 +248,7 @@ namespace JetBrains.Diagnostics
     /// <returns>created factory</returns>
     /// <exception cref="Exception"></exception>
     /// <exception cref="IOException"></exception>
-    public static TextWriterLogFactory CreateFileLogFactory([NotNull]Lifetime lifetime, string path, bool append = false, LoggingLevel enabledLevel = LoggingLevel.VERBOSE)
+    public static TextWriterLogFactory CreateFileLogFactory(Lifetime lifetime, string path, bool append = false, LoggingLevel enabledLevel = LoggingLevel.VERBOSE)
     {      
       Assertion.Assert(lifetime.IsAlive, "lifetime.IsTerminated");
       

--- a/rd-net/Lifetimes/Diagnostics/LogEx.cs
+++ b/rd-net/Lifetimes/Diagnostics/LogEx.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
@@ -8,7 +7,7 @@ namespace JetBrains.Diagnostics
   public static class LogEx
   {
 
-    public static ILog GetSublogger([NotNull] this ILog log, [NotNull] string subcategory)
+    public static ILog GetSublogger(this ILog log, string subcategory)
     {
       return Log.GetLog(log.Category + "." + subcategory);
     }
@@ -17,12 +16,12 @@ namespace JetBrains.Diagnostics
     
     #region IsEnabled
 
-    public static bool IsTraceEnabled([NotNull] this ILog @this)
+    public static bool IsTraceEnabled(this ILog @this)
     {
       return @this.IsEnabled(LoggingLevel.TRACE);
     }
 
-    public static bool IsVersboseEnabled([NotNull] this ILog @this)
+    public static bool IsVersboseEnabled(this ILog @this)
     {
       return @this.IsEnabled(LoggingLevel.VERBOSE);
     }
@@ -35,28 +34,28 @@ namespace JetBrains.Diagnostics
     #region LogFormat
     
     [StringFormatMethod("message")]
-    public static void LogFormat<T1>([NotNull] this ILog @this, LoggingLevel level, string message, T1 t1)
+    public static void LogFormat<T1>(this ILog @this, LoggingLevel level, string message, T1 t1)
     {
       if(@this.IsEnabled(level))
         @this.Log(level, message.FormatEx(t1));
     }
 
     [StringFormatMethod("message")]
-    public static void LogFormat<T1, T2>([NotNull] this ILog @this, LoggingLevel level, string message, T1 t1, T2 t2)
+    public static void LogFormat<T1, T2>(this ILog @this, LoggingLevel level, string message, T1 t1, T2 t2)
     {
       if(@this.IsEnabled(level))
         @this.Log(level, message.FormatEx(t1, t2));
     }
 
     [StringFormatMethod("message")]
-    public static void LogFormat<T1, T2, T3>([NotNull] this ILog @this, LoggingLevel level, string message, T1 t1, T2 t2, T3 t3)
+    public static void LogFormat<T1, T2, T3>(this ILog @this, LoggingLevel level, string message, T1 t1, T2 t2, T3 t3)
     {
       if(@this.IsEnabled(level))
         @this.Log(level, message.FormatEx(t1, t2, t3));
     }
 
     [StringFormatMethod("message")]
-    public static void LogFormat<T1, T2, T3, T4>([NotNull] this ILog @this, LoggingLevel level, string message, T1 t1, T2 t2, T3 t3, T4 t4)
+    public static void LogFormat<T1, T2, T3, T4>(this ILog @this, LoggingLevel level, string message, T1 t1, T2 t2, T3 t3, T4 t4)
     {
       if(@this.IsEnabled(level))
         @this.Log(level, message.FormatEx(t1, t2, t3, t4));
@@ -64,7 +63,7 @@ namespace JetBrains.Diagnostics
 
     //Universal method for many parameter
     [StringFormatMethod("message")]
-    public static void LogFormat([NotNull] this ILog @this, LoggingLevel level, string message, params object[] args)
+    public static void LogFormat(this ILog @this, LoggingLevel level, string message, params object?[] args)
     {
       if(@this.IsEnabled(level))
         @this.Log(level, message.FormatEx(args));
@@ -76,43 +75,43 @@ namespace JetBrains.Diagnostics
     
     #region Trace
 
-    public static void Trace([NotNull] this ILog @this, [NotNull] string message)
+    public static void Trace(this ILog @this, string message)
     {
       @this.Log(LoggingLevel.TRACE, message);      
     }    
 
     [StringFormatMethod("message")]
-    public static void Trace<T1>([NotNull] this ILog @this, string message, T1 t1)
+    public static void Trace<T1>(this ILog @this, string message, T1 t1)
     {
       @this.LogFormat(LoggingLevel.TRACE, message, t1);
     }
 
     [StringFormatMethod("message")]
-    public static void Trace<T1, T2>([NotNull] this ILog @this, string message, T1 t1, T2 t2)
+    public static void Trace<T1, T2>(this ILog @this, string message, T1 t1, T2 t2)
     {
       @this.LogFormat(LoggingLevel.TRACE, message, t1, t2);
     }
 
     [StringFormatMethod("message")]
-    public static void Trace<T1, T2, T3>([NotNull] this ILog @this, string message, T1 t1, T2 t2, T3 t3)
+    public static void Trace<T1, T2, T3>(this ILog @this, string message, T1 t1, T2 t2, T3 t3)
     {
       @this.LogFormat(LoggingLevel.TRACE, message, t1, t2, t3);
     }
 
     [StringFormatMethod("message")]
-    public static void Trace<T1, T2, T3, T4>([NotNull] this ILog @this, string message, T1 t1, T2 t2, T3 t3, T4 t4)
+    public static void Trace<T1, T2, T3, T4>(this ILog @this, string message, T1 t1, T2 t2, T3 t3, T4 t4)
     {
       @this.LogFormat(LoggingLevel.TRACE, message, t1, t2, t3, t4);
     }
 
     [StringFormatMethod("message")]
-    public static void Trace<T1, T2, T3, T4, T5>([NotNull] this ILog @this, string message, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5)
+    public static void Trace<T1, T2, T3, T4, T5>(this ILog @this, string message, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5)
     {
       @this.LogFormat(LoggingLevel.TRACE, message, t1, t2, t3, t4, t5);
     }
 
     [StringFormatMethod("message")]
-    public static void Trace<T1, T2, T3, T4, T5, T6>([NotNull] this ILog @this, string message, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6)
+    public static void Trace<T1, T2, T3, T4, T5, T6>(this ILog @this, string message, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6)
     {
       @this.LogFormat(LoggingLevel.TRACE, message, t1, t2, t3, t4, t5, t6);
     }
@@ -123,54 +122,54 @@ namespace JetBrains.Diagnostics
     
     #region Verbose
        
-    public static void Verbose([NotNull] this ILog @this, [NotNull] string message)
+    public static void Verbose(this ILog @this, string message)
     {
       @this.Log(LoggingLevel.VERBOSE, message);
     }
 
     [StringFormatMethod("message")]
-    public static void Verbose<T1>([NotNull] this ILog @this, string message, T1 t1)
+    public static void Verbose<T1>(this ILog @this, string message, T1 t1)
     {
       @this.LogFormat(LoggingLevel.VERBOSE, message, t1);
     }
 
     [StringFormatMethod("message")]
-    public static void Verbose<T1, T2>([NotNull] this ILog @this, string message, T1 t1, T2 t2)
+    public static void Verbose<T1, T2>(this ILog @this, string message, T1 t1, T2 t2)
     {
       @this.LogFormat(LoggingLevel.VERBOSE, message, t1, t2);
     }
 
     [StringFormatMethod("message")]
-    public static void Verbose<T1, T2, T3>([NotNull] this ILog @this, string message, T1 t1, T2 t2, T3 t3)
+    public static void Verbose<T1, T2, T3>(this ILog @this, string message, T1 t1, T2 t2, T3 t3)
     {
       @this.LogFormat(LoggingLevel.VERBOSE, message, t1, t2, t3);
     }
 
     [StringFormatMethod("message")]
-    public static void Verbose<T1, T2, T3, T4>([NotNull] this ILog @this, string message, T1 t1, T2 t2, T3 t3, T4 t4)
+    public static void Verbose<T1, T2, T3, T4>(this ILog @this, string message, T1 t1, T2 t2, T3 t3, T4 t4)
     {
       @this.LogFormat(LoggingLevel.VERBOSE, message, t1, t2, t3, t4);
     }
 
     [StringFormatMethod("message")]
-    public static void Verbose<T1, T2, T3, T4, T5>([NotNull] this ILog @this, string message, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5)
+    public static void Verbose<T1, T2, T3, T4, T5>(this ILog @this, string message, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5)
     {
       @this.LogFormat(LoggingLevel.VERBOSE, message, t1, t2, t3, t4, t5);
     }
 
     [StringFormatMethod("message")]
-    public static void Verbose<T1, T2, T3, T4, T5, T6>([NotNull] this ILog @this, string message, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6)
+    public static void Verbose<T1, T2, T3, T4, T5, T6>(this ILog @this, string message, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6)
     {
       @this.LogFormat(LoggingLevel.VERBOSE, message, t1, t2, t3, t4, t5, t6);
     }
 
     [StringFormatMethod("message")]
-    public static void Verbose([NotNull] this ILog @this, string message, object[] args)
+    public static void Verbose(this ILog @this, string message, object[] args)
     {
       @this.LogFormat(LoggingLevel.VERBOSE, message, args);
     }
 
-    public static void Verbose([NotNull] this ILog @this, [NotNull] Exception ex, string message = null)
+    public static void Verbose(this ILog @this, Exception ex, string? message = null)
     {
       @this.Log(LoggingLevel.VERBOSE, message, ex);
     }
@@ -178,18 +177,18 @@ namespace JetBrains.Diagnostics
     #endregion
 
     #region Info
-    public static void Info([NotNull] this ILog @this, [NotNull] string message)
+    public static void Info(this ILog @this, string message)
     {
       @this.Log(LoggingLevel.INFO, message);
     }
 
     [StringFormatMethod("message")]
-    public static void Info([NotNull] this ILog @this, [NotNull] string message, params object[] args)
+    public static void Info(this ILog @this, string message, params object[] args)
     {
       @this.LogFormat(LoggingLevel.INFO, message, args);
     }
 
-    public static void Info([NotNull] this ILog @this, [NotNull] Exception ex, string message = null)
+    public static void Info(this ILog @this, Exception ex, string? message = null)
     {
       @this.Log(LoggingLevel.INFO, message, ex);
     }
@@ -199,18 +198,18 @@ namespace JetBrains.Diagnostics
 
 
     #region Warn    
-    public static void Warn([NotNull] this ILog @this, [NotNull] string message)
+    public static void Warn(this ILog @this, string message)
     {
       @this.Log(LoggingLevel.WARN, message);
     } 
     
     [StringFormatMethod("message")]
-    public static void Warn([NotNull] this ILog @this, [NotNull] string message, params object[] args)
+    public static void Warn(this ILog @this, string message, params object[] args)
     {
       @this.LogFormat(LoggingLevel.WARN, message, args);
     }
     
-    public static void Warn([NotNull] this ILog @this, [NotNull] Exception ex, string message = null)
+    public static void Warn(this ILog @this, Exception ex, string? message = null)
     {
       @this.Log(LoggingLevel.WARN, message, ex);
     }
@@ -221,25 +220,25 @@ namespace JetBrains.Diagnostics
     
     #region Error    
     [StringFormatMethod("message")]
-    public static void Error([NotNull] this ILog @this, [NotNull] string message)
+    public static void Error(this ILog @this, string message)
     {
       @this.Log(LoggingLevel.ERROR, message);
     } 
     
     [StringFormatMethod("message")]
-    public static void Error([NotNull] this ILog @this, [NotNull] string message, params object[] args)
+    public static void Error(this ILog @this, string message, params object?[] args)
     {
       @this.LogFormat(LoggingLevel.ERROR, message, args);
     }
     
     [StringFormatMethod("message")]
-    public static void Error([NotNull] this ILog @this, [NotNull] string message, Exception e)
+    public static void Error(this ILog @this, string message, Exception e)
     {
       @this.Log(LoggingLevel.ERROR, message, e);
     }
     
     [StringFormatMethod("message")]
-    public static void Error([NotNull] this ILog @this, [NotNull] Exception ex, string message = null)
+    public static void Error(this ILog @this, Exception ex, string? message = null)
     {
       @this.Log(LoggingLevel.ERROR, message, ex);
     }
@@ -251,7 +250,7 @@ namespace JetBrains.Diagnostics
     
     #region Assert
     
-    public static void Assert([NotNull] this ILog @this, bool condition, string message)
+    public static void Assert(this ILog @this, bool condition, string message)
     {
       if (!condition)
       {
@@ -259,7 +258,7 @@ namespace JetBrains.Diagnostics
       }
     }
     
-    public static void Assert<T1>([NotNull] this ILog @this, bool condition, string message, T1 t1)
+    public static void Assert<T1>(this ILog @this, bool condition, string message, T1 t1)
     {
       if (!condition)
       {
@@ -267,7 +266,7 @@ namespace JetBrains.Diagnostics
       }
     } 
     
-    public static void Assert([NotNull] this ILog @this, bool condition, string message, params object[] args)
+    public static void Assert(this ILog @this, bool condition, string message, params object[] args)
     {
       if (!condition)
       {
@@ -310,7 +309,7 @@ namespace JetBrains.Diagnostics
 #if !NET35
     [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
 #endif  
-    [PublicAPI] public static T Catch<T>(this ILog log, Func<T> action)
+    [PublicAPI] public static T? Catch<T>(this ILog log, Func<T> action)
     {
       try
       {
@@ -352,7 +351,7 @@ namespace JetBrains.Diagnostics
 #if !NET35
     [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
 #endif  
-    [PublicAPI] public static T CatchAndDrop<T>(this ILog log, Func<T> action)
+    [PublicAPI] public static T? CatchAndDrop<T>(this ILog log, Func<T> action)
     {
       try
       {
@@ -394,7 +393,7 @@ namespace JetBrains.Diagnostics
 #if !NET35
     [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
 #endif
-    [PublicAPI] public static T CatchWarn<T>(this ILog log, Func<T> action)
+    [PublicAPI] public static T? CatchWarn<T>(this ILog log, Func<T> action)
     {
       try
       {
@@ -422,7 +421,7 @@ namespace JetBrains.Diagnostics
       
     [MethodImpl(MethodImplOptions.NoInlining)]
     [StringFormatMethod("s")]
-    private static string FormatEx(this string s, params object[] p)
+    private static string FormatEx(this string s, params object?[] p)
     {
       return string.Format(s, p);
     }

--- a/rd-net/Lifetimes/Diagnostics/LogLog.cs
+++ b/rd-net/Lifetimes/Diagnostics/LogLog.cs
@@ -12,7 +12,7 @@ namespace JetBrains.Diagnostics
   /// </summary>
   public class LogLogRecord
   {
-    public LogLogRecord(string category, LoggingLevel severity, [NotNull] string message)
+    public LogLogRecord(string? category, LoggingLevel severity, string message)
     {
       Time = DateTime.Now.ToLocalTime(); //no need for UTC, because we want to display dates in local format
       Category = category;
@@ -21,10 +21,9 @@ namespace JetBrains.Diagnostics
     }
 
     public DateTime Time { get; }
-    public string Category { get; }
+    public string? Category { get; }
     public LoggingLevel Severity { get; }
 
-    [NotNull]
     public string Message { get; }
 
     public string Format(bool includeDate)
@@ -83,7 +82,7 @@ namespace JetBrains.Diagnostics
     [ThreadStatic]
     private static bool ourReentrancyGuard;
 
-    private static void Fire([CanBeNull] string category, [NotNull] string msg, LoggingLevel severity)
+    private static void Fire(string? category, string msg, LoggingLevel severity)
     {
       if (ourReentrancyGuard)
       {
@@ -184,7 +183,7 @@ namespace JetBrains.Diagnostics
 
     #region API for logloging
 
-    public static void Error([NotNull] Exception ex, string comment = null)
+    public static void Error(Exception ex, string? comment = null)
     {
       if (ex == null) throw new ArgumentException("ex is null");
 
@@ -192,7 +191,7 @@ namespace JetBrains.Diagnostics
       Fire(null, msg, LoggingLevel.ERROR);
     }
 
-    public static void Error([NotNull] string error)
+    public static void Error(string error)
     {
       if (error == null) throw new ArgumentNullException(nameof(error));
 
@@ -201,7 +200,7 @@ namespace JetBrains.Diagnostics
     }
     
     [StringFormatMethod("format")]
-    public static void Warn([NotNull] string format, params object[] args)
+    public static void Warn(string format, params object[] args)
     {
       if (format == null) throw new ArgumentException("message is null");
 
@@ -210,7 +209,7 @@ namespace JetBrains.Diagnostics
     }
 
     [StringFormatMethod("format")]
-    public static void Info([NotNull] string format, params object[] args)
+    public static void Info(string format, params object[] args)
     {
       if (format == null) throw new ArgumentException("message is null");
 
@@ -219,7 +218,7 @@ namespace JetBrains.Diagnostics
     }
 
     [StringFormatMethod("format")]
-    public static void Verbose([CanBeNull] string category, [NotNull] string format, params object[] args)
+    public static void Verbose(string? category, string format, params object[] args)
     {
       if (format == null) throw new ArgumentException("message is null");
 
@@ -228,7 +227,7 @@ namespace JetBrains.Diagnostics
     }
     
     [StringFormatMethod("format")]
-    public static void Trace([CanBeNull] string category, [NotNull] string format, params object[] args)
+    public static void Trace(string? category, string format, params object[] args)
     {
       if (format == null) throw new ArgumentException("message is null");
 
@@ -240,7 +239,7 @@ namespace JetBrains.Diagnostics
     }
     
     [StringFormatMethod("format")]
-    public static void Trace<T1>([CanBeNull] string category, [NotNull] string format, T1 arg) //to suppress array creation
+    public static void Trace<T1>(string? category, string format, T1 arg) //to suppress array creation
     {
       if (format == null) throw new ArgumentException("message is null");
 
@@ -252,7 +251,7 @@ namespace JetBrains.Diagnostics
     }
     
     [StringFormatMethod("format")]
-    public static void Trace<T1, T2>([CanBeNull] string category, [NotNull] string format, T1 arg1, T2 arg2) //to suppress array creation 
+    public static void Trace<T1, T2>(string? category, string format, T1 arg1, T2 arg2) //to suppress array creation 
     {
       if (format == null) throw new ArgumentException("message is null");
 
@@ -267,7 +266,7 @@ namespace JetBrains.Diagnostics
     [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
 #endif    
     
-    public static void Catch([NotNull] string comment, [NotNull] Action action)
+    public static void Catch(string comment, Action action)
     {
       try
       {
@@ -283,7 +282,7 @@ namespace JetBrains.Diagnostics
     [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
 #endif
     
-    public static void Catch([NotNull] Action action)
+    public static void Catch(Action action)
     {
       try
       {
@@ -299,7 +298,7 @@ namespace JetBrains.Diagnostics
     [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
 #endif
     
-    public static T Catch<T>([NotNull] Func<T> action)
+    public static T? Catch<T>(Func<T> action)
     {
       try
       {

--- a/rd-net/Lifetimes/Diagnostics/LogWithLevel.cs
+++ b/rd-net/Lifetimes/Diagnostics/LogWithLevel.cs
@@ -22,7 +22,7 @@ namespace JetBrains.Diagnostics
     [PublicAPI] public ILog Logger { get; }
     [PublicAPI] public LoggingLevel Level {get; }
 
-    [PublicAPI] public LogWithLevel([NotNull] ILog logger, LoggingLevel level)
+    [PublicAPI] public LogWithLevel(ILog logger, LoggingLevel level)
     {
       Logger = logger ?? throw new ArgumentNullException(nameof(logger));
       Level = level;
@@ -41,7 +41,7 @@ namespace JetBrains.Diagnostics
     /// <param name="level"/>
     /// <returns><see cref="LogWithLevel"/>(<paramref name="logger"/>, <paramref name="level"/>) if <see cref="ILog.IsEnabled"/> for given level;
     /// null otherwise</returns>
-    [PublicAPI] public static LogWithLevel? CreateIfEnabled([NotNull] ILog logger, LoggingLevel level) => 
+    [PublicAPI] public static LogWithLevel? CreateIfEnabled(ILog logger, LoggingLevel level) => 
       logger.IsEnabled(level) ? new LogWithLevel(logger, level) : (LogWithLevel?) null;
   }
 }

--- a/rd-net/Lifetimes/Diagnostics/RName.cs
+++ b/rd-net/Lifetimes/Diagnostics/RName.cs
@@ -10,22 +10,22 @@ namespace JetBrains.Diagnostics
   {
     [PublicAPI] public static readonly RName Empty = new RName(null, "", "");
     
-    [PublicAPI, CanBeNull] 
-    public readonly object Parent;
-    [PublicAPI, NotNull]
+    [PublicAPI] 
+    public readonly object? Parent;
+    [PublicAPI]
     public readonly string Separator;
-    [PublicAPI, NotNull] 
+    [PublicAPI] 
     public readonly object LocalName;
     
 
-    public RName([CanBeNull] object parent, [NotNull] object localName, [NotNull] string separator)
+    public RName(object? parent, object localName, string separator)
     {
       Parent = parent;
       Separator = separator ?? throw new ArgumentNullException(nameof(separator));
       LocalName = localName ?? throw new ArgumentNullException(nameof(localName));
     }
     
-    public RName([NotNull] object localName) : this(Empty, localName, "") {}
+    public RName(object localName) : this(Empty, localName, "") {}
 
     /// <summary>
     /// Separator doesn't count if localName is empty or parent is empty.
@@ -34,7 +34,7 @@ namespace JetBrains.Diagnostics
     /// <param name="separator"></param>
     /// <returns></returns>
     /// <exception cref="ArgumentNullException"></exception>
-    public RName Sub([NotNull] object localName, string separator=".")
+    public RName Sub(object localName, string separator=".")
     {
       if (localName == null) throw new ArgumentNullException(nameof(localName));
       if (localName is string s && s.Length == 0) 
@@ -43,7 +43,6 @@ namespace JetBrains.Diagnostics
       return new RName(this, localName, separator ?? "");
     }
 
-    [NotNull]
     public RName GetNonEmptyRoot()
     {
       if (!(Parent is RName parent) || Parent == Empty)
@@ -52,7 +51,6 @@ namespace JetBrains.Diagnostics
       return parent.GetNonEmptyRoot();
     }
 
-    [NotNull]
     public RName DropNonEmptyRoot()
     {
       if (!(Parent is RName parent) || parent == Empty)

--- a/rd-net/Lifetimes/Lifetimes.csproj
+++ b/rd-net/Lifetimes/Lifetimes.csproj
@@ -16,7 +16,6 @@
         
         <Platforms>AnyCPU</Platforms>
         
-        <LangVersion>8</LangVersion>
     </PropertyGroup>
     
     <PropertyGroup Label="NuGet">

--- a/rd-net/Lifetimes/Lifetimes.csproj
+++ b/rd-net/Lifetimes/Lifetimes.csproj
@@ -16,6 +16,7 @@
         
         <Platforms>AnyCPU</Platforms>
         
+        <Nullable>enable</Nullable>
     </PropertyGroup>
     
     <PropertyGroup Label="NuGet">

--- a/rd-net/Lifetimes/Lifetimes.csproj
+++ b/rd-net/Lifetimes/Lifetimes.csproj
@@ -15,8 +15,6 @@
         <Configurations>Debug;Release;CrossTests</Configurations>
         
         <Platforms>AnyCPU</Platforms>
-        
-        <Nullable>enable</Nullable>
     </PropertyGroup>
     
     <PropertyGroup Label="NuGet">

--- a/rd-net/Lifetimes/Lifetimes/Lifetime.cs
+++ b/rd-net/Lifetimes/Lifetimes/Lifetime.cs
@@ -83,11 +83,11 @@ namespace JetBrains.Lifetimes
   public readonly struct Lifetime : IEquatable<Lifetime>
   {        
     
-    [CanBeNull] private readonly LifetimeDefinition myDefinition;   
-    [NotNull] internal LifetimeDefinition Definition => myDefinition ?? LifetimeDefinition.Eternal;   
+    private readonly LifetimeDefinition? myDefinition;   
+    internal LifetimeDefinition Definition => myDefinition ?? LifetimeDefinition.Eternal;   
     
     //ctor
-    internal Lifetime([NotNull] LifetimeDefinition definition)
+    internal Lifetime(LifetimeDefinition definition)
     {
       myDefinition = definition;
     }
@@ -151,7 +151,7 @@ namespace JetBrains.Lifetimes
     /// <param name="action">Action to invoke on termination</param>
     /// <exception cref="InvalidOperationException">if lifetime already started destructuring, i.e. <see cref="Status"/> &ge; <see cref="LifetimeStatus.Terminating"/>  </exception>
     /// <returns>this lifetime</returns>
-    [PublicAPI] public Lifetime OnTermination([NotNull] Action action) { Definition.OnTermination(action); return this; }
+    [PublicAPI] public Lifetime OnTermination(Action action) { Definition.OnTermination(action); return this; }
     
     
     /// <summary>
@@ -165,7 +165,7 @@ namespace JetBrains.Lifetimes
     /// </summary>
     /// <param name="disposable">Disposable whose <see cref="IDisposable.Dispose"/> method is invoked on termination</param>
     /// <returns>this lifetime</returns>
-    [PublicAPI] public Lifetime OnTermination([NotNull] IDisposable disposable) { Definition.OnTermination(disposable); return this; }
+    [PublicAPI] public Lifetime OnTermination(IDisposable disposable) { Definition.OnTermination(disposable); return this; }
     
     
     /// <summary>
@@ -179,7 +179,7 @@ namespace JetBrains.Lifetimes
     /// </summary>
     /// <param name="terminationHandler">termination resources whose <see cref="ITerminationHandler.OnTermination"/> method is invoked on termination</param>
     /// <returns>this lifetime</returns>
-    [PublicAPI] public Lifetime OnTermination([NotNull] ITerminationHandler terminationHandler) { Definition.OnTermination(terminationHandler); return this; }
+    [PublicAPI] public Lifetime OnTermination(ITerminationHandler terminationHandler) { Definition.OnTermination(terminationHandler); return this; }
     
     
     //TryOnTermination that do nothing and returns false in case of bad status
@@ -195,7 +195,7 @@ namespace JetBrains.Lifetimes
     /// </summary>
     /// <param name="action">Action to invoke on termination</param>
     /// <returns><c>true</c> if resource added - only status &le; <see cref="LifetimeStatus.Canceling"/>. <c>false</c> if resource's not added - status &ge; <see cref="LifetimeStatus.Terminating"/> </returns>
-    [PublicAPI]          public bool TryOnTermination([NotNull] Action action)      => Definition.TryAdd(action);
+    [PublicAPI]          public bool TryOnTermination(Action action)      => Definition.TryAdd(action);
     
     /// <summary>
     /// Add termination resource with <c>kind == Dispose</c> that will be invoked when lifetime termination starts 
@@ -207,7 +207,7 @@ namespace JetBrains.Lifetimes
     /// </summary>
     /// <param name="disposable">Disposable to invoke on termination</param>
     /// <returns><c>true</c> if resource added - only status &le; <see cref="LifetimeStatus.Canceling"/>. <c>false</c> if resource's not added - status &ge; <see cref="LifetimeStatus.Terminating"/> </returns>
-    [PublicAPI]          public bool TryOnTermination([NotNull] IDisposable disposable) => Definition.TryAdd(disposable);
+    [PublicAPI]          public bool TryOnTermination(IDisposable disposable) => Definition.TryAdd(disposable);
     
     
     /// <summary>
@@ -221,7 +221,7 @@ namespace JetBrains.Lifetimes
     /// <param name="disposable">Action to invoke on termination</param>
     /// <returns><c>true</c> if resource added - only status &le; <see cref="LifetimeStatus.Canceling"/>. <c>false</c> if resource's not added - status &ge; <see cref="LifetimeStatus.Terminating"/> </returns>
 
-    [PublicAPI]          public bool TryOnTermination([NotNull] ITerminationHandler disposable) => Definition.TryAdd(disposable); 
+    [PublicAPI]          public bool TryOnTermination(ITerminationHandler disposable) => Definition.TryAdd(disposable); 
 
     #endregion
 
@@ -285,7 +285,7 @@ namespace JetBrains.Lifetimes
     /// into <see cref="Result{T}"/> or throw (default)</param>
     /// <typeparam name="T"></typeparam>
     /// <returns><see cref="Result"/> that encapsulates execution: successful, canceled ot fail</returns>
-    [PublicAPI] public Result<T> TryExecute<T>([NotNull, InstantHandle] Func<T> action, bool wrapExceptions = false) => Definition.TryExecute(action, wrapExceptions);
+    [PublicAPI] public Result<T> TryExecute<T>([InstantHandle] Func<T> action, bool wrapExceptions = false) => Definition.TryExecute(action, wrapExceptions);
     
     /// <summary>
     /// See <see cref="TryExecute{T}"/>
@@ -293,7 +293,7 @@ namespace JetBrains.Lifetimes
     /// <param name="action"></param>
     /// <param name="wrapExceptions"></param>
     /// <returns></returns>
-    [PublicAPI] public Result<Unit> TryExecute([NotNull, InstantHandle] Action action, bool wrapExceptions = false) => Definition.TryExecute(action, wrapExceptions);
+    [PublicAPI] public Result<Unit> TryExecute([InstantHandle] Action action, bool wrapExceptions = false) => Definition.TryExecute(action, wrapExceptions);
     
     /// <summary>
     /// Same as <see cref="TryExecute{T}"/> but any if lifetime <see cref="IsNotAlive"/> than throws <see cref="LifetimeCanceledException"/>
@@ -301,13 +301,13 @@ namespace JetBrains.Lifetimes
     /// <param name="action"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    [PublicAPI] public T Execute<T>([NotNull, InstantHandle] Func<T> action) => Definition.Execute(action);
+    [PublicAPI] public T Execute<T>([InstantHandle] Func<T> action) => Definition.Execute(action);
     
     /// <summary>
     /// Same as <see cref="TryExecute{T}"/> but any if lifetime <see cref="IsNotAlive"/> than throws <see cref="LifetimeCanceledException"/> 
     /// </summary>
     /// <param name="action"></param>
-    [PublicAPI] public void Execute([NotNull, InstantHandle] Action action) => Definition.Execute(action);
+    [PublicAPI] public void Execute([InstantHandle] Action action) => Definition.Execute(action);
     
     #endregion
     
@@ -327,7 +327,7 @@ namespace JetBrains.Lifetimes
     /// <param name="closing"></param>
     /// <param name="wrapExceptions"></param>
     /// <returns></returns>
-    [PublicAPI] public Result<Unit> TryBracket([NotNull, InstantHandle] Action opening, [NotNull] Action closing, bool wrapExceptions = false) => Definition.TryBracket(opening, closing, wrapExceptions);
+    [PublicAPI] public Result<Unit> TryBracket([InstantHandle] Action opening, Action closing, bool wrapExceptions = false) => Definition.TryBracket(opening, closing, wrapExceptions);
     
     /// <summary>
     /// <inheritdoc cref="TryBracket(Action, Action, bool)"/>
@@ -337,12 +337,12 @@ namespace JetBrains.Lifetimes
     /// <param name="wrapExceptions"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    [PublicAPI] public Result<T> TryBracket<T>([NotNull, InstantHandle] Func<T> opening, [NotNull] Action closing, bool wrapExceptions = false) => Definition.TryBracket(opening, closing, wrapExceptions);
+    [PublicAPI] public Result<T> TryBracket<T>([InstantHandle] Func<T> opening, Action closing, bool wrapExceptions = false) => Definition.TryBracket(opening, closing, wrapExceptions);
     
     /// <summary>
     /// <inheritdoc cref="TryBracket(Action, Action, bool)"/>
     /// </summary>
-    [PublicAPI] public Result<T> TryBracket<T>([NotNull, InstantHandle] Func<T> opening, [NotNull] Action<T> closing, bool wrapExceptions = false) => Definition.TryBracket(opening, closing, wrapExceptions);
+    [PublicAPI] public Result<T> TryBracket<T>([InstantHandle] Func<T> opening, Action<T> closing, bool wrapExceptions = false) => Definition.TryBracket(opening, closing, wrapExceptions);
     
     
     
@@ -354,17 +354,17 @@ namespace JetBrains.Lifetimes
     /// If exception happens in <paramref name="opening"/> it will be thrown but <paramref name="closing"/>
     /// will be executed on termination anyway.
     /// </summary>
-    [PublicAPI] public void Bracket([NotNull, InstantHandle] Action opening, [NotNull] Action closing) => Definition.Bracket(opening, closing);
+    [PublicAPI] public void Bracket([InstantHandle] Action opening, Action closing) => Definition.Bracket(opening, closing);
     
     /// <summary>
     /// <inheritdoc cref="Bracket(Action, Action)"/>
     /// </summary>
-    [PublicAPI] public T Bracket<T>([NotNull, InstantHandle] Func<T> opening, [NotNull] Action closing) => Definition.Bracket(opening, closing);
+    [PublicAPI] public T Bracket<T>([InstantHandle] Func<T> opening, Action closing) => Definition.Bracket(opening, closing);
     
     /// <summary>
     /// <inheritdoc cref="Bracket(Action, Action)"/>
     /// </summary>
-    [PublicAPI] public T Bracket<T>([NotNull, InstantHandle] Func<T> opening, [NotNull] Action<T> closing) => Definition.Bracket(opening, closing);
+    [PublicAPI] public T Bracket<T>([InstantHandle] Func<T> opening, Action<T> closing) => Definition.Bracket(opening, closing);
     
     
     #endregion
@@ -396,7 +396,7 @@ namespace JetBrains.Lifetimes
     /// </summary>
     /// <param name="action">The code to execute with a temporary lifetime.</param>
     [PublicAPI]
-    public static void Using([NotNull, InstantHandle] Action<Lifetime> action)
+    public static void Using([InstantHandle] Action<Lifetime> action)
     {
       if (action == null) throw new ArgumentNullException(nameof(action));
       
@@ -410,7 +410,7 @@ namespace JetBrains.Lifetimes
     /// </summary>
     /// <param name="action">The code to execute with a temporary lifetime.</param>
     [PublicAPI]
-    public static T Using<T>([NotNull, InstantHandle] Func<Lifetime, T> action)
+    public static T Using<T>([InstantHandle] Func<Lifetime, T> action)
     {
       if (action == null) throw new ArgumentNullException(nameof(action));
       
@@ -427,7 +427,7 @@ namespace JetBrains.Lifetimes
     /// </summary>
     /// <param name="action">The code to execute with a temporary lifetime.</param>
     [PublicAPI]
-    public void UsingNested([NotNull, InstantHandle] Action<Lifetime> action)
+    public void UsingNested([InstantHandle] Action<Lifetime> action)
     {
       if (action == null) throw new ArgumentNullException(nameof(action));
       
@@ -443,7 +443,7 @@ namespace JetBrains.Lifetimes
     /// </summary>
     /// <param name="action">The code to execute with a temporary lifetime.</param>
     [PublicAPI]
-    public T UsingNested<T>([NotNull, InstantHandle] Func<Lifetime, T> action)
+    public T UsingNested<T>([InstantHandle] Func<Lifetime, T> action)
     {
       if (action == null) throw new ArgumentNullException(nameof(action));
       
@@ -460,7 +460,7 @@ namespace JetBrains.Lifetimes
     ///   <para>Analogous to the <c>using</c> statement of the C# language on everything that is added to the lifetime.</para>
     /// </summary>
     /// <param name="action">The code to execute with a temporary lifetime.</param>
-    [PublicAPI] public static async Task UsingAsync([NotNull] [InstantHandle] Func<Lifetime, Task> action)
+    [PublicAPI] public static async Task UsingAsync([InstantHandle] Func<Lifetime, Task> action)
     {
       if(action == null)
         throw new ArgumentNullException(nameof(action));
@@ -474,7 +474,7 @@ namespace JetBrains.Lifetimes
     ///   <para>Analogous to the <c>using</c> statement of the C# language on everything that is added to the lifetime.</para>
     /// </summary>
     /// <param name="action">The code to execute with a temporary lifetime.</param>
-    [PublicAPI] public static async Task<T> UsingAsync<T>([NotNull] [InstantHandle] Func<Lifetime, Task<T>> action)
+    [PublicAPI] public static async Task<T> UsingAsync<T>([InstantHandle] Func<Lifetime, Task<T>> action)
     {
       if(action == null)
         throw new ArgumentNullException(nameof(action));
@@ -489,7 +489,7 @@ namespace JetBrains.Lifetimes
     /// </summary>
     /// <param name="parent">A parent lifetime which limits the lifetime given to your action, and might terminate it before the action ends.</param>
     /// <param name="action">The code to execute with a temporary lifetime.</param>
-    [PublicAPI] public static async Task UsingAsync(OuterLifetime parent, [NotNull] [InstantHandle] Func<Lifetime, Task> action)
+    [PublicAPI] public static async Task UsingAsync(OuterLifetime parent, [InstantHandle] Func<Lifetime, Task> action)
     {
       if(action == null)
         throw new ArgumentNullException(nameof(action));
@@ -507,7 +507,7 @@ namespace JetBrains.Lifetimes
     /// </summary>
     /// <param name="parent">A parent lifetime which limits the lifetime given to your action, and might terminate it before the action ends.</param>
     /// <param name="action">The code to execute with a temporary lifetime.</param>
-    [PublicAPI] public static async Task<T> UsingAsync<T>(OuterLifetime parent, [NotNull] [InstantHandle] Func<Lifetime, Task<T>> action)
+    [PublicAPI] public static async Task<T> UsingAsync<T>(OuterLifetime parent, [InstantHandle] Func<Lifetime, Task<T>> action)
     {
       if(action == null)
         throw new ArgumentNullException(nameof(action));
@@ -525,7 +525,7 @@ namespace JetBrains.Lifetimes
     ///   <para>The parent lifetime which might cause premature termination of our lifetime (and, supposedly, the chain of tasks executed under the lifetime, if started correctly).</para>
     /// </summary>
     /// <param name="action">The code to execute with a temporary lifetime.</param>
-    [PublicAPI] public async Task<TRetVal> UsingNestedAsync<TRetVal>([NotNull] [InstantHandle] Func<Lifetime, Task<TRetVal>> action)
+    [PublicAPI] public async Task<TRetVal> UsingNestedAsync<TRetVal>([InstantHandle] Func<Lifetime, Task<TRetVal>> action)
     {
       if(action == null) throw new ArgumentNullException(nameof(action));
 
@@ -539,7 +539,7 @@ namespace JetBrains.Lifetimes
     ///   <para>The parent lifetime which might cause premature termination of our lifetime (and, supposedly, the chain of tasks executed under the lifetime, if started correctly).</para>
     /// </summary>
     /// <param name="action">The code to execute with a temporary lifetime.</param>
-    public async Task UsingNestedAsync([NotNull] [InstantHandle] Func<Lifetime, Task> action)
+    public async Task UsingNestedAsync([InstantHandle] Func<Lifetime, Task> action)
     {
       if(action == null) throw new ArgumentNullException(nameof(action));
 
@@ -558,15 +558,15 @@ namespace JetBrains.Lifetimes
     /// Same as <see cref="LifetimeDefinition(Lifetime)"/>
     /// </summary>
     /// <returns></returns>
-    [PublicAPI, NotNull]
+    [PublicAPI]
     public LifetimeDefinition CreateNested() => new LifetimeDefinition(this);
         
     /// <summary>
     /// Same as <see cref="LifetimeDefinition(Lifetime, Action{LifetimeDefinition})"/>
     /// </summary>
     /// <returns></returns>
-    [PublicAPI, NotNull]
-    public LifetimeDefinition CreateNested([NotNull, InstantHandle] Action<LifetimeDefinition> atomicAction) => new LifetimeDefinition(this, atomicAction);
+    [PublicAPI]
+    public LifetimeDefinition CreateNested([InstantHandle] Action<LifetimeDefinition> atomicAction) => new LifetimeDefinition(this, atomicAction);
     
     /// <summary>
     /// Keeps object from being garbage collected until this lifetime is terminated.
@@ -576,7 +576,7 @@ namespace JetBrains.Lifetimes
     /// <returns></returns>
     /// <exception cref="ArgumentNullException"></exception>
     [PublicAPI]
-    public Lifetime KeepAlive([NotNull] object @object)
+    public Lifetime KeepAlive(object @object)
     {
       if (@object == null) throw new ArgumentNullException(nameof(@object));      
 
@@ -589,7 +589,7 @@ namespace JetBrains.Lifetimes
     /// </summary>
     /// <param name="disposable"></param>
     /// <returns>The same lifetime (fluent API)</returns>
-    [PublicAPI] public Lifetime AddDispose([NotNull] IDisposable disposable) => OnTermination(disposable);
+    [PublicAPI] public Lifetime AddDispose(IDisposable disposable) => OnTermination(disposable);
     
     #endregion
                
@@ -598,18 +598,18 @@ namespace JetBrains.Lifetimes
     
     // ReSharper disable InconsistentNaming
     [Obsolete("Use `Bracket` method instead")]
-    public Lifetime AddBracket([NotNull, InstantHandle] Action FOpening, [NotNull] Action FClosing) { Bracket(FOpening, FClosing); return this; }
+    public Lifetime AddBracket([InstantHandle] Action FOpening, Action FClosing) { Bracket(FOpening, FClosing); return this; }
     // ReSharper restore InconsistentNaming
 
     [Obsolete("Use `OnTermination()` instead")]
-    public Lifetime AddAction([NotNull] Action action) => OnTermination(action);
+    public Lifetime AddAction(Action action) => OnTermination(action);
 
     [Obsolete("For most cases you need `IsNotAlive` which means lifetime is terminated or soon will be terminated (somebody called Terminate() on this lifetime or its parent)." +
               " If your operation makes sense in Canceling status (but must be stopped when resources termination already began) use Status < Terminating ")]
     public bool IsTerminated => Status >= LifetimeStatus.Terminating;
 
     [Obsolete("Use `KeepAlive() instead`")]
-    public Lifetime AddRef([NotNull] object @object) => KeepAlive(@object);
+    public Lifetime AddRef(object @object) => KeepAlive(@object);
 
     
     /// <summary>
@@ -617,7 +617,7 @@ namespace JetBrains.Lifetimes
     /// Whenever any one is terminated, the other will be terminated also.
     /// </summary>
     [Obsolete("Reconsider your architecture and use Intersect")]
-    public static void Synchronize([NotNull] params LifetimeDefinition[] definitions)
+    public static void Synchronize(params LifetimeDefinition[] definitions)
     {
       if(definitions == null)
         throw new ArgumentNullException(nameof(definitions));
@@ -665,7 +665,7 @@ namespace JetBrains.Lifetimes
     /// <summary>
     /// <inheritdoc cref="Intersect(JetBrains.Lifetimes.Lifetime, Lifetime)"/>
     /// </summary>
-    [PublicAPI] public static Lifetime Intersect([NotNull] params Lifetime[] lifetimes)
+    [PublicAPI] public static Lifetime Intersect(params Lifetime[] lifetimes)
     {
       return DefineIntersection(lifetimes).Lifetime;
     }
@@ -693,8 +693,8 @@ namespace JetBrains.Lifetimes
     /// <summary>
     /// <inheritdoc cref="DefineIntersection(JetBrains.Lifetimes.Lifetime, Lifetime)"/>
     /// </summary>
-    [PublicAPI, NotNull]
-    public static LifetimeDefinition DefineIntersection([NotNull] params Lifetime[] lifetimes)
+    [PublicAPI]
+    public static LifetimeDefinition DefineIntersection(params Lifetime[] lifetimes)
     {
       if (lifetimes == null) throw new ArgumentNullException(nameof(lifetimes));
 
@@ -715,7 +715,7 @@ namespace JetBrains.Lifetimes
     /// <summary>
     /// <inheritdoc cref="LifetimeDefinition.Id"/>
     /// </summary>
-    [PublicAPI, CanBeNull] public object Id
+    [PublicAPI] public object? Id
     {
       get => Definition.Id;
       set => Definition.Id = value;
@@ -765,8 +765,7 @@ namespace JetBrains.Lifetimes
     ///
     /// <remarks>For compatibility reason logic is different than <see cref="LifetimeDefinition(Lifetime, Action{LifetimeDefinition})"/>: in this method
     /// <paramref name="atomicAction"/> is always executed</remarks>
-    [NotNull]
-    public static LifetimeDefinition Define(Lifetime lifetime, [CanBeNull] string id = null, [CanBeNull] [InstantHandle] Action<LifetimeDefinition> atomicAction = null)
+    public static LifetimeDefinition Define(Lifetime lifetime, string? id = null, [InstantHandle] Action<LifetimeDefinition>? atomicAction = null)
     {
       var res = new LifetimeDefinition {Id = id};
       try
@@ -791,7 +790,7 @@ namespace JetBrains.Lifetimes
     /// <param name="lifetime"></param>
     /// <param name="atomicAction"></param>
     /// <returns></returns>
-    public static LifetimeDefinition Define(Lifetime lifetime, [CanBeNull] [InstantHandle] Action<Lifetime> atomicAction) => Define(lifetime, null, atomicAction);
+    public static LifetimeDefinition Define(Lifetime lifetime, [InstantHandle] Action<Lifetime>? atomicAction) => Define(lifetime, null, atomicAction);
 
     /// <summary>
     /// Same as <see cref="Define(Lifetime, string, Action{LifetimeDefinition})"/>
@@ -800,7 +799,7 @@ namespace JetBrains.Lifetimes
     /// <param name="id"></param>
     /// <param name="atomicAction"></param>
     /// <returns></returns>
-    public static LifetimeDefinition Define(Lifetime lifetime, [CanBeNull] string id, [CanBeNull] [InstantHandle] Action<Lifetime> atomicAction)
+    public static LifetimeDefinition Define(Lifetime lifetime, string? id, [InstantHandle] Action<Lifetime>? atomicAction)
     {
       var res = new LifetimeDefinition {Id = id};
       try
@@ -824,9 +823,8 @@ namespace JetBrains.Lifetimes
     /// </summary>
     /// <param name="id"></param>
     /// <returns></returns>
-    [NotNull]
     [Pure]
-    public static LifetimeDefinition Define([CanBeNull] string id = null) => new LifetimeDefinition {Id = id};
+    public static LifetimeDefinition Define(string? id = null) => new LifetimeDefinition {Id = id};
     
     #endregion
     
@@ -844,7 +842,7 @@ namespace JetBrains.Lifetimes
     /// </summary>
     /// <param name="closure"></param>
     /// <returns></returns>
-    [PublicAPI, NotNull] public Task ExecuteAsync([NotNull] Func<Task> closure) { using (UsingAsyncLocal()) return Definition.ExecuteAsync(closure); }
+    [PublicAPI] public Task ExecuteAsync(Func<Task> closure) { using (UsingAsyncLocal()) return Definition.ExecuteAsync(closure); }
     
     /// <summary>
     /// <inheritdoc cref="ExecuteAsync"/>
@@ -852,7 +850,7 @@ namespace JetBrains.Lifetimes
     /// <param name="closure"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    [PublicAPI, NotNull] public Task<T> ExecuteAsync<T>([NotNull] Func<Task<T>> closure)  { using (UsingAsyncLocal()) return Definition.ExecuteAsync(closure); }
+    [PublicAPI] public Task<T> ExecuteAsync<T>(Func<Task<T>> closure)  { using (UsingAsyncLocal()) return Definition.ExecuteAsync(closure); }
 
     /// <summary>
     /// Do the same as <see cref="TryExecute{T}"/> but also (if <see cref="IsAlive"/>) suppress lifetime termination until task returned by <paramref name="closure"/>
@@ -861,7 +859,7 @@ namespace JetBrains.Lifetimes
     /// <param name="closure"></param>
     /// <param name="wrapExceptions"></param>
     /// <returns></returns>
-    [PublicAPI, NotNull] public Task TryExecuteAsync([NotNull] Func<Task> closure, bool wrapExceptions = false) => Definition.TryExecuteAsync(closure, wrapExceptions);
+    [PublicAPI] public Task TryExecuteAsync(Func<Task> closure, bool wrapExceptions = false) => Definition.TryExecuteAsync(closure, wrapExceptions);
     
     /// <summary>
     /// <inheritdoc cref="ExecuteAsync"/>
@@ -869,7 +867,7 @@ namespace JetBrains.Lifetimes
     /// <param name="closure"></param>
     /// <param name="wrapExceptions"></param>
     /// <returns></returns>
-    [PublicAPI, NotNull] public Task<T> TryExecuteAsync<T>([NotNull] Func<Task<T>> closure, bool wrapExceptions = false) => Definition.TryExecuteAsync(closure, wrapExceptions);
+    [PublicAPI] public Task<T> TryExecuteAsync<T>(Func<Task<T>> closure, bool wrapExceptions = false) => Definition.TryExecuteAsync(closure, wrapExceptions);
     
     
     /// <summary>
@@ -879,7 +877,7 @@ namespace JetBrains.Lifetimes
     /// <param name="action"></param>
     /// <param name="options"></param>
     /// <returns></returns>
-    [PublicAPI, NotNull] public Task Start(TaskScheduler scheduler, Action action, TaskCreationOptions options = TaskCreationOptions.None) { using (UsingAsyncLocal()) return Task.Factory.StartNew(action, this, options, scheduler); }
+    [PublicAPI] public Task Start(TaskScheduler scheduler, Action action, TaskCreationOptions options = TaskCreationOptions.None) { using (UsingAsyncLocal()) return Task.Factory.StartNew(action, this, options, scheduler); }
     
     /// <summary>
     /// <inheritdoc cref="Start"/>
@@ -889,7 +887,7 @@ namespace JetBrains.Lifetimes
     /// <param name="options"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    [PublicAPI, NotNull] public Task<T> Start<T>(TaskScheduler scheduler, Func<T> action, TaskCreationOptions options = TaskCreationOptions.None) { using (UsingAsyncLocal()) return Task.Factory.StartNew(action, this, options, scheduler); }
+    [PublicAPI] public Task<T> Start<T>(TaskScheduler scheduler, Func<T> action, TaskCreationOptions options = TaskCreationOptions.None) { using (UsingAsyncLocal()) return Task.Factory.StartNew(action, this, options, scheduler); }
     
     /// <summary>
     /// <inheritdoc cref="Start"/>
@@ -898,7 +896,7 @@ namespace JetBrains.Lifetimes
     /// <param name="action"></param>
     /// <param name="options"></param>
     /// <returns></returns>
-    [PublicAPI, NotNull] public Task StartAsync(TaskScheduler scheduler, Func<Task> action, TaskCreationOptions options = TaskCreationOptions.None) { using (UsingAsyncLocal()) return Task.Factory.StartNew(action, this, options, scheduler).Unwrap(); }
+    [PublicAPI] public Task StartAsync(TaskScheduler scheduler, Func<Task> action, TaskCreationOptions options = TaskCreationOptions.None) { using (UsingAsyncLocal()) return Task.Factory.StartNew(action, this, options, scheduler).Unwrap(); }
     
     /// <summary>
     /// <inheritdoc cref="Start"/>
@@ -908,7 +906,7 @@ namespace JetBrains.Lifetimes
     /// <param name="options"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    [PublicAPI, NotNull] public Task<T> StartAsync<T>(TaskScheduler scheduler, Func<Task<T>> action, TaskCreationOptions options = TaskCreationOptions.None) { using (UsingAsyncLocal()) return Task.Factory.StartNew(action, this, options, scheduler).Unwrap(); }
+    [PublicAPI] public Task<T> StartAsync<T>(TaskScheduler scheduler, Func<Task<T>> action, TaskCreationOptions options = TaskCreationOptions.None) { using (UsingAsyncLocal()) return Task.Factory.StartNew(action, this, options, scheduler).Unwrap(); }
 
 
     /// <summary>
@@ -919,7 +917,7 @@ namespace JetBrains.Lifetimes
     /// <param name="action"></param>
     /// <param name="options"></param>
     /// <returns></returns>
-    [PublicAPI, NotNull] public Task StartAttached(TaskScheduler scheduler, Action action, TaskCreationOptions options = TaskCreationOptions.None) => Definition.Attached(Start(scheduler, action, options));
+    [PublicAPI] public Task StartAttached(TaskScheduler scheduler, Action action, TaskCreationOptions options = TaskCreationOptions.None) => Definition.Attached(Start(scheduler, action, options));
     
     /// <summary>
     /// <inheritdoc cref="StartAttached"/>
@@ -929,7 +927,7 @@ namespace JetBrains.Lifetimes
     /// <param name="options"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    [PublicAPI, NotNull] public Task<T> StartAttached<T>(TaskScheduler scheduler, Func<T> action, TaskCreationOptions options = TaskCreationOptions.None) => Definition.Attached(Start(scheduler, action, options));
+    [PublicAPI] public Task<T> StartAttached<T>(TaskScheduler scheduler, Func<T> action, TaskCreationOptions options = TaskCreationOptions.None) => Definition.Attached(Start(scheduler, action, options));
     
     /// <summary>
     /// <inheritdoc cref="StartAttached"/>
@@ -938,7 +936,7 @@ namespace JetBrains.Lifetimes
     /// <param name="action"></param>
     /// <param name="options"></param>
     /// <returns></returns>
-    [PublicAPI, NotNull] public Task StartAttachedAsync(TaskScheduler scheduler, Func<Task> action, TaskCreationOptions options = TaskCreationOptions.None) => Definition.Attached(StartAsync(scheduler, action, options));
+    [PublicAPI] public Task StartAttachedAsync(TaskScheduler scheduler, Func<Task> action, TaskCreationOptions options = TaskCreationOptions.None) => Definition.Attached(StartAsync(scheduler, action, options));
     
     /// <summary>
     /// <inheritdoc cref="StartAttached"/>
@@ -948,7 +946,7 @@ namespace JetBrains.Lifetimes
     /// <param name="options"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    [PublicAPI, NotNull] public Task<T> StartAttachedAsync<T>(TaskScheduler scheduler, Func<Task<T>> action, TaskCreationOptions options = TaskCreationOptions.None) => Definition.Attached(StartAsync(scheduler, action, options));
+    [PublicAPI] public Task<T> StartAttachedAsync<T>(TaskScheduler scheduler, Func<Task<T>> action, TaskCreationOptions options = TaskCreationOptions.None) => Definition.Attached(StartAsync(scheduler, action, options));
 
 
 
@@ -958,7 +956,7 @@ namespace JetBrains.Lifetimes
     /// <param name="options">to pass into <see cref="TaskCompletionSource{TResult}.ctor"/></param>
     /// <typeparam name="T"></typeparam>
     /// <returns>New <see cref="TaskCompletionSource{TResult}"/>. Possibly with already canceled <see cref="TaskCompletionSource{TResult}.Task"/> if this lifetime already terminated</returns>
-    [PublicAPI, NotNull] public TaskCompletionSource<T> CreateTaskCompletionSource<T>(TaskCreationOptions options = TaskCreationOptions.None)
+    [PublicAPI] public TaskCompletionSource<T> CreateTaskCompletionSource<T>(TaskCreationOptions options = TaskCreationOptions.None)
     {
       var res = new TaskCompletionSource<T>(options);
       
@@ -973,7 +971,7 @@ namespace JetBrains.Lifetimes
     /// </summary>
     /// <param name="timeSpan">Terminate lifetime after this amount of time</param>
     /// <param name="terminationScheduler">Scheduler where termination will be invoked (if none specified, termination will start in timer's thread)</param>
-    [PublicAPI] public Lifetime CreateTerminatedAfter(TimeSpan timeSpan, TaskScheduler terminationScheduler = null)
+    [PublicAPI] public Lifetime CreateTerminatedAfter(TimeSpan timeSpan, TaskScheduler? terminationScheduler = null)
     {
       var def = new LifetimeDefinition(this);
       Task.Delay(timeSpan, this).ContinueWith(
@@ -1008,7 +1006,7 @@ namespace JetBrains.Lifetimes
       return ReferenceEquals(Definition, other.Definition);
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
       if (ReferenceEquals(null, obj)) return false;
       return obj is Lifetime other && Equals(other);
@@ -1060,7 +1058,7 @@ namespace JetBrains.Lifetimes
     /// <remarks>
     /// <para>As this method operates on a <see cref="Lifetime"/> object you do not own, it cannot terminate the lifetime automatically when a missed termination is detected.</para>
     /// </remarks>
-    public Lifetime AssertEverTerminated(string comment = null)
+    public Lifetime AssertEverTerminated(string? comment = null)
     {
       Definition.AssertEverTerminated(comment);
       return this;
@@ -1072,7 +1070,7 @@ namespace JetBrains.Lifetimes
     /// </summary>
     /// <param name="timeout">Maximum timeout to wait this lifetime is terminated</param>
     /// <param name="comment">Optional comment to log when assertion failed</param>
-    public async void AssertTerminatesIn(TimeSpan timeout, string comment = null)
+    public async void AssertTerminatesIn(TimeSpan timeout, string? comment = null)
     {
       try
       {

--- a/rd-net/Lifetimes/Lifetimes/Lifetimed.cs
+++ b/rd-net/Lifetimes/Lifetimes/Lifetimed.cs
@@ -1,4 +1,3 @@
-using System;
 using JetBrains.Annotations;
 
 namespace JetBrains.Lifetimes
@@ -11,14 +10,14 @@ namespace JetBrains.Lifetimes
   /// <typeparam name="T"></typeparam>
   public class Lifetimed<T> : ITerminationHandler
   {
-    [PublicAPI] public void Deconstruct(out Lifetime lifetime, out T value)
+    [PublicAPI] public void Deconstruct(out Lifetime lifetime, out T? value)
     {
       lifetime = Lifetime;
       value = Value;
     }
 
     public Lifetime Lifetime { get; }
-    public T Value { get; private set; }
+    public T? Value { get; private set; }
 
     public Lifetimed(Lifetime lifetime, T value)
     {

--- a/rd-net/Lifetimes/Lifetimes/OuterLifetime.cs
+++ b/rd-net/Lifetimes/Lifetimes/OuterLifetime.cs
@@ -81,7 +81,7 @@ namespace JetBrains.Lifetimes
     ///   <para>The parent lifetime which might cause premature termination of our lifetime (and, supposedly, the chain of tasks executed under the lifetime, if started correctly).</para>
     /// </summary>
     /// <param name="action">The code to execute with a temporary lifetime.</param>
-    public Task<TRetVal> UsingNestedAsync<TRetVal>([NotNull] [InstantHandle] Func<Lifetime, Task<TRetVal>> action) => myLifetime.UsingNestedAsync(action);
+    public Task<TRetVal> UsingNestedAsync<TRetVal>([InstantHandle] Func<Lifetime, Task<TRetVal>> action) => myLifetime.UsingNestedAsync(action);
 
     /// <summary>
     ///   <para>Scopes your code in <paramref name="action" /> with a lifetime that is terminated automatically when <paramref name="action" /> completes execution, or when its execution is aborted by an exception.</para>
@@ -89,15 +89,14 @@ namespace JetBrains.Lifetimes
     ///   <para>The parent lifetime which might cause premature termination of our lifetime (and, supposedly, the chain of tasks executed under the lifetime, if started correctly).</para>
     /// </summary>
     /// <param name="action">The code to execute with a temporary lifetime.</param>
-    public Task UsingNestedAsync([NotNull] [InstantHandle] Func<Lifetime, Task> action) => myLifetime.UsingNestedAsync(action);
+    public Task UsingNestedAsync([InstantHandle] Func<Lifetime, Task> action) => myLifetime.UsingNestedAsync(action);
     
     internal LifetimeDefinition Def => myLifetime.Definition;
 
     /// <summary>
     ///   <para>See documentation on an overload which takes a <see cref="Lifetime" />.</para>
     /// </summary>
-    [NotNull]
-    public static LifetimeDefinition Define(OuterLifetime lifetime, [CanBeNull] string id = null, [CanBeNull] [InstantHandle] Action<LifetimeDefinition, Lifetime> atomicAction = null)
+    public static LifetimeDefinition Define(OuterLifetime lifetime, string? id = null, [InstantHandle] Action<LifetimeDefinition, Lifetime>? atomicAction = null)
     {
       lifetime.AssertNotNull();
 
@@ -129,8 +128,8 @@ namespace JetBrains.Lifetimes
     /// <summary>
     /// Creates an intersection of some lifetimes — a lifetime to terminate when either one terminates.
     /// </summary>
-    [PublicAPI, NotNull]
-    public static LifetimeDefinition DefineIntersection([NotNull] params OuterLifetime[] lifetimes)
+    [PublicAPI]
+    public static LifetimeDefinition DefineIntersection(params OuterLifetime[] lifetimes)
     {
       var res = new LifetimeDefinition();
       foreach (var lf in lifetimes)

--- a/rd-net/Lifetimes/Lifetimes/SequentialLifetimes.cs
+++ b/rd-net/Lifetimes/Lifetimes/SequentialLifetimes.cs
@@ -13,7 +13,7 @@ namespace JetBrains.Lifetimes
   public class SequentialLifetimes
   {
     private readonly Lifetime myParentLifetime;
-    [NotNull] private LifetimeDefinition myCurrentDef = LifetimeDefinition.Terminated;
+    private LifetimeDefinition myCurrentDef = LifetimeDefinition.Terminated;
 
     /// <summary>Creates and binds to the lifetime.</summary>
     /// <param name="lifetime">When this lifetime is closed, the last of the sequential lifetimes is closed too.</param>
@@ -37,7 +37,7 @@ namespace JetBrains.Lifetimes
     /// Terminates the current lifetime, calls your handler with the new lifetime and tries to set it as current.
     /// Similar to <see cref="DefineNext"/>
     /// </summary>
-    public void Next([NotNull] Action<Lifetime> atomicAction)
+    public void Next(Action<Lifetime> atomicAction)
     {
       if (atomicAction == null) throw new ArgumentNullException(nameof(atomicAction));
       DefineNext(lifetimeDefinition => atomicAction(lifetimeDefinition.Lifetime));
@@ -47,7 +47,7 @@ namespace JetBrains.Lifetimes
     /// Terminates the current lifetime, calls your handler with the new lifetime and tries to set it as current.
     /// Similar to <see cref="Next(System.Action{JetBrains.Lifetimes.Lifetime})"/>
     /// </summary>
-    public void DefineNext([NotNull] Action<LifetimeDefinition> atomicAction)
+    public void DefineNext(Action<LifetimeDefinition> atomicAction)
     {
       if (atomicAction == null) throw new ArgumentNullException(nameof(atomicAction));
       
@@ -81,7 +81,7 @@ namespace JetBrains.Lifetimes
     /// <param name="newLifetimeDefinition">New lifetime definition to set</param>
     /// <param name="actionWithNewLifetime">Action to perform once new lifetime is set</param>
     /// <returns>New lifetime definition which can be terminated in case of a race condition</returns>
-    private LifetimeDefinition TrySetNewAndTerminateOld(LifetimeDefinition newLifetimeDefinition, [CanBeNull] Action<LifetimeDefinition> actionWithNewLifetime = null)
+    private LifetimeDefinition TrySetNewAndTerminateOld(LifetimeDefinition newLifetimeDefinition, Action<LifetimeDefinition>? actionWithNewLifetime = null)
     {
       void TerminateLifetimeDefinition(LifetimeDefinition lifetimeDefinition)
       {

--- a/rd-net/Lifetimes/Lifetimes/ValueLifetimed.cs
+++ b/rd-net/Lifetimes/Lifetimes/ValueLifetimed.cs
@@ -6,14 +6,14 @@ namespace JetBrains.Lifetimes
   /// <typeparam name="T"></typeparam>
   public struct ValueLifetimed<T>
   {
-    public void Deconstruct(out Lifetime lifetime, out T value)
+    public void Deconstruct(out Lifetime lifetime, out T? value)
     {
       lifetime = Lifetime;
       value = Value;
     }
 
     public Lifetime Lifetime { get; }
-    public T Value { get; private set; }
+    public T? Value { get; private set; }
 
     public ValueLifetimed(Lifetime lifetime, T value)
     {

--- a/rd-net/Lifetimes/Serialization/UnsafeReader.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeReader.cs
@@ -261,9 +261,8 @@ namespace JetBrains.Serialization
       return new Uri(Uri.UnescapeDataString(ReadString()), UriKind.RelativeOrAbsolute);
     }
 
-    [CanBeNull]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public string ReadString()
+    public string? ReadString()
     {
       int len = ReadInt32();
 
@@ -297,9 +296,8 @@ namespace JetBrains.Serialization
       }
     }
 
-    [CanBeNull]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public string ReadStringInterned(IRawStringIntern intern)
+    public string? ReadStringInterned(IRawStringIntern intern)
     {
       int len = ReadInt32();
 
@@ -337,11 +335,11 @@ namespace JetBrains.Serialization
     public static readonly ReadDelegate<UInt64> UInt64Delegate = reader => reader.ReadUInt64();
     public static readonly ReadDelegate<DateTime> DateTimeDelegate = reader => reader.ReadDateTime();
     public static readonly ReadDelegate<Uri> UriDelegate = reader => reader.ReadUri();
-    public static readonly ReadDelegate<string> StringDelegate = reader => reader.ReadString();
-    public static readonly ReadDelegate<byte[]> ByteArrayDelegate = reader => reader.ReadByteArray();
-    public static readonly ReadDelegate<bool[]> BoolArrayDelegate = reader => reader.ReadArray(BooleanDelegate);
-    public static readonly ReadDelegate<int[]> IntArrayDelegate = reader => reader.ReadIntArray();
-    public static readonly ReadDelegate<string[]> StringArrayDelegate = reader => reader.ReadArray(StringDelegate);
+    public static readonly ReadDelegate<string?> StringDelegate = reader => reader.ReadString();
+    public static readonly ReadDelegate<byte[]?> ByteArrayDelegate = reader => reader.ReadByteArray();
+    public static readonly ReadDelegate<bool[]?> BoolArrayDelegate = reader => reader.ReadArray(BooleanDelegate);
+    public static readonly ReadDelegate<int[]?> IntArrayDelegate = reader => reader.ReadIntArray();
+    public static readonly ReadDelegate<string?[]?> StringArrayDelegate = reader => reader.ReadArray(StringDelegate);
 
     #endregion
 
@@ -349,19 +347,19 @@ namespace JetBrains.Serialization
     #region Collection readers
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public T[] ReadArray<T>(ReadDelegate<T> readDelegate)
+    public T?[]? ReadArray<T>(ReadDelegate<T?> readDelegate)
     {
       int len = ReadInt32();
       if (len < 0) return null;
       if (len == 0) return EmptyArray<T>.Instance;
 
-      var res = new T[len];
+      var res = new T?[len];
       for (int i = 0; i < len; i++) res[i] = readDelegate(this);
       return res;
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public int[] ReadIntArray()
+    public int[]? ReadIntArray()
     {
       int len = ReadInt32();
       if (len < 0) return null;
@@ -377,7 +375,7 @@ namespace JetBrains.Serialization
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public byte[] ReadByteArray()
+    public byte[]? ReadByteArray()
     {
       int len = ReadInt32();
       if (len < 0) return null;
@@ -401,7 +399,7 @@ namespace JetBrains.Serialization
     /// <param name="constructor"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public TCol ReadCollection<T, TCol>(ReadDelegate<T> readDelegate, Func<int, TCol> constructor) where TCol : ICollection<T>
+    public TCol? ReadCollection<T, TCol>(ReadDelegate<T> readDelegate, Func<int, TCol> constructor) where TCol : ICollection<T>
     {
       int count = ReadInt32();
       if (count < 0) return default(TCol);
@@ -415,7 +413,7 @@ namespace JetBrains.Serialization
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public TDict ReadDictionary<TK, TV, TDict>(ReadDelegate<TK> readKeyDelegate, ReadDelegate<TV> readValueDelegate,
+    public TDict? ReadDictionary<TK, TV, TDict>(ReadDelegate<TK> readKeyDelegate, ReadDelegate<TV> readValueDelegate,
       Func<int, TDict> constructor) where TDict : IDictionary<TK, TV>
     {
       int count = ReadInt32();

--- a/rd-net/Lifetimes/Threading/Actor.cs
+++ b/rd-net/Lifetimes/Threading/Actor.cs
@@ -27,7 +27,7 @@ namespace JetBrains.Threading
     private readonly ILog myLog;
 
 
-    private readonly AsyncLocal<Unit> myInsideProcessingFlow = new AsyncLocal<Unit>(); 
+    private readonly AsyncLocal<Unit?> myInsideProcessingFlow = new(); 
 
     private long myTotalMessagesProcessed;
 
@@ -69,7 +69,7 @@ namespace JetBrains.Threading
     /// <param name="processor">handler of messages</param>
     /// <param name="scheduler"><paramref name="processor"/>'s body scheduler</param>
     /// <param name="maxQueueSize">upper bound for channel after that <see cref="SendBlocking"/> will block</param>
-    public Actor(string id, Lifetime lifetime, Action<T> processor, TaskScheduler scheduler = null,
+    public Actor(string id, Lifetime lifetime, Action<T> processor, TaskScheduler? scheduler = null,
       int maxQueueSize = int.MaxValue) :
       this(id, lifetime, async item => processor(item), scheduler, maxQueueSize) {}
     
@@ -82,7 +82,7 @@ namespace JetBrains.Threading
     /// <param name="scheduler"></param>
     /// <param name="maxQueueSize"></param>
     //todo move lifetime into Send
-    public Actor(string id, Lifetime lifetime, Func<T, Task> processor, TaskScheduler scheduler = null, int maxQueueSize = int.MaxValue)
+    public Actor(string id, Lifetime lifetime, Func<T, Task> processor, TaskScheduler? scheduler = null, int maxQueueSize = int.MaxValue)
     {
       Id = id;
       myProcessor = processor;

--- a/rd-net/Lifetimes/Threading/ByteBufferAsyncProcessor.cs
+++ b/rd-net/Lifetimes/Threading/ByteBufferAsyncProcessor.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using JetBrains.Diagnostics;
 using JetBrains.Serialization;
 using JetBrains.Util.Internal;
+#nullable disable
 
 namespace JetBrains.Threading
 {

--- a/rd-net/Lifetimes/Threading/Channel.cs
+++ b/rd-net/Lifetimes/Threading/Channel.cs
@@ -61,7 +61,7 @@ namespace JetBrains.Threading
 
     void SetCanceledIsolated<TResult>(TaskCompletionSource<TResult> tcs) { try { tcs.SetCanceled(); } catch (Exception e) { Log.Root.Error(e);}}
     
-    public AsyncChannel([NotNull] Lifetime lifetime, int sendBufferSize = Int32.MaxValue)
+    public AsyncChannel(Lifetime lifetime, int sendBufferSize = Int32.MaxValue)
     {
       
       myLifetime = lifetime;

--- a/rd-net/Lifetimes/Threading/Channel.cs
+++ b/rd-net/Lifetimes/Threading/Channel.cs
@@ -142,7 +142,7 @@ namespace JetBrains.Threading
     }
         
 
-    [PublicAPI, NotNull]
+    [PublicAPI]
     public Task<T> ReceiveAsync()
     {      
       lock (myLock)

--- a/rd-net/Lifetimes/Threading/ExceptionEx.cs
+++ b/rd-net/Lifetimes/Threading/ExceptionEx.cs
@@ -12,7 +12,7 @@ namespace JetBrains.Threading
         /// </summary>
         /// <param name="exception">exception to test or null</param>
         /// <returns>if <paramref name="exception"/> is null, returns false. Otherwise tries to run algorithm from the summary.</returns>
-        [PublicAPI] public static bool IsOperationCanceled([CanBeNull] this Exception exception)
+        [PublicAPI] public static bool IsOperationCanceled(this Exception? exception)
         {
             switch (exception)
             {

--- a/rd-net/Lifetimes/Threading/ProactiveLazy.cs
+++ b/rd-net/Lifetimes/Threading/ProactiveLazy.cs
@@ -12,9 +12,9 @@ namespace JetBrains.Threading
     /// <typeparam name="T"></typeparam>
     public class ProactiveLazy<T>
     {
-        [NotNull] private readonly Task<T> myTask; //todo Not very footprint-friendly. Need to clear task after execution.
+        private readonly Task<T> myTask; //todo Not very footprint-friendly. Need to clear task after execution.
 
-        public ProactiveLazy(Lifetime lifetime, Func<T> factory, TaskScheduler taskScheduler = null)
+        public ProactiveLazy(Lifetime lifetime, Func<T> factory, TaskScheduler? taskScheduler = null)
         {
             myTask = Task.Factory.StartNew(factory, lifetime, TaskCreationOptions.None, taskScheduler ?? TaskScheduler.Default);
         }

--- a/rd-net/Lifetimes/Threading/TaskEx.cs
+++ b/rd-net/Lifetimes/Threading/TaskEx.cs
@@ -15,7 +15,7 @@ namespace JetBrains.Threading
         ///   <para>The task is let to run, its return value (if any) is abandoned, its exceptions are consumed by our logger.</para>
         ///   <para>Prevents Compiler Warning (level 1) CS4014 “Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.”</para>
         /// </summary>
-        [PublicAPI] public static void NoAwait([CanBeNull] this Task task)
+        [PublicAPI] public static void NoAwait(this Task? task)
         {
             task?.ContinueWith
             (t =>
@@ -33,7 +33,7 @@ namespace JetBrains.Threading
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
-        [PublicAPI] public static IReadonlyProperty<Result<T>> ToResultProperty<T>([NotNull] this Task<T> task)
+        [PublicAPI] public static IReadonlyProperty<Result<T>> ToResultProperty<T>(this Task<T> task)
         {
             if (task == null) throw new ArgumentNullException(nameof(task));
 
@@ -54,7 +54,7 @@ namespace JetBrains.Threading
         /// <param name="lifetime">Cancellation token for </param>
         /// <typeparam name="T"></typeparam>
         /// <returns><see cref="Task.Result"/> of <paramref name="task"/></returns>
-        public static T GetOrWait<T>([NotNull] this Task<T> task, Lifetime lifetime)
+        public static T GetOrWait<T>(this Task<T> task, Lifetime lifetime)
         {
             task.Wait(lifetime);
             return task.Result;
@@ -67,7 +67,7 @@ namespace JetBrains.Threading
         /// </summary>
         /// <param name="task"></param>
         /// <returns>true only if task finished and resulting exception matches <see cref="ExceptionEx.IsOperationCanceled"/></returns>
-        public static bool IsOperationCanceled([NotNull] this Task task)
+        public static bool IsOperationCanceled(this Task task)
         {
           return task.IsCanceled || task.Exception.IsOperationCanceled();
         }
@@ -83,7 +83,7 @@ namespace JetBrains.Threading
         /// <typeparam name="TDst">destination type</typeparam>
         /// <returns>new task that is considered completed right after original task completes</returns>
         /// <exception cref="ArgumentNullException"></exception>
-        [PublicAPI] public static async Task<TDst> Select<TSrc, TDst>([NotNull] this Task<TSrc> task, Func<TSrc, TDst> selector)
+        [PublicAPI] public static async Task<TDst> Select<TSrc, TDst>(this Task<TSrc> task, Func<TSrc, TDst> selector)
         {
           if (task == null) 
             throw new ArgumentNullException(nameof(task));

--- a/rd-net/Lifetimes/Threading/ThreadEx.cs
+++ b/rd-net/Lifetimes/Threading/ThreadEx.cs
@@ -5,7 +5,7 @@ namespace JetBrains.Threading
 {
   public static class ThreadEx
   {
-    public static string ToThreadString([CanBeNull] this Thread thread)
+    public static string ToThreadString(this Thread? thread)
     {
       return thread == null ? "<NULL>" : $"{thread.Name ?? ""}:{thread.ManagedThreadId}";
     }

--- a/rd-net/Lifetimes/Util/BitSlice.cs
+++ b/rd-net/Lifetimes/Util/BitSlice.cs
@@ -76,19 +76,19 @@ namespace JetBrains.Util.Util
 
     #region Static API
 
-    private static int NextSliceLoBit([CanBeNull] BitSlice slice) => slice?.HiBit + 1 ?? 0; 
+    private static int NextSliceLoBit(BitSlice? slice) => slice?.HiBit + 1 ?? 0; 
     
-    public static IntBitSlice Int(int bitCount, [CanBeNull] BitSlice previousSlice = null)
+    public static IntBitSlice Int(int bitCount, BitSlice? previousSlice = null)
     {
       return new IntBitSlice(NextSliceLoBit(previousSlice), bitCount);
     }
 
-    public static BoolBitSlice Bool([CanBeNull] BitSlice previousSlice = null)
+    public static BoolBitSlice Bool(BitSlice? previousSlice = null)
     {
       return new BoolBitSlice(NextSliceLoBit(previousSlice), 1);
     }
     
-    public static Enum32BitSlice<T> Enum<T>([CanBeNull] BitSlice previousSlice = null) where T  :
+    public static Enum32BitSlice<T> Enum<T>(BitSlice? previousSlice = null) where T  :
 #if !NET35
     unmanaged, 
 #endif

--- a/rd-net/Lifetimes/Util/ReflectionUtil.cs
+++ b/rd-net/Lifetimes/Util/ReflectionUtil.cs
@@ -22,8 +22,7 @@ namespace JetBrains.Util
     /// <summary>
     /// Return setter for either field or property info
     /// </summary>
-    [NotNull]
-    public static SetValueDelegate GetSetter([NotNull] MemberInfo mi)
+    public static SetValueDelegate GetSetter(MemberInfo mi)
     {
       return TryGetSetter(mi) ?? throw new ArgumentOutOfRangeException($"Entity: {mi} is not supported");
     }
@@ -31,8 +30,7 @@ namespace JetBrains.Util
     /// <summary>
     /// Return setter for either field or property info, or null if can't be set.
     /// </summary>
-    [CanBeNull]
-    public static SetValueDelegate TryGetSetter(MemberInfo mi)
+    public static SetValueDelegate? TryGetSetter(MemberInfo mi)
     {
       SetValueDelegate GetFieldSetter(FieldInfo backingField)
       {
@@ -64,8 +62,7 @@ namespace JetBrains.Util
     /// <summary>
     /// Return getter for either field or property
     /// </summary>
-    [NotNull]
-    public static Func<object, object> GetGetter([NotNull] MemberInfo mi)
+    public static Func<object, object?> GetGetter(MemberInfo mi)
     {
       switch (mi)
       {
@@ -81,8 +78,7 @@ namespace JetBrains.Util
     /// <summary>
     /// Get field or property type.
     /// </summary>
-    [NotNull]
-    public static Type GetReturnType([NotNull] MemberInfo mi)
+    public static Type GetReturnType(MemberInfo mi)
     {
       switch (mi)
       {
@@ -95,8 +91,7 @@ namespace JetBrains.Util
       }
     }
 
-    [CanBeNull]
-    public static object InvokeGenericThis(object self, string methodName, Type argument, [CanBeNull] object[] parameters = null)
+    public static object? InvokeGenericThis(object self, string methodName, Type argument, object?[]? parameters = null)
     {
       var methodInfo = self.GetType().OptionalTypeInfo().GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
       try
@@ -113,8 +108,7 @@ namespace JetBrains.Util
       }
     }
 
-    [CanBeNull]
-    public static object InvokeStaticGeneric(Type type, string methodName, Type argument, [CanBeNull] params object[] parameters)
+    public static object? InvokeStaticGeneric(Type type, string methodName, Type argument, params object?[]? parameters)
     {
       var methodInfo = type.OptionalTypeInfo().GetMethod(methodName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
       try
@@ -131,8 +125,7 @@ namespace JetBrains.Util
       }
     }
 
-    [CanBeNull]
-    public static object InvokeStaticGeneric2(Type type, string methodName, Type argument1, Type argument2, [CanBeNull] params object[] parameters)
+    public static object? InvokeStaticGeneric2(Type type, string methodName, Type argument1, Type argument2, params object?[]? parameters)
     {
       var methodInfo = type.OptionalTypeInfo().GetMethod(methodName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
       try
@@ -150,8 +143,7 @@ namespace JetBrains.Util
     }
 
 
-    [CanBeNull]
-    public static object TryGetNonStaticField(object ownerObject, string memberName)
+    public static object? TryGetNonStaticField(object ownerObject, string memberName)
     {
       try
       {
@@ -164,8 +156,7 @@ namespace JetBrains.Util
       }
     }
     
-    [CanBeNull]
-    public static object TryGetNonStaticProperty(object ownerObject, string memberName)
+    public static object? TryGetNonStaticProperty(object ownerObject, string memberName)
     {
       try
       {
@@ -194,9 +185,9 @@ namespace JetBrains.Util
     /// <param name="defaultValue">Default value to return if failed</param>
     /// <typeparam name="T">Expected return type</typeparam>
     /// <returns>Evaluated property value or default value</returns>
-    public static T GetPropertyValueSafe<T>([NotNull] this object o, string propertyName, T defaultValue = default(T))
+    public static T? GetPropertyValueSafe<T>(this object o, string propertyName, T? defaultValue = default(T))
     {
-      T result = defaultValue;
+      T? result = defaultValue;
       try
       {
         var type = o.GetType();

--- a/rd-net/Lifetimes/Util/ReflectionUtil.cs
+++ b/rd-net/Lifetimes/Util/ReflectionUtil.cs
@@ -62,7 +62,7 @@ namespace JetBrains.Util
     /// <summary>
     /// Return getter for either field or property
     /// </summary>
-    public static Func<object, object?> GetGetter([NotNull] MemberInfo mi)
+    public static Func<object, object?> GetGetter(MemberInfo mi)
     {
       switch (mi)
       {

--- a/rd-net/Lifetimes/Util/ReflectionUtil.cs
+++ b/rd-net/Lifetimes/Util/ReflectionUtil.cs
@@ -17,7 +17,7 @@ namespace JetBrains.Util
 {
   public static class ReflectionUtil
   {
-    public delegate void SetValueDelegate(object instance, object value);
+    public delegate void SetValueDelegate(object instance, object? value);
 
     /// <summary>
     /// Return setter for either field or property info
@@ -62,7 +62,7 @@ namespace JetBrains.Util
     /// <summary>
     /// Return getter for either field or property
     /// </summary>
-    public static Func<object, object?> GetGetter(MemberInfo mi)
+    public static Func<object, object?> GetGetter([NotNull] MemberInfo mi)
     {
       switch (mi)
       {

--- a/rd-net/Lifetimes/Util/RuntimeInfo.cs
+++ b/rd-net/Lifetimes/Util/RuntimeInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JetBrains.Annotations;
 
@@ -6,8 +7,7 @@ namespace JetBrains.Util
 {
   public static class RuntimeInfo
   {
-    [CanBeNull]
-    public static Version CurrentMonoVersion;
+    public static Version? CurrentMonoVersion;
     public static readonly bool IsRunningOnMono; 
     public static readonly bool IsRunningUnderWindows;
     public static readonly bool IsRunningOnCore;
@@ -50,7 +50,7 @@ namespace JetBrains.Util
     }
 
 #if NET35
-    private static bool TryParseVersion(string input, out Version version)
+    private static bool TryParseVersion(string input, [MaybeNullWhen(false)] out Version version)
     {
       if (string.IsNullOrEmpty(input))
       {

--- a/rd-net/Lifetimes/Util/Statics.cs
+++ b/rd-net/Lifetimes/Util/Statics.cs
@@ -11,7 +11,7 @@ namespace JetBrains.Util.Util
   public class StaticsForType<T> where T:class
   {     
     private readonly List<T> myList = new List<T>();
-    private event Action Changed;
+    private event Action? Changed;
 
     private void FireChanged()
     {
@@ -31,7 +31,7 @@ namespace JetBrains.Util.Util
     
     
     
-    public void AddLast([NotNull]T value)
+    public void AddLast(T value)
     {
       lock (myList)
       {
@@ -41,7 +41,7 @@ namespace JetBrains.Util.Util
     }
 
     
-    public void AddFirst([NotNull]T value)
+    public void AddFirst(T value)
     {
       lock (myList)
       {
@@ -50,8 +50,7 @@ namespace JetBrains.Util.Util
       FireChanged();
     }
 
-    [CanBeNull]
-    public T PeekFirst()
+    public T? PeekFirst()
     {
       lock (myList)
       {
@@ -59,8 +58,7 @@ namespace JetBrains.Util.Util
       }
     }
     
-    [CanBeNull]
-    public T PeekLast()
+    public T? PeekLast()
     {
       lock (myList)
       {
@@ -68,7 +66,7 @@ namespace JetBrains.Util.Util
       }
     }
 
-    public void ReplaceFirst([NotNull]T value)
+    public void ReplaceFirst(T value)
     {
       lock (myList)
       {
@@ -78,7 +76,7 @@ namespace JetBrains.Util.Util
       FireChanged();
     }
 
-    public bool RemoveLastReferenceEqual([NotNull]T value, bool failIfNotLast = false)
+    public bool RemoveLastReferenceEqual(T value, bool failIfNotLast = false)
     {
       var result = false;
       

--- a/rd-net/Lifetimes/Util/Types.cs
+++ b/rd-net/Lifetimes/Util/Types.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -53,7 +54,8 @@ namespace JetBrains.Util.Util
     [ContractAnnotation("thisType:null=>null;=>notnull")]
     public static string ToString(this Type thisType, bool withNamespaces, bool withGenericArguments = true)
     {
-      string Present(Type type, Type[] genericArguments = null)
+      [return: NotNullIfNotNull("type")]
+      string? Present(Type? type, Type[]? genericArguments = null)
       {
         if (type == null)
           return null;

--- a/rd-net/RdFramework.Reflection/BindableChildrenUtil.cs
+++ b/rd-net/RdFramework.Reflection/BindableChildrenUtil.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using JetBrains.Diagnostics;
 using JetBrains.Rd.Base;
 using JetBrains.Rd.Util;
 using JetBrains.Util;
@@ -81,7 +82,9 @@ namespace JetBrains.Rd.Reflection
           for (int i = 0; i < bindableMembers.Length; i++)
           {
             var value = getters[i](obj);
-            obj.BindableChildren.Add(new KeyValuePair<string, object>(bindableMembers[i].Name, value));
+            // value can be null for fields primitive types in RdModels. They are used in serializations, but send their value on bind
+            if (value != null)
+              obj.BindableChildren.Add(new KeyValuePair<string, object>(bindableMembers[i].Name, value));
           }
         };
         lock (ourFillBindableChildren)

--- a/rd-net/RdFramework.Reflection/CollectionSerializers.cs
+++ b/rd-net/RdFramework.Reflection/CollectionSerializers.cs
@@ -12,7 +12,7 @@ namespace JetBrains.Rd.Reflection
   {
     public static SerializerPair CreateListSerializerPair<T>(SerializerPair itemSerializer)
     {
-      CtxReadDelegate<List<T>> readListSerializer = (ctx, reader) => reader.ReadList(itemSerializer.GetReader<T>(), ctx);
+      CtxReadDelegate<List<T>?> readListSerializer = (ctx, reader) => reader.ReadList(itemSerializer.GetReader<T>(), ctx);
       CtxWriteDelegate<IEnumerable<T>> writeListSerializer =(ctx, writer, value) => writer.WriteEnumerable(itemSerializer.GetWriter<T>(), ctx, value);
       return new SerializerPair(readListSerializer, writeListSerializer);
     }
@@ -20,7 +20,7 @@ namespace JetBrains.Rd.Reflection
     public static SerializerPair CreateDictionarySerializerPair<TKey, TValue>(SerializerPair keySerializer, SerializerPair valueSerializer)
     {
       var read = CreateReadDictionary<TKey, TValue>(keySerializer, valueSerializer);
-      CtxWriteDelegate<IDictionary<TKey, TValue>> write = (ctx, writer, value) =>
+      CtxWriteDelegate<IDictionary<TKey, TValue>?> write = (ctx, writer, value) =>
       {
         if (value is Dictionary<TKey, TValue> val && !Equals(val.Comparer, EqualityComparer<TKey>.Default))
           throw new Exception($"Unable to serialize {value.GetType().ToString(true)}. Custom equality comparers are not supported");
@@ -47,7 +47,7 @@ namespace JetBrains.Rd.Reflection
       throw new NotSupportedException();
 #else
       var read = CreateReadDictionary<TKey, TValue>(keySerializer, valueSerializer);
-      CtxWriteDelegate<IReadOnlyDictionary<TKey, TValue>> write = (ctx, writer, value) =>
+      CtxWriteDelegate<IReadOnlyDictionary<TKey, TValue>?> write = (ctx, writer, value) =>
       {
         if (value is Dictionary<TKey, TValue> val && !Equals(val.Comparer, EqualityComparer<TKey>.Default))
           throw new Exception($"Unable to serialize {value.GetType().ToString(true)}. Custom equality comparers are not supported");
@@ -70,9 +70,9 @@ namespace JetBrains.Rd.Reflection
     }
 
 
-    private static CtxReadDelegate<Dictionary<TKey, TValue>> CreateReadDictionary<TKey, TValue>(SerializerPair keySerializer, SerializerPair valueSerializer)
+    private static CtxReadDelegate<Dictionary<TKey, TValue>?> CreateReadDictionary<TKey, TValue>(SerializerPair keySerializer, SerializerPair valueSerializer)
     {
-      CtxReadDelegate<Dictionary<TKey, TValue>> read = (ctx, reader) =>
+      CtxReadDelegate<Dictionary<TKey, TValue>?> read = (ctx, reader) =>
       {
         int count = reader.ReadInt();
         if (count == -1)

--- a/rd-net/RdFramework.Reflection/IProxyGenerator.cs
+++ b/rd-net/RdFramework.Reflection/IProxyGenerator.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Reflection;
 using System.Reflection.Emit;
-using JetBrains.Annotations;
 
 namespace JetBrains.Rd.Reflection
 {
@@ -13,7 +12,7 @@ namespace JetBrains.Rd.Reflection
 
   public static class ProxyGeneratorEx
   {
-    public static Type CreateType<TInterface>([NotNull] this IProxyGenerator proxyGenerator) where TInterface : class
+    public static Type CreateType<TInterface>(this IProxyGenerator proxyGenerator) where TInterface : class
     {
       return proxyGenerator.CreateType(typeof(TInterface));
     }

--- a/rd-net/RdFramework.Reflection/ITypesCatalog.cs
+++ b/rd-net/RdFramework.Reflection/ITypesCatalog.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using JetBrains.Annotations;
 
 namespace JetBrains.Rd.Reflection
 {
   public interface ITypesCatalog
   {
-    [CanBeNull] Type GetById(RdId id);
-    void AddType([NotNull] Type type);
+    Type? GetById(RdId id);
+    void AddType(Type type);
   }
 }

--- a/rd-net/RdFramework.Reflection/Intrinsic.cs
+++ b/rd-net/RdFramework.Reflection/Intrinsic.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Reflection;
-using JetBrains.Annotations;
 using JetBrains.Diagnostics;
 using JetBrains.Util;
 using JetBrains.Util.Util;
@@ -13,8 +12,7 @@ namespace JetBrains.Rd.Reflection
 {
   public static class Intrinsic
   {
-    [CanBeNull]
-    public static SerializerPair TryGetIntrinsicSerializer(TypeInfo typeInfo, Func<Type, SerializerPair> getInstanceSerializer)
+    public static SerializerPair? TryGetIntrinsicSerializer(TypeInfo typeInfo, Func<Type, SerializerPair> getInstanceSerializer)
     {
       if (ReflectionSerializerVerifier.HasIntrinsicNonProtocolMethods(typeInfo))
       {
@@ -84,7 +82,7 @@ namespace JetBrains.Rd.Reflection
       {
         var marshallerType = typeInfo.GetCustomAttribute<RdScalarAttribute>().NotNull().Marshaller;
         var marshaller = Activator.CreateInstance(marshallerType);
-        return (SerializerPair) ReflectionUtil.InvokeStaticGeneric(typeof(SerializerPair), nameof(SerializerPair.FromMarshaller), typeInfo, marshaller);
+        return (SerializerPair?) ReflectionUtil.InvokeStaticGeneric(typeof(SerializerPair), nameof(SerializerPair.FromMarshaller), typeInfo, marshaller);
       }
 
       return null;

--- a/rd-net/RdFramework.Reflection/ProxyGenerator.cs
+++ b/rd-net/RdFramework.Reflection/ProxyGenerator.cs
@@ -79,8 +79,8 @@ namespace JetBrains.Rd.Reflection
     {
       myAllowSave = allowSave;
 #if NETSTANDARD
-     myModuleBuilder = new Lazy<ModuleBuilder>(() => myAssemblyBuilder.Value.DefineDynamicModule(DynamicAssemblyName));
      myAssemblyBuilder = new Lazy<AssemblyBuilder>(() => AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(DynamicAssemblyName), AssemblyBuilderAccess.Run));
+     myModuleBuilder = new Lazy<ModuleBuilder>(() => myAssemblyBuilder.Value.DefineDynamicModule(DynamicAssemblyName));
 #else
       myAssemblyBuilder = new Lazy<AssemblyBuilder>(() => AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName(DynamicAssemblyName), allowSave ? AssemblyBuilderAccess.RunAndSave : AssemblyBuilderAccess.Run));
       if (allowSave)
@@ -137,9 +137,9 @@ namespace JetBrains.Rd.Reflection
       }
 
 #if NET35
-      return typebuilder.CreateType();
+      return typebuilder.CreateType().NotNull("Unable to create type");
 #else
-      return typebuilder.CreateTypeInfo();
+      return typebuilder.CreateTypeInfo().NotNull("Unable to create type");
 #endif
     }
 

--- a/rd-net/RdFramework.Reflection/ProxyGeneratorUtil.cs
+++ b/rd-net/RdFramework.Reflection/ProxyGeneratorUtil.cs
@@ -44,7 +44,7 @@ namespace JetBrains.Rd.Reflection
     /// <summary>
     /// Sync call which allow nested call execution with help of <see cref="SwitchingScheduler"/>
     /// </summary>
-    public static TRes SyncNested<TReq, TRes>(RdCall<TReq, TRes> call, TReq request, RpcTimeouts timeouts = null)
+    public static TRes SyncNested<TReq, TRes>(RdCall<TReq, TRes> call, TReq request, RpcTimeouts? timeouts = null)
     {
       return SyncNested(call, Lifetime.Eternal, request, timeouts);
     }
@@ -52,7 +52,7 @@ namespace JetBrains.Rd.Reflection
     /// <summary>
     /// Sync call which allow nested call execution with help of <see cref="SwitchingScheduler"/>
     /// </summary>
-    public static TRes SyncNested<TReq, TRes>(RdCall<TReq, TRes> call, Lifetime lifetime, TReq request, RpcTimeouts timeouts = null)
+    public static TRes SyncNested<TReq, TRes>(RdCall<TReq, TRes> call, Lifetime lifetime, TReq request, RpcTimeouts? timeouts = null)
     {
       Assertion.Require(call.IsBound, "Not bound: {0}", call);
 

--- a/rd-net/RdFramework.Reflection/RdFramework.Reflection.csproj
+++ b/rd-net/RdFramework.Reflection/RdFramework.Reflection.csproj
@@ -15,7 +15,6 @@
         <Configurations>Debug;Release;CrossTests</Configurations>
 
         <Platforms>AnyCPU</Platforms>
-        <Nullable>enable</Nullable>
     </PropertyGroup>
 
 

--- a/rd-net/RdFramework.Reflection/RdFramework.Reflection.csproj
+++ b/rd-net/RdFramework.Reflection/RdFramework.Reflection.csproj
@@ -15,6 +15,7 @@
         <Configurations>Debug;Release;CrossTests</Configurations>
 
         <Platforms>AnyCPU</Platforms>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
 

--- a/rd-net/RdFramework.Reflection/ReflectionSerializerVerifier.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionSerializerVerifier.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using JetBrains.Annotations;
 using JetBrains.Collections.Viewable;
 using JetBrains.Core;
 using JetBrains.Diagnostics;
@@ -157,7 +156,7 @@ namespace JetBrains.Rd.Reflection
              IsNullable(typeInfo, type => IsPrimitive(type) || type.GetTypeInfo().IsEnum);
     }
 
-    private static bool IsNullable([NotNull] TypeInfo typeInfo, Func<Type, bool> filter)
+    private static bool IsNullable(TypeInfo typeInfo, Func<Type, bool> filter)
     {
       return typeInfo.IsValueType &&
              typeInfo.IsGenericType &&
@@ -288,7 +287,7 @@ namespace JetBrains.Rd.Reflection
         "only (RdProperty | RdList | RdSet | RdMap | RdModel | RdCall | custom sealed bindable types) allowed in RdModel or RdExt!");
     }
 
-    public static void AssertValidRdModel([NotNull] TypeInfo type)
+    public static void AssertValidRdModel(TypeInfo type)
     {
       var isDataModel = HasRdModelAttribute(type);
       Assertion.Assert(isDataModel, $"Error in {type.ToString(true)} model: no {nameof(RdModelAttribute)} attribute specified");

--- a/rd-net/RdFramework.Reflection/ReflectionSerializersFacade.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionSerializersFacade.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.Reflection;
-using JetBrains.Annotations;
+using JetBrains.Diagnostics;
 using JetBrains.Lifetimes;
 using JetBrains.Rd.Base;
 
@@ -8,29 +7,23 @@ namespace JetBrains.Rd.Reflection
 {
   public class ReflectionSerializersFacade
   {
-    [NotNull]
     public ReflectionRdActivator Activator { get; }
 
-    [NotNull]
     public ITypesCatalog TypesCatalog { get; }
 
-    [NotNull]
     public IScalarSerializers ScalarSerializers { get; }
 
-    [NotNull]
     public ReflectionSerializersFactory SerializersFactory { get; }
 
-    [NotNull]
     public IProxyGenerator ProxyGenerator { get; }
 
-    [NotNull]
     public ITypesRegistrar Registrar { get; }
 
     public ReflectionSerializersFacade() : this(null)
     {
     }
 
-    public ReflectionSerializersFacade([CanBeNull] ITypesCatalog typesCatalog = null, [CanBeNull] IScalarSerializers scalarSerializers = null, [CanBeNull] ReflectionSerializersFactory reflectionSerializers = null, [CanBeNull] IProxyGenerator proxyGenerator = null, [CanBeNull] ReflectionRdActivator activator = null, [CanBeNull] TypesRegistrar registrar = null, bool allowSave = false, [CanBeNull] Predicate<Type> blackListChecker = null)
+    public ReflectionSerializersFacade(ITypesCatalog? typesCatalog = null, IScalarSerializers? scalarSerializers = null, ReflectionSerializersFactory? reflectionSerializers = null, IProxyGenerator? proxyGenerator = null, ReflectionRdActivator? activator = null, TypesRegistrar? registrar = null, bool allowSave = false, Predicate<Type>? blackListChecker = null)
     {
       TypesCatalog = typesCatalog ?? new SimpleTypesCatalog();
       ScalarSerializers = scalarSerializers ?? new ScalarSerializer(TypesCatalog, blackListChecker);
@@ -45,6 +38,7 @@ namespace JetBrains.Rd.Reflection
     {
       var type = ProxyGenerator.CreateType<TInterface>();
       var proxyInstance = Activator.ActivateBind(type, lifetime, protocol) as TInterface;
+      Assertion.Assert(proxyInstance != null, "Unable to cast proxy to desired interface ({0})", typeof(TInterface));
       return proxyInstance;
     }
 

--- a/rd-net/RdFramework.Reflection/ReflectionSerializersFactory.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionSerializersFactory.cs
@@ -158,7 +158,7 @@ namespace JetBrains.Rd.Reflection
             var intrinsic = Intrinsic.TryGetIntrinsicSerializer(
               type.GetTypeInfo(), 
               t => GetOrRegisterStaticSerializerInternal(t, true));
-            Assertion.Assert(intrinsic != null, "Unable to get intrinsic serializer for type {0}, thought API detect the presense of it. Probably it was only partially implemeted", type);
+            Assertion.Assert(intrinsic != null, "Unable to get intrinsic serializer for type {0}, thought API detect the presense of it. Probably it was only partially implemented", type);
             mySerializers.Add(type, intrinsic);
           }
           else

--- a/rd-net/RdFramework.Reflection/SerializerReflectionUtil.cs
+++ b/rd-net/RdFramework.Reflection/SerializerReflectionUtil.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using JetBrains.Annotations;
 using JetBrains.Diagnostics;
 using JetBrains.Rd.Base;
 using JetBrains.Serialization;
@@ -19,8 +18,7 @@ namespace JetBrains.Rd.Reflection
     private static readonly MethodInfo ourConvertTypedCtxRead = typeof(SerializerReflectionUtil).GetTypeInfo().GetMethod(nameof(CtxReadTypedToObject), BindingFlags.Static | BindingFlags.NonPublic);
     private static readonly MethodInfo ourConvertTypedCtxWrite = typeof(SerializerReflectionUtil).GetTypeInfo().GetMethod(nameof(CtxWriteTypedToObject), BindingFlags.Static | BindingFlags.NonPublic);
 
-    [NotNull]
-    public static MethodInfo GetReadStaticSerializer([NotNull] TypeInfo typeInfo)
+    public static MethodInfo GetReadStaticSerializer(TypeInfo typeInfo)
     {
       var types = new[]
       {
@@ -37,8 +35,7 @@ namespace JetBrains.Rd.Reflection
       return methodInfo;
     }
 
-    [NotNull]
-    public static MethodInfo GetReadStaticNonProtocolSerializer([NotNull] TypeInfo typeInfo)
+    public static MethodInfo GetReadStaticNonProtocolSerializer(TypeInfo typeInfo)
     {
       var types = new[]
       {
@@ -54,8 +51,7 @@ namespace JetBrains.Rd.Reflection
       return methodInfo;
     }
 
-    [NotNull]
-    public static MethodInfo GetReadStaticSerializer([NotNull] TypeInfo typeInfo, Type argumentType)
+    public static MethodInfo GetReadStaticSerializer(TypeInfo typeInfo, Type argumentType)
     {
       var types = new[]
       {
@@ -74,8 +70,7 @@ namespace JetBrains.Rd.Reflection
       return methodInfo;
     }
 
-    [NotNull]
-    public static MethodInfo GetReadStaticSerializer([NotNull] TypeInfo typeInfo, Type key, Type value)
+    public static MethodInfo GetReadStaticSerializer(TypeInfo typeInfo, Type key, Type value)
     {
       var types = new[]
       {
@@ -96,8 +91,7 @@ namespace JetBrains.Rd.Reflection
       return methodInfo;
     }
 
-    [NotNull]
-    public static MethodInfo GetWriteStaticDeserializer([NotNull] TypeInfo typeInfo)
+    public static MethodInfo GetWriteStaticDeserializer(TypeInfo typeInfo)
     {
       var types = new[]
       {
@@ -115,8 +109,7 @@ namespace JetBrains.Rd.Reflection
       return methodInfo;
     }
 
-    [NotNull]
-    public static MethodInfo GetWriteNonProtocolDeserializer([NotNull] TypeInfo typeInfo)
+    public static MethodInfo GetWriteNonProtocolDeserializer(TypeInfo typeInfo)
     {
       var types = new[]
       {
@@ -137,7 +130,6 @@ namespace JetBrains.Rd.Reflection
     /// Get lists of members which take part in object serialization.
     /// Can be used for RdExt, RdModel and any RdScalar.
     /// </summary>
-    [NotNull]
     internal static FieldInfo[] GetBindableMembers(TypeInfo typeInfo)
     {
 /*
@@ -211,16 +203,16 @@ namespace JetBrains.Rd.Reflection
       return (CtxReadDelegate<object>)result;
     }
 
-    internal static CtxWriteDelegate<object> ConvertWriter(Type returnType, object writer)
+    internal static CtxWriteDelegate<object?> ConvertWriter(Type returnType, object writer)
     {
-      if (writer is CtxWriteDelegate<object> objWriter)
+      if (writer is CtxWriteDelegate<object?> objWriter)
         return objWriter;
 
-      return (CtxWriteDelegate<object>)ourConvertTypedCtxWrite.MakeGenericMethod(returnType).Invoke(null, new[] { writer });
+      return (CtxWriteDelegate<object?>)ourConvertTypedCtxWrite.MakeGenericMethod(returnType).Invoke(null, new[] { writer });
     }
 
 
-    private static CtxReadDelegate<object> CtxReadTypedToObject<T>(CtxReadDelegate<T> typedDelegate)
+    private static CtxReadDelegate<object?> CtxReadTypedToObject<T>(CtxReadDelegate<T> typedDelegate)
     {
       return (ctx, unsafeReader) => typedDelegate(ctx, unsafeReader);
     }

--- a/rd-net/RdFramework.Reflection/SimpleTypesCatalog.cs
+++ b/rd-net/RdFramework.Reflection/SimpleTypesCatalog.cs
@@ -7,7 +7,7 @@ namespace JetBrains.Rd.Reflection
   {
     private readonly Dictionary<RdId, Type> myRdIdToTypeMapping = new Dictionary<RdId, Type>();
 
-    public Type GetById(RdId id)
+    public Type? GetById(RdId id)
     {
       if (myRdIdToTypeMapping.TryGetValue(id, out var type))
       {

--- a/rd-net/RdFramework.Reflection/TypesRegistrar.cs
+++ b/rd-net/RdFramework.Reflection/TypesRegistrar.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using JetBrains.Annotations;
 using JetBrains.Util;
 
 namespace JetBrains.Rd.Reflection
@@ -9,7 +8,7 @@ namespace JetBrains.Rd.Reflection
     private readonly ITypesCatalog myCatalog;
     private readonly ReflectionSerializersFactory myReflectionSerializersFactory;
 
-    public TypesRegistrar([NotNull] ITypesCatalog catalog, [NotNull] ReflectionSerializersFactory reflectionSerializersFactory)
+    public TypesRegistrar(ITypesCatalog catalog, ReflectionSerializersFactory reflectionSerializersFactory)
     {
       myCatalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
       myReflectionSerializersFactory = reflectionSerializersFactory ?? throw new ArgumentNullException(nameof(reflectionSerializersFactory));

--- a/rd-net/RdFramework/Base/IRdBindable.cs
+++ b/rd-net/RdFramework/Base/IRdBindable.cs
@@ -13,9 +13,9 @@ namespace JetBrains.Rd.Base
 {
   public interface IRdDynamic
   {
-    [NotNull] IProtocol Proto { get; }
+    IProtocol Proto { get; }
     SerializationCtx SerializationContext { get; }
-    [NotNull] RName Location { get; }
+    RName Location { get; }
   }
 
 
@@ -50,7 +50,7 @@ namespace JetBrains.Rd.Base
     #region Bind
 
 
-    internal static void BindPolymorphic(this object value, Lifetime lifetime, IRdDynamic parent, string name)
+    internal static void BindPolymorphic(this object? value, Lifetime lifetime, IRdDynamic parent, string name)
     {
       if (value is IRdBindable rdBindable) 
         rdBindable.Bind(lifetime, parent, name);
@@ -78,7 +78,7 @@ namespace JetBrains.Rd.Base
     }
 
 
-    private static void Bind0([CanBeNull] this IEnumerable items, Lifetime lifetime, IRdDynamic parent, string name)
+    private static void Bind0(this IEnumerable? items, Lifetime lifetime, IRdDynamic parent, string name)
     {
       if (items == null) return;
 
@@ -88,18 +88,18 @@ namespace JetBrains.Rd.Base
     }
 
 
-    public static void BindEx<T>([CanBeNull] this T value, Lifetime lifetime, IRdDynamic parent, string name) where T : IRdBindable
+    public static void BindEx<T>(this T? value, Lifetime lifetime, IRdDynamic parent, string name) where T : IRdBindable
     {
       if (value != null) value.Bind(lifetime, parent, name);
     }
 
     // ASSHEATING C# OVERLOAD RESOLUTION
-    public static void BindEx<T>([CanBeNull] this List<T> items, Lifetime lifetime, IRdDynamic parent, string name) where T : IRdBindable
+    public static void BindEx<T>(this List<T>? items, Lifetime lifetime, IRdDynamic parent, string name) where T : IRdBindable
     {
       Bind0(items, lifetime, parent, name);
     }
 
-    public static void BindEx<T>([CanBeNull] this T[] items, Lifetime lifetime, IRdDynamic parent, string name) where T : IRdBindable
+    public static void BindEx<T>(this T[]? items, Lifetime lifetime, IRdDynamic parent, string name) where T : IRdBindable
     {
       Bind0(items, lifetime, parent, name);
     }
@@ -110,7 +110,7 @@ namespace JetBrains.Rd.Base
 
     #region Identify
 
-    internal static void IdentifyPolymorphic(this object value, IIdentities ids, RdId id)
+    internal static void IdentifyPolymorphic(this object? value, IIdentities ids, RdId id)
     {  
       if (value is IRdBindable rdBindable)
         rdBindable.Identify(ids, id);
@@ -120,7 +120,7 @@ namespace JetBrains.Rd.Base
     
 
 
-    private static void Identify0([CanBeNull] this IEnumerable items, IIdentities ids, RdId id)
+    private static void Identify0(this IEnumerable? items, IIdentities ids, RdId id)
     {
       if (items == null) return;
 
@@ -132,18 +132,18 @@ namespace JetBrains.Rd.Base
     }
 
 
-    public static void IdentifyEx<T>([CanBeNull] this T value, IIdentities ids, RdId id) where T : IRdBindable
+    public static void IdentifyEx<T>(this T? value, IIdentities ids, RdId id) where T : IRdBindable
     {
       if (value != null) value.Identify(ids, id);
     }
 
     //PLEASE DON'T MERGE these two methods into one with IEnumerable<T>, just believe me
-    public static void IdentifyEx<T>([CanBeNull] this List<T> items, IIdentities ids, RdId id) where T : IRdBindable
+    public static void IdentifyEx<T>(this List<T>? items, IIdentities ids, RdId id) where T : IRdBindable
     {
       items.Identify0(ids, id);
     }
 
-    public static void IdentifyEx<T>([CanBeNull] this T[] items, IIdentities ids, RdId id) where T : IRdBindable
+    public static void IdentifyEx<T>(this T[]? items, IIdentities ids, RdId id) where T : IRdBindable
     {
       items.Identify0(ids, id);
     }
@@ -155,7 +155,7 @@ namespace JetBrains.Rd.Base
 
   public static class PrintableEx
   {
-    public static void PrintEx(this object me, PrettyPrinter printer)
+    public static void PrintEx(this object? me, PrettyPrinter printer)
     {
       var printable = me as IPrintable;
       if (printer.BufferExceeded)
@@ -211,14 +211,14 @@ namespace JetBrains.Rd.Base
       }
     }
 
-    public static string PrintToString(this object me)
+    public static string PrintToString(this object? me)
     {
       var prettyPrinter = new PrettyPrinter();
       me.PrintEx(prettyPrinter);
       return prettyPrinter.ToString();
     }
 
-    public static string PrintToStringNoLimits(this object me)
+    public static string PrintToStringNoLimits(this object? me)
     {
       var prettyPrinter = new PrettyPrinter { CollectionMaxLength = Int32.MaxValue };
       me.PrintEx(prettyPrinter);

--- a/rd-net/RdFramework/Base/ISingleContextHandler.cs
+++ b/rd-net/RdFramework/Base/ISingleContextHandler.cs
@@ -18,6 +18,6 @@ namespace JetBrains.Rd.Base
   {
     RdContext<T> Context { get; }
 
-    T ReadValue(SerializationCtx context, UnsafeReader reader);
+    T? ReadValue(SerializationCtx context, UnsafeReader reader);
   }
 }

--- a/rd-net/RdFramework/Base/RdExtBase.cs
+++ b/rd-net/RdFramework/Base/RdExtBase.cs
@@ -9,6 +9,8 @@ using JetBrains.Rd.Impl;
 using JetBrains.Serialization;
 using JetBrains.Util;
 
+#nullable disable
+
 namespace JetBrains.Rd.Base
 {
   public abstract class RdExtBase : RdReactiveBase

--- a/rd-net/RdFramework/IInternRoot.cs
+++ b/rd-net/RdFramework/IInternRoot.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using JetBrains.Rd.Base;
 using JetBrains.Serialization;
+#nullable disable
 
 namespace JetBrains.Rd
 {

--- a/rd-net/RdFramework/IProtocol.cs
+++ b/rd-net/RdFramework/IProtocol.cs
@@ -7,13 +7,13 @@ namespace JetBrains.Rd
 {
   public interface IProtocol : IRdDynamic
   {
-    [NotNull] ViewableSet<RdExtBase> OutOfSyncModels { get; }
-    [NotNull] string Name { get; }
-    [NotNull] ISerializers Serializers { get; }
-    [NotNull] IIdentities Identities { get; }
-    [NotNull] IScheduler Scheduler { get; }
-    [NotNull] IWire Wire { get; }    
-    [NotNull] ProtocolContexts Contexts { get; }
-    [NotNull] ISignal<ExtCreationInfo> ExtCreated { get; }
+    ViewableSet<RdExtBase> OutOfSyncModels { get; }
+    string Name { get; }
+    ISerializers Serializers { get; }
+    IIdentities Identities { get; }
+    IScheduler Scheduler { get; }
+    IWire Wire { get; }    
+    ProtocolContexts Contexts { get; }
+    ISignal<ExtCreationInfo> ExtCreated { get; }
   }
 }

--- a/rd-net/RdFramework/ISerializers.cs
+++ b/rd-net/RdFramework/ISerializers.cs
@@ -6,7 +6,7 @@ namespace JetBrains.Rd
 {
   public interface ISerializersContainer
   {
-    void Register<T>([NotNull] CtxReadDelegate<T> reader, [NotNull] CtxWriteDelegate<T> writer, long? predefinedType = null);
+    void Register<T>(CtxReadDelegate<T> reader, CtxWriteDelegate<T> writer, long? predefinedType = null);
 
     void RegisterEnum<T>() where T :
 #if !NET35
@@ -19,8 +19,8 @@ namespace JetBrains.Rd
 
   public interface ISerializers : ISerializersContainer
   {
-    T Read<T>(SerializationCtx ctx, [NotNull] UnsafeReader reader, [CanBeNull] CtxReadDelegate<T> unknownInstanceReader = null);
+    T? Read<T>(SerializationCtx ctx, UnsafeReader reader, CtxReadDelegate<T>? unknownInstanceReader = null);
 
-    void Write<T>(SerializationCtx ctx, [NotNull] UnsafeWriter writer, [CanBeNull] T value);
+    void Write<T>(SerializationCtx ctx, UnsafeWriter writer, T value);
   }
 }

--- a/rd-net/RdFramework/ITypesRegistrar.cs
+++ b/rd-net/RdFramework/ITypesRegistrar.cs
@@ -11,7 +11,7 @@ namespace JetBrains.Rd
     /// </summary>
     /// <param name="id"></param>
     /// <param name="serializers"></param>
-    void TryRegister(RdId id, [NotNull] ISerializers serializers);
-    void TryRegister([NotNull] Type clrType, [NotNull] ISerializers serializers);
+    void TryRegister(RdId id, ISerializers serializers);
+    void TryRegister(Type clrType, ISerializers serializers);
   }
 }

--- a/rd-net/RdFramework/IWire.cs
+++ b/rd-net/RdFramework/IWire.cs
@@ -18,12 +18,12 @@ namespace JetBrains.Rd
     /// </summary>
     bool IsStub { get; }
 
-    void Send<TParam>(RdId id, TParam param, [NotNull, InstantHandle] Action<TParam, UnsafeWriter> writer);
-    void Advise([NotNull] Lifetime lifetime, [NotNull] IRdWireable entity);
+    void Send<TParam>(RdId id, TParam param, [InstantHandle] Action<TParam, UnsafeWriter> writer);
+    void Advise(Lifetime lifetime, IRdWireable entity);
     
-    [NotNull] ProtocolContexts Contexts { get; set; }
+    ProtocolContexts Contexts { get; set; }
 
-    [CanBeNull] IRdWireable TryGetById(RdId rdId);
+    IRdWireable? TryGetById(RdId rdId);
   }
 
   public interface IWireWithDelayedDelivery : IWire
@@ -64,8 +64,10 @@ namespace JetBrains.Rd
     }
 
 
-    protected WireBase([NotNull] IScheduler scheduler)
+    protected WireBase(IScheduler scheduler)
     {
+      // contexts is initialized when protocol is created.
+      myContexts = null!;
       if (scheduler == null) throw new ArgumentNullException(nameof(scheduler));
 
       Scheduler = scheduler;
@@ -118,7 +120,7 @@ namespace JetBrains.Rd
       MessageBroker.Advise(lifetime, reactive);
     }
 
-    public IRdWireable TryGetById(RdId rdId)
+    public IRdWireable? TryGetById(RdId rdId)
     {
       return MessageBroker.TryGetById(rdId);
     }

--- a/rd-net/RdFramework/Impl/ExtCreatedUtils.cs
+++ b/rd-net/RdFramework/Impl/ExtCreatedUtils.cs
@@ -8,7 +8,6 @@ namespace JetBrains.Rd.Impl
 {
   public static class ExtCreatedUtils
   {
-    [NotNull]
     public static RdSignal<ExtCreationInfo> CreateExtSignal(this IRdDynamic @this)
     {
       var signal = new RdSignal<ExtCreationInfo>(
@@ -31,8 +30,7 @@ namespace JetBrains.Rd.Impl
       return signal;
     }
     
-    [NotNull]
-    internal static RName ReadRName([NotNull] UnsafeReader reader)
+    internal static RName ReadRName(UnsafeReader reader)
     {
       var isEmpty = reader.ReadBool();
       if (isEmpty)
@@ -51,7 +49,7 @@ namespace JetBrains.Rd.Impl
       return rName;
     }
 
-    internal static void WriteRName([NotNull] UnsafeWriter writer, [NotNull] RName value)
+    internal static void WriteRName(UnsafeWriter writer, RName value)
     {
       writer.Write(value == RName.Empty);
       TraverseRName(value, true, (rName, last) =>
@@ -66,7 +64,7 @@ namespace JetBrains.Rd.Impl
       });
     }
 
-    private static void TraverseRName([NotNull] RName rName, bool last, [NotNull] Action<RName, bool> handler)
+    private static void TraverseRName(RName rName, bool last, Action<RName, bool> handler)
     {
       if (rName.Parent is RName rParent)
       {

--- a/rd-net/RdFramework/Impl/HeavySingleContextHandler.cs
+++ b/rd-net/RdFramework/Impl/HeavySingleContextHandler.cs
@@ -6,6 +6,8 @@ using JetBrains.Rd.Base;
 using JetBrains.Rd.Util;
 using JetBrains.Serialization;
 
+#nullable disable
+
 namespace JetBrains.Rd.Impl
 {
   internal class HeavySingleContextHandler<T> : RdReactiveBase, ISingleContextHandler<T>

--- a/rd-net/RdFramework/Impl/InternRoot.cs
+++ b/rd-net/RdFramework/Impl/InternRoot.cs
@@ -10,6 +10,8 @@ using JetBrains.Rd.Util;
 using JetBrains.Serialization;
 using JetBrains.Util.Util;
 
+#nullable disable
+
 namespace JetBrains.Rd.Impl
 {
   public class InternRoot<TBase> : IInternRoot<TBase>

--- a/rd-net/RdFramework/Impl/LightSingleContextHandler.cs
+++ b/rd-net/RdFramework/Impl/LightSingleContextHandler.cs
@@ -1,6 +1,8 @@
 using JetBrains.Rd.Base;
 using JetBrains.Serialization;
 
+#nullable disable
+
 namespace JetBrains.Rd.Impl
 {
   internal class LightSingleContextHandler<T> : ISingleContextHandler<T>

--- a/rd-net/RdFramework/Impl/MessageBroker.cs
+++ b/rd-net/RdFramework/Impl/MessageBroker.cs
@@ -124,7 +124,7 @@ namespace JetBrains.Rd.Impl
           
           myScheduler.Queue(() =>
           {
-            byte[] msg1;
+            byte[]? msg1;
 
             IRdWireable subscription;
             bool hasSubscription;
@@ -229,8 +229,7 @@ namespace JetBrains.Rd.Impl
         });
     }
 
-    [CanBeNull]
-    public IRdWireable TryGetById(RdId rdId)
+    public IRdWireable? TryGetById(RdId rdId)
     {
       lock (myLock)
       {

--- a/rd-net/RdFramework/Impl/Protocol.cs
+++ b/rd-net/RdFramework/Impl/Protocol.cs
@@ -27,14 +27,14 @@ namespace JetBrains.Rd.Impl
     /// </summary>
     const string ProtocolInternScopeStringId = "Protocol";
 
-    public Protocol([NotNull] string name, [NotNull] ISerializers serializers, [NotNull] IIdentities identities, [NotNull] IScheduler scheduler, 
-      [NotNull] IWire wire, Lifetime lifetime, params RdContextBase[] initialContexts) 
+    public Protocol(string name, ISerializers serializers, IIdentities identities, IScheduler scheduler, 
+      IWire wire, Lifetime lifetime, params RdContextBase[] initialContexts) 
       : this(name, serializers, identities, scheduler, wire, lifetime, null, null, null, null, initialContexts)
     { }
 
-    internal Protocol([NotNull] string name, [NotNull] ISerializers serializers, [NotNull] IIdentities identities, [NotNull] IScheduler scheduler,
-      [NotNull] IWire wire, Lifetime lifetime, SerializationCtx? serializationCtx = null, [CanBeNull] ProtocolContexts parentContexts = null, 
-      [CanBeNull] ISignal<ExtCreationInfo> parentExtCreated = null, [CanBeNull] RdSignal<ExtCreationInfo> parentExtConfirmation = null, params RdContextBase[] initialContexts)
+    internal Protocol(string name, ISerializers serializers, IIdentities identities, IScheduler scheduler,
+      IWire wire, Lifetime lifetime, SerializationCtx? serializationCtx = null, ProtocolContexts? parentContexts = null, 
+      ISignal<ExtCreationInfo>? parentExtCreated = null, RdSignal<ExtCreationInfo>? parentExtConfirmation = null, params RdContextBase[] initialContexts)
     {
       
       Name = name ?? throw new ArgumentNullException(nameof(name));

--- a/rd-net/RdFramework/Impl/ProtocolContexts.cs
+++ b/rd-net/RdFramework/Impl/ProtocolContexts.cs
@@ -118,7 +118,7 @@ namespace JetBrains.Rd.Impl
     /// <summary>
     /// Get a value set for a given key. The values are local relative to transform
     /// </summary>
-    public IViewableSet<T> GetValueSet<T>(RdContext<T> context)
+    public IViewableSet<T> GetValueSet<T>(RdContext<T> context) where T : notnull
     {
       Assertion.Assert(context.IsHeavy, "Only heavy keys have value sets, key {0} is light", context.Key);
       return ((HeavySingleContextHandler<T>) GetHandlerForContext(context)).LocalValueSet;

--- a/rd-net/RdFramework/Impl/RdList.cs
+++ b/rd-net/RdFramework/Impl/RdList.cs
@@ -12,15 +12,17 @@ using JetBrains.Rd.Base;
 using JetBrains.Rd.Util;
 using JetBrains.Serialization;
 
+#nullable disable
+
 // ReSharper disable InconsistentNaming
 
 namespace JetBrains.Rd.Impl
 {
-  public class RdList<V> : RdReactiveBase, IViewableList<V>
+  public class  RdList<V> : RdReactiveBase, IViewableList<V>
 #if !NET35
     , INotifyCollectionChanged
 #endif
-  
+    where V : notnull
   {
     private readonly ViewableList<V> myList = new ViewableList<V>();
        

--- a/rd-net/RdFramework/Impl/RdMap.cs
+++ b/rd-net/RdFramework/Impl/RdMap.cs
@@ -137,11 +137,11 @@ namespace JetBrains.Rd.Impl
       Wire.Advise(lifetime, this);
 
 
-      if (!OptimizeNested) //means values must be bindable
+      if (!OptimizeNested && !typeof(V).IsValueType) //means values must be bindable
       {
         this.View(lifetime, (lf, k, v) =>
         {
-          v.BindPolymorphic(lf, this, "["+k+"]");
+          RdBindableEx.BindPolymorphic(v!, lf, this, "["+k+"]");
         });
       }
     }

--- a/rd-net/RdFramework/Impl/RdMap.cs
+++ b/rd-net/RdFramework/Impl/RdMap.cs
@@ -16,7 +16,7 @@ using JetBrains.Serialization;
 namespace JetBrains.Rd.Impl
 {
 
-  public class RdMap<K, V> : RdReactiveBase, IViewableMap<K, V>
+  public class RdMap<K, V> : RdReactiveBase, IViewableMap<K, V> where K : notnull
   {
     private readonly ViewableMap<K, V> myMap = new ViewableMap<K, V>();
 
@@ -122,7 +122,7 @@ namespace JetBrains.Rd.Impl
             }              
             
             me.WriteKeyDelegate(sContext, stream, evt.Key);
-            if (evt.Kind != AddUpdateRemove.Remove) 
+            if (evt.IsUpdate || evt.IsAdd) 
               me.WriteValueDelegate(sContext, stream, evt.NewValue);
 
 
@@ -141,7 +141,7 @@ namespace JetBrains.Rd.Impl
       {
         this.View(lifetime, (lf, k, v) =>
         {
-          RdBindableEx.BindPolymorphic(v!, lf, this, "["+k+"]");
+          RdBindableEx.BindPolymorphic(v, lf, this, "["+k+"]");
         });
       }
     }
@@ -159,7 +159,7 @@ namespace JetBrains.Rd.Impl
 
       if (opType == Ack)
       {
-        string error = null;
+        string? error = null;
 
         if (!msgVersioned) error = "Received ACK while msg hasn't versioned flag set";
         else if (!IsMaster) error = "Received ACK when not a Master";
@@ -363,7 +363,7 @@ namespace JetBrains.Rd.Impl
       }
     }
 
-    public override RdBindableBase FindByRName(RName rName)
+    public override RdBindableBase? FindByRName(RName rName)
     {
       var rootName = rName.GetNonEmptyRoot();
       var localName = rootName.LocalName.ToString();

--- a/rd-net/RdFramework/Impl/RdMap.cs
+++ b/rd-net/RdFramework/Impl/RdMap.cs
@@ -137,11 +137,11 @@ namespace JetBrains.Rd.Impl
       Wire.Advise(lifetime, this);
 
 
-      if (!OptimizeNested && !typeof(V).IsValueType) //means values must be bindable
+      if (!OptimizeNested) //means values must be bindable
       {
         this.View(lifetime, (lf, k, v) =>
         {
-          RdBindableEx.BindPolymorphic(v, lf, this, "["+k+"]");
+          v.BindPolymorphic(lf, this, "["+k+"]");
         });
       }
     }

--- a/rd-net/RdFramework/Impl/RdPerContextMap.cs
+++ b/rd-net/RdFramework/Impl/RdPerContextMap.cs
@@ -9,7 +9,7 @@ using JetBrains.Serialization;
 
 namespace JetBrains.Rd.Impl
 {
-    public class RdPerContextMap<K, V> : RdReactiveBase, IPerContextMap<K, V> where V : RdBindableBase
+    public class RdPerContextMap<K, V> : RdReactiveBase, IPerContextMap<K, V> where V : RdBindableBase where K: notnull
     {
         public RdContext<K> Context { get; }
         private readonly Func<Boolean, V> myValueFactory;

--- a/rd-net/RdFramework/Impl/RdProperty.cs
+++ b/rd-net/RdFramework/Impl/RdProperty.cs
@@ -16,7 +16,7 @@ namespace JetBrains.Rd.Impl
   {
     #region Constructor
 
-    public override event PropertyChangedEventHandler PropertyChanged;
+    public override event PropertyChangedEventHandler? PropertyChanged;
 
     public RdProperty() : this(Polymorphic<T>.Read, Polymorphic<T>.Write) {}
 
@@ -200,7 +200,7 @@ namespace JetBrains.Rd.Impl
         myProperty.Advise(lifetime, handler);
     }
 
-    public override RdBindableBase FindByRName(RName rName)
+    public override RdBindableBase? FindByRName(RName rName)
     {
       var rootName = rName.GetNonEmptyRoot();
       var localName = rootName.LocalName.ToString();

--- a/rd-net/RdFramework/Impl/RdSecureString.cs
+++ b/rd-net/RdFramework/Impl/RdSecureString.cs
@@ -9,10 +9,9 @@ namespace JetBrains.Rd.Impl
   /// </summary>
   public struct RdSecureString : IEquatable<RdSecureString>
   {
-    [NotNull]
     public readonly string Contents;
 
-    public RdSecureString([NotNull] string contents)
+    public RdSecureString(string contents)
     {
       Contents = contents;
     }

--- a/rd-net/RdFramework/Impl/RdSet.cs
+++ b/rd-net/RdFramework/Impl/RdSet.cs
@@ -11,13 +11,13 @@ using JetBrains.Serialization;
 
 namespace JetBrains.Rd.Impl
 {
-  public class RdSet<T> : RdReactiveBase, IViewableSet<T>
+  public class RdSet<T> : RdReactiveBase, IViewableSet<T> where T: notnull
   {
     private readonly IViewableSet<T> mySet;
 
     public RdSet() : this(Polymorphic<T>.Read, Polymorphic<T>.Write) {}
 
-    public RdSet(CtxReadDelegate<T> readValue, CtxWriteDelegate<T> writeValue, IViewableSet<T> backingSet)
+    public RdSet(CtxReadDelegate<T> readValue, CtxWriteDelegate<T> writeValue, IViewableSet<T>? backingSet)
     {
       ValueCanBeNull = false;
       ReadValueDelegate = readValue;

--- a/rd-net/RdFramework/Impl/RdSignal.cs
+++ b/rd-net/RdFramework/Impl/RdSignal.cs
@@ -38,7 +38,7 @@ namespace JetBrains.Rd.Impl
     
     public override IScheduler WireScheduler => Scheduler ?? DefaultScheduler;
 
-    public IScheduler Scheduler { get; set; }
+    public IScheduler? Scheduler { get; set; }
 
 
     public RdSignal() : this(Polymorphic<T>.Read, Polymorphic<T>.Write)

--- a/rd-net/RdFramework/Impl/RdSimpleDispatcher.cs
+++ b/rd-net/RdFramework/Impl/RdSimpleDispatcher.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using JetBrains.Annotations;
 using JetBrains.Collections.Viewable;
 using JetBrains.Diagnostics;
 using JetBrains.Lifetimes;
@@ -11,15 +10,15 @@ namespace JetBrains.Rd.Impl
   public class RdSimpleDispatcher : IScheduler
   {
     private readonly Lifetime myLifetime;
-    [NotNull] private readonly ILog myLogger;
-    private readonly string myId;
+    private readonly ILog myLogger;
+    private readonly string? myId;
 
     private readonly Queue<Action> myTasks = new Queue<Action>();
     private readonly AutoResetEvent myEvent = new AutoResetEvent(false);
 
     public TimeSpan? MessageTimeout = null;
 
-    public RdSimpleDispatcher(Lifetime lifetime, [NotNull] ILog logger, string id = null)
+    public RdSimpleDispatcher(Lifetime lifetime, ILog logger, string? id = null)
     {
       myLogger = logger;
       myId = id;
@@ -35,7 +34,7 @@ namespace JetBrains.Rd.Impl
     {
       while (myLifetime.IsAlive)
       {
-        Action nextTask = null;
+        Action? nextTask = null;
         lock (myTasks)
         {
           if (myTasks.Count > 0)

--- a/rd-net/RdFramework/Impl/SerializersEx.cs
+++ b/rd-net/RdFramework/Impl/SerializersEx.cs
@@ -9,7 +9,7 @@ namespace JetBrains.Rd.Impl
   public static class SerializersEx
   {
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public static List<T> ReadList<T>(this UnsafeReader reader, CtxReadDelegate<T> itemReader, SerializationCtx ctx)
+    public static List<T>? ReadList<T>(this UnsafeReader reader, CtxReadDelegate<T> itemReader, SerializationCtx ctx)
     {
       int count = reader.ReadInt32();
       if (count < 0) return null;
@@ -21,7 +21,7 @@ namespace JetBrains.Rd.Impl
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public static void WriteList<T>(this UnsafeWriter writer, CtxWriteDelegate<T> itemWriter, SerializationCtx ctx, List<T> value)
+    public static void WriteList<T>(this UnsafeWriter writer, CtxWriteDelegate<T> itemWriter, SerializationCtx ctx, List<T>? value)
     {
       if (value == null)
       {
@@ -59,7 +59,7 @@ namespace JetBrains.Rd.Impl
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public static T[] ReadArray<T>(this UnsafeReader reader, CtxReadDelegate<T> itemReader, SerializationCtx ctx)
+    public static T[]? ReadArray<T>(this UnsafeReader reader, CtxReadDelegate<T> itemReader, SerializationCtx ctx)
     {
       int count = reader.ReadInt32();
       if (count < 0) return null;
@@ -71,7 +71,7 @@ namespace JetBrains.Rd.Impl
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public static void WriteArray<T>(this UnsafeWriter writer, CtxWriteDelegate<T> itemWriter, SerializationCtx ctx, T[] value)
+    public static void WriteArray<T>(this UnsafeWriter writer, CtxWriteDelegate<T> itemWriter, SerializationCtx ctx, T[]? value)
     {
       if (value == null)
       {
@@ -89,7 +89,7 @@ namespace JetBrains.Rd.Impl
 
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public static T ReadNullableClass<T>(this UnsafeReader reader, CtxReadDelegate<T> itemReader, SerializationCtx ctx) where T:class
+    public static T? ReadNullableClass<T>(this UnsafeReader reader, CtxReadDelegate<T> itemReader, SerializationCtx ctx) where T:class
     {
       return reader.ReadNullness() ? itemReader(ctx, reader) : null;
     }
@@ -101,7 +101,7 @@ namespace JetBrains.Rd.Impl
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public static void WriteNullableClass<T>(this UnsafeWriter writer, CtxWriteDelegate<T> itemWriter, SerializationCtx ctx, T value) where T:class
+    public static void WriteNullableClass<T>(this UnsafeWriter writer, CtxWriteDelegate<T> itemWriter, SerializationCtx ctx, T? value) where T:class
     {
       if (writer.WriteNullness(value)) itemWriter(ctx, writer, value);
     }
@@ -115,7 +115,9 @@ namespace JetBrains.Rd.Impl
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public static RdSecureString ReadSecureString(this UnsafeReader reader)
     {
-      return new RdSecureString(reader.ReadString());
+      var str = reader.ReadString();
+      if (str == null) return default;
+      return new RdSecureString(str);
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
@@ -145,17 +147,17 @@ namespace JetBrains.Rd.Impl
     // Composition functors
 
     //Readers
-    public static CtxReadDelegate<T[]> Array<T>(this CtxReadDelegate<T> inner)
+    public static CtxReadDelegate<T[]?> Array<T>(this CtxReadDelegate<T> inner)
     {
       return (ctx, reader) => reader.ReadArray(inner, ctx);
     }
 
-    public static CtxReadDelegate<List<T>> List<T>(this CtxReadDelegate<T> inner)
+    public static CtxReadDelegate<List<T>?> List<T>(this CtxReadDelegate<T> inner)
     {
       return (ctx, reader) => reader.ReadList(inner, ctx);
     }
 
-    public static CtxReadDelegate<T> NullableClass<T>(this CtxReadDelegate<T> inner) where T : class
+    public static CtxReadDelegate<T?> NullableClass<T>(this CtxReadDelegate<T> inner) where T : class
     {
       return (ctx, reader) => reader.ReadNullableClass(inner, ctx);
     }
@@ -182,7 +184,7 @@ namespace JetBrains.Rd.Impl
       return (ctx, reader, value) => reader.WriteList(inner, ctx, value);
     }
 
-    public static CtxWriteDelegate<T> NullableClass<T>(this CtxWriteDelegate<T> inner) where T:class
+    public static CtxWriteDelegate<T?> NullableClass<T>(this CtxWriteDelegate<T> inner) where T:class
     {
       return (ctx, reader, value) => reader.WriteNullableClass(inner, ctx, value);
     }

--- a/rd-net/RdFramework/Impl/StealingScheduler.cs
+++ b/rd-net/RdFramework/Impl/StealingScheduler.cs
@@ -13,14 +13,14 @@ namespace JetBrains.Rd.Impl
   public class StealingScheduler : TaskScheduler
   {
     private readonly bool myAllowParallelJoin;
-    [NotNull] private readonly TaskScheduler myScheduler;
+    private readonly TaskScheduler myScheduler;
 
     /// <summary>
     /// >0: The number of currently simultaneously running tasks.
     /// -1: exclusive mode taken by Join when <see cref="myAllowParallelJoin"/> is false, no tasks allowed to process 
     /// </summary>
     private volatile int myActive;
-    [NotNull] private readonly ConcurrentQueue<Task> myActions = new ConcurrentQueue<Task>();
+    private readonly ConcurrentQueue<Task> myActions = new ConcurrentQueue<Task>();
 
     /// <summary>
     /// Creates stealing scheduler
@@ -30,7 +30,7 @@ namespace JetBrains.Rd.Impl
     /// Indicates whether is it safe to execute tasks simultaneously in <see cref="Join"/> method and provided scheduler.
     /// Note, that this is your responsibility to provide limited concurrency scheduler when concurrent processing is forbidden.
     /// </param>
-    public StealingScheduler([CanBeNull] TaskScheduler scheduler, bool allowParallelJoin = true)
+    public StealingScheduler(TaskScheduler? scheduler, bool allowParallelJoin = true)
     {
       myAllowParallelJoin = allowParallelJoin;
       myScheduler = scheduler ?? Default;

--- a/rd-net/RdFramework/Impl/WebSocketSharp/HttpHeaders.cs
+++ b/rd-net/RdFramework/Impl/WebSocketSharp/HttpHeaders.cs
@@ -32,6 +32,8 @@ using System.Text;
 using System.Threading;
 using JetBrains.Diagnostics;
 
+#nullable disable
+
 namespace JetBrains.Rd.Impl.WebSocketSharp
 {
   internal static class HttpHeaders

--- a/rd-net/RdFramework/Impl/WebSocketSharp/WebSocketException.cs
+++ b/rd-net/RdFramework/Impl/WebSocketSharp/WebSocketException.cs
@@ -25,7 +25,7 @@
  */
 
 using System;
-
+#nullable disable
 namespace JetBrains.Rd.Impl.WebSocketSharp
 {
   /// <summary>

--- a/rd-net/RdFramework/Impl/WebSocketSharp/WebSocketFrameHeader.cs
+++ b/rd-net/RdFramework/Impl/WebSocketSharp/WebSocketFrameHeader.cs
@@ -28,7 +28,7 @@
  * Contributors:
  * - Chris Swiedler
  */
-
+#nullable disable
 using System.Security.Cryptography;
 using JetBrains.Serialization;
 

--- a/rd-net/RdFramework/RdContext.cs
+++ b/rd-net/RdFramework/RdContext.cs
@@ -5,6 +5,8 @@ using JetBrains.Annotations;
 using JetBrains.Rd.Impl;
 using JetBrains.Serialization;
 
+#nullable disable
+
 namespace JetBrains.Rd
 {
   public abstract class RdContextBase : IEquatable<RdContextBase>

--- a/rd-net/RdFramework/RdFramework.csproj
+++ b/rd-net/RdFramework/RdFramework.csproj
@@ -15,7 +15,6 @@
         <Configurations>Debug;Release;CrossTests</Configurations>
         
         <Platforms>AnyCPU</Platforms>
-        <Nullable>enable</Nullable>
     </PropertyGroup>
 
 

--- a/rd-net/RdFramework/RdFramework.csproj
+++ b/rd-net/RdFramework/RdFramework.csproj
@@ -15,6 +15,7 @@
         <Configurations>Debug;Release;CrossTests</Configurations>
         
         <Platforms>AnyCPU</Platforms>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
 

--- a/rd-net/RdFramework/RdId.cs
+++ b/rd-net/RdFramework/RdId.cs
@@ -56,7 +56,7 @@ namespace JetBrains.Rd
       return new RdId(myValue * 31 + (tail + 1));
     }
 
-    public static long Hash(string s, long initValue = 19)
+    public static long Hash(string? s, long initValue = 19)
     {
       if (s == null) return 0;
 
@@ -82,7 +82,7 @@ namespace JetBrains.Rd
       return myValue == other.myValue;
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
       if (ReferenceEquals(null, obj)) return false;
       return obj is RdId && Equals((RdId) obj);

--- a/rd-net/RdFramework/SerializationCtx.cs
+++ b/rd-net/RdFramework/SerializationCtx.cs
@@ -4,6 +4,8 @@ using JetBrains.Rd.Base;
 using JetBrains.Rd.Impl;
 using JetBrains.Serialization;
 
+#nullable disable
+
 namespace JetBrains.Rd
 {
   public struct SerializationCtx

--- a/rd-net/RdFramework/Tasks/Interfaces.cs
+++ b/rd-net/RdFramework/Tasks/Interfaces.cs
@@ -14,15 +14,15 @@ namespace JetBrains.Rd.Tasks
   
   public interface IRdEndpoint<TReq, TRes>
   {
-    void Set(Func<Lifetime, TReq, RdTask<TRes>> handler, IScheduler cancellationScheduler = null, IScheduler handlerScheduler = null);
+    void Set(Func<Lifetime, TReq, RdTask<TRes>> handler, IScheduler? cancellationScheduler = null, IScheduler? handlerScheduler = null);
   }
 
   public interface IRdCall<in TReq, TRes>
   {
-    TRes Sync(TReq request, RpcTimeouts timeouts = null);
+    TRes Sync(TReq request, RpcTimeouts? timeouts = null);
     
     [Obsolete("Use overload with Lifetime")]
-    IRdTask<TRes> Start(TReq request, IScheduler responseScheduler = null);
-    IRdTask<TRes> Start(Lifetime lifetime, TReq request, IScheduler responseScheduler = null);
+    IRdTask<TRes> Start(TReq request, IScheduler? responseScheduler = null);
+    IRdTask<TRes> Start(Lifetime lifetime, TReq request, IScheduler? responseScheduler = null);
   }
 }

--- a/rd-net/RdFramework/Tasks/RdCall.cs
+++ b/rd-net/RdFramework/Tasks/RdCall.cs
@@ -28,15 +28,15 @@ namespace JetBrains.Rd.Tasks
     internal new SerializationCtx SerializationContext;
 
     //set via Set method
-    [PublicAPI] public Func<Lifetime, TReq, RdTask<TRes>> Handler { get; private set; }
+    [PublicAPI] public Func<Lifetime, TReq, RdTask<TRes>>? Handler { get; private set; }
 
 
 
 
 
     private Lifetime myBindLifetime;
-    private IScheduler myCancellationScheduler;
-    private IScheduler myHandlerScheduler;
+    private IScheduler? myCancellationScheduler;
+    private IScheduler? myHandlerScheduler;
 
     public override IScheduler WireScheduler => myHandlerScheduler ?? base.WireScheduler;
 
@@ -67,7 +67,7 @@ namespace JetBrains.Rd.Tasks
 
 
     [PublicAPI]
-    public void Set(Func<Lifetime, TReq, RdTask<TRes>> handler, IScheduler cancellationScheduler = null, IScheduler handlerScheduler = null)
+    public void Set(Func<Lifetime, TReq, RdTask<TRes>> handler, IScheduler? cancellationScheduler = null, IScheduler? handlerScheduler = null)
     {
       Handler = handler;
       myCancellationScheduler = cancellationScheduler;
@@ -133,7 +133,7 @@ namespace JetBrains.Rd.Tasks
     }
     
 
-    public TRes Sync(TReq request, RpcTimeouts timeouts = null)
+    public TRes Sync(TReq request, RpcTimeouts? timeouts = null)
     {
       AssertBound();
       if (!Async) AssertThreading();
@@ -161,14 +161,14 @@ namespace JetBrains.Rd.Tasks
     }
 
 
-    public IRdTask<TRes> Start(TReq request, IScheduler responseScheduler = null)
+    public IRdTask<TRes> Start(TReq request, IScheduler? responseScheduler = null)
       => StartInternal(Lifetime.Eternal, request, responseScheduler ?? Proto.Scheduler);
 
-    public IRdTask<TRes> Start(Lifetime lifetime, TReq request, IScheduler responseScheduler = null)
+    public IRdTask<TRes> Start(Lifetime lifetime, TReq request, IScheduler? responseScheduler = null)
       => StartInternal(lifetime, request, responseScheduler ?? Proto.Scheduler);
 
 
-    private IRdTask<TRes> StartInternal(Lifetime requestLifetime, TReq request, [NotNull] IScheduler scheduler)
+    private IRdTask<TRes> StartInternal(Lifetime requestLifetime, TReq request, IScheduler scheduler)
     {
       AssertBound();
       if (!Async) AssertThreading();

--- a/rd-net/RdFramework/Tasks/RdFault.cs
+++ b/rd-net/RdFramework/Tasks/RdFault.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using JetBrains.Annotations;
+using JetBrains.Diagnostics;
 using JetBrains.Serialization;
 
 namespace JetBrains.Rd.Tasks
@@ -12,7 +13,7 @@ namespace JetBrains.Rd.Tasks
     public string ReasonText { get; private set; }
     public string ReasonMessage { get; private set; }
 
-    public RdFault([NotNull] Exception inner) : base(inner.Message, inner)
+    public RdFault(Exception inner) : base(inner.Message, inner)
     {
       ReasonTypeFqn = inner.GetType().FullName;
       ReasonMessage = inner.Message;
@@ -21,7 +22,7 @@ namespace JetBrains.Rd.Tasks
 
     
     
-    public RdFault([NotNull] string reasonTypeFqn, [NotNull] string reasonMessage, [NotNull] string reasonText, Exception reason = null) 
+    public RdFault(string reasonTypeFqn, string reasonMessage, string reasonText, Exception? reason = null) 
       : base(reasonMessage + (reason == null ? ", reason: " + reasonText : ""), reason)
     {
       ReasonTypeFqn = reasonTypeFqn;
@@ -32,9 +33,9 @@ namespace JetBrains.Rd.Tasks
     
     public static RdFault Read(SerializationCtx ctx, UnsafeReader reader)
     {
-      var typeFqn = reader.ReadString();
-      var message = reader.ReadString();
-      var body = reader.ReadString();
+      var typeFqn = reader.ReadString().NotNull("typeFqn");
+      var message = reader.ReadString().NotNull("message");
+      var body = reader.ReadString().NotNull("body");
       
       return new RdFault(typeFqn, message, body);
     }

--- a/rd-net/RdFramework/Tasks/RdTaskEx.cs
+++ b/rd-net/RdFramework/Tasks/RdTaskEx.cs
@@ -26,7 +26,7 @@ namespace JetBrains.Rd.Tasks
         if (t.IsOperationCanceled())
           res.SetCancelled();
         else if (t.IsFaulted)
-          res.Set(t.Exception?.Flatten().GetBaseException());
+          res.Set(t.Exception?.Flatten().GetBaseException() ?? new Exception("Unknown exception"));
         else
           res.Set(t.Result);
       }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Current);
@@ -41,7 +41,7 @@ namespace JetBrains.Rd.Tasks
         if (t.IsOperationCanceled())
           res.SetCancelled();
         else if (t.IsFaulted)
-          res.Set(t.Exception?.Flatten().GetBaseException());
+          res.Set(t.Exception?.Flatten().GetBaseException() ?? new Exception("Unknown exception"));
         else
           res.Set(Unit.Instance);
       }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Current);
@@ -49,22 +49,22 @@ namespace JetBrains.Rd.Tasks
     }
 
 
-    [PublicAPI] public static void Set<TReq, TRes>(this IRdEndpoint<TReq, TRes> endpoint, Func<Lifetime, TReq, Task<TRes>> handler, IScheduler cancellationScheduler = null, IScheduler handlerScheduler = null)
+    [PublicAPI] public static void Set<TReq, TRes>(this IRdEndpoint<TReq, TRes> endpoint, Func<Lifetime, TReq, Task<TRes>> handler, IScheduler? cancellationScheduler = null, IScheduler? handlerScheduler = null)
     {
       endpoint.Set((lt, req) => handler(lt, req).ToRdTask(), cancellationScheduler, handlerScheduler);
     }
     
-    [PublicAPI] public static void Set<TReq, TRes>(this IRdEndpoint<TReq, TRes> endpoint, Func<Lifetime, TReq, TRes> handler, IScheduler cancellationScheduler = null, IScheduler handlerScheduler = null)
+    [PublicAPI] public static void Set<TReq, TRes>(this IRdEndpoint<TReq, TRes> endpoint, Func<Lifetime, TReq, TRes> handler, IScheduler? cancellationScheduler = null, IScheduler? handlerScheduler = null)
     {
       endpoint.Set((lifetime, req) => RdTask<TRes>.Successful(handler(lifetime, req)), cancellationScheduler, handlerScheduler);
     }
     
-    [PublicAPI] public static void Set<TReq, TRes>(this IRdEndpoint<TReq, TRes> endpoint, Func<TReq, TRes> handler, IScheduler cancellationScheduler = null, IScheduler handlerScheduler = null)
+    [PublicAPI] public static void Set<TReq, TRes>(this IRdEndpoint<TReq, TRes> endpoint, Func<TReq, TRes> handler, IScheduler? cancellationScheduler = null, IScheduler? handlerScheduler = null)
     {
       endpoint.Set((_, req) => RdTask<TRes>.Successful(handler(req)), cancellationScheduler, handlerScheduler);
     }
     
-    [PublicAPI] public static void SetVoid<TReq>(this IRdEndpoint<TReq, Unit> endpoint, Action<TReq> handler, IScheduler cancellationScheduler = null, IScheduler handlerScheduler = null)
+    [PublicAPI] public static void SetVoid<TReq>(this IRdEndpoint<TReq, Unit> endpoint, Action<TReq> handler, IScheduler? cancellationScheduler = null, IScheduler? handlerScheduler = null)
     {
       endpoint.Set(req =>
       {
@@ -74,7 +74,7 @@ namespace JetBrains.Rd.Tasks
     }
     
     [PublicAPI]
-    public static Task<T> AsTask<T>([NotNull] this IRdTask<T> task)
+    public static Task<T> AsTask<T>(this IRdTask<T> task)
     {
       if (task == null) throw new ArgumentNullException(nameof(task));
       var tcs = new TaskCompletionSource<T>();

--- a/rd-net/RdFramework/Tasks/RdTaskResult.cs
+++ b/rd-net/RdFramework/Tasks/RdTaskResult.cs
@@ -3,6 +3,8 @@ using JetBrains.Rd.Base;
 using JetBrains.Rd.Util;
 using JetBrains.Serialization;
 
+#nullable disable
+
 namespace JetBrains.Rd.Tasks
 {
   //todo Union with Result

--- a/rd-net/RdFramework/Tasks/RpcTimeouts.cs
+++ b/rd-net/RdFramework/Tasks/RpcTimeouts.cs
@@ -68,8 +68,7 @@ namespace JetBrains.Rd.Tasks
     /// <summary>
     /// Returns a mix of optionally provided timeouts and default one.
     /// </summary>
-    [NotNull]
-    public static RpcTimeouts GetRpcTimeouts([CanBeNull] RpcTimeouts timeouts)
+    public static RpcTimeouts GetRpcTimeouts(RpcTimeouts? timeouts)
     {
       RpcTimeouts timeoutsToUse;
       if (RespectRpcTimeouts)

--- a/rd-net/RdFramework/Tasks/WiredRdTask.cs
+++ b/rd-net/RdFramework/Tasks/WiredRdTask.cs
@@ -33,7 +33,7 @@ namespace JetBrains.Rd.Tasks
     //received response from wire
     public abstract void OnWireReceived(UnsafeReader reader);
 
-    protected void Trace(ILog log, string message, object additional = null)
+    protected void Trace(ILog log, string message, object? additional = null)
     {
       if (!log.IsTraceEnabled())
         return;

--- a/rd-net/RdFramework/Text/Impl/Intrinsics/RdAssertion.cs
+++ b/rd-net/RdFramework/Text/Impl/Intrinsics/RdAssertion.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using JetBrains.Annotations;
+using JetBrains.Diagnostics;
 using JetBrains.Rd.Base;
 using JetBrains.Rd.Util;
 
@@ -10,14 +11,14 @@ namespace JetBrains.Rd.Text.Impl.Intrinsics
     //public fields
     public int MasterVersion {get; private set;}
     public int SlaveVersion {get; private set;}
-    [NotNull] public string Text {get; private set;}
+    public string Text {get; private set;}
     
     //private fields
     //primary constructor
     public RdAssertion(
       int masterVersion,
       int slaveVersion,
-      [NotNull] string text
+      string text
     )
     {
       if (text == null) throw new ArgumentNullException("text");
@@ -33,7 +34,7 @@ namespace JetBrains.Rd.Text.Impl.Intrinsics
     {
       var masterVersion = reader.ReadInt();
       var slaveVersion = reader.ReadInt();
-      var text = reader.ReadString();
+      var text = reader.ReadString().NotNull("text");
       return new RdAssertion(masterVersion, slaveVersion, text);
     };
     
@@ -45,14 +46,14 @@ namespace JetBrains.Rd.Text.Impl.Intrinsics
     };
     //custom body
     //equals trait
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
       if (ReferenceEquals(null, obj)) return false;
       if (ReferenceEquals(this, obj)) return true;
       if (obj.GetType() != GetType()) return false;
       return Equals((RdAssertion) obj);
     }
-    public bool Equals(RdAssertion other)
+    public bool Equals(RdAssertion? other)
     {
       if (ReferenceEquals(null, other)) return false;
       if (ReferenceEquals(this, other)) return true;

--- a/rd-net/RdFramework/Text/Impl/Intrinsics/RdTextBufferState.cs
+++ b/rd-net/RdFramework/Text/Impl/Intrinsics/RdTextBufferState.cs
@@ -13,23 +13,23 @@ namespace JetBrains.Rd.Text.Impl.Intrinsics
   {
     //fields
     //public fields
-    [NotNull] public IViewableProperty<RdTextBufferChange> Changes { get { return _Changes; }}
-    [NotNull] public IViewableProperty<TextBufferVersion> VersionBeforeTypingSession { get { return _VersionBeforeTypingSession; }}
-    [NotNull] public IViewableProperty<RdAssertion> AssertedMasterText { get { return _AssertedMasterText; }}
-    [NotNull] public IViewableProperty<RdAssertion> AssertedSlaveText { get { return _AssertedSlaveText; }}
+    public IViewableProperty<RdTextBufferChange?> Changes { get { return _Changes; }}
+    public IViewableProperty<TextBufferVersion> VersionBeforeTypingSession { get { return _VersionBeforeTypingSession; }}
+    public IViewableProperty<RdAssertion> AssertedMasterText { get { return _AssertedMasterText; }}
+    public IViewableProperty<RdAssertion> AssertedSlaveText { get { return _AssertedSlaveText; }}
 
     //private fields
-    [NotNull] private readonly RdProperty<RdTextBufferChange> _Changes;
-    [NotNull] private readonly RdProperty<TextBufferVersion> _VersionBeforeTypingSession;
-    [NotNull] private readonly RdProperty<RdAssertion> _AssertedMasterText;
-    [NotNull] private readonly RdProperty<RdAssertion> _AssertedSlaveText;
+    private readonly RdProperty<RdTextBufferChange?> _Changes;
+    private readonly RdProperty<TextBufferVersion> _VersionBeforeTypingSession;
+    private readonly RdProperty<RdAssertion> _AssertedMasterText;
+    private readonly RdProperty<RdAssertion> _AssertedSlaveText;
 
     //primary constructor
     private RdTextBufferState(
-      [NotNull] RdProperty<RdTextBufferChange> changes,
-      [NotNull] RdProperty<TextBufferVersion> versionBeforeTypingSession,
-      [NotNull] RdProperty<RdAssertion> assertedMasterText,
-      [NotNull] RdProperty<RdAssertion> assertedSlaveText
+      RdProperty<RdTextBufferChange?> changes,
+      RdProperty<TextBufferVersion> versionBeforeTypingSession,
+      RdProperty<RdAssertion> assertedMasterText,
+      RdProperty<RdAssertion> assertedSlaveText
     )
     {
       if (changes == null) throw new ArgumentNullException("changes");
@@ -54,33 +54,36 @@ namespace JetBrains.Rd.Text.Impl.Intrinsics
     //secondary constructor
     public RdTextBufferState (
     ) : this (
-      new RdProperty<RdTextBufferChange>(ReadRdTextBufferChangeNullable, WriteRdTextBufferChangeNullable),
+      new RdProperty<RdTextBufferChange?>(ReadRdTextBufferChangeNullable, WriteRdTextBufferChangeNullable),
       new RdProperty<TextBufferVersion>(TextBufferVersionSerializer.ReadDelegate, TextBufferVersionSerializer.WriteDelegate),
       new RdProperty<RdAssertion>(RdAssertion.Read, RdAssertion.Write),
       new RdProperty<RdAssertion>(RdAssertion.Read, RdAssertion.Write)
     ) {}
     //statics
 
+    public static CtxReadDelegate<RdTextBufferChange?> ReadRdTextBufferChangeNullable = RdTextBufferChange.ReadDelegate.NullableClass();
+    public static CtxWriteDelegate<RdTextBufferChange?> WriteRdTextBufferChangeNullable = RdTextBufferChange.WriteDelegate.NullableClass();
+
     public static CtxReadDelegate<RdTextBufferState> Read = (ctx, reader) =>
     {
       var _id = RdId.Read(reader);
-      var changes = RdProperty<RdTextBufferChange>.Read(ctx, reader, ReadRdTextBufferChangeNullable, WriteRdTextBufferChangeNullable);
+      var writeRdTextBufferChangeNullable = WriteRdTextBufferChangeNullable;
+      var changes = RdProperty<RdTextBufferChange?>.Read(ctx, reader, ReadRdTextBufferChangeNullable!, writeRdTextBufferChangeNullable);
       var versionBeforeTypingSession = RdProperty<TextBufferVersion>.Read(ctx, reader, TextBufferVersionSerializer.ReadDelegate, TextBufferVersionSerializer.WriteDelegate);
       var assertedMasterText = RdProperty<RdAssertion>.Read(ctx, reader, RdAssertion.Read, RdAssertion.Write);
       var assertedSlaveText = RdProperty<RdAssertion>.Read(ctx, reader, RdAssertion.Read, RdAssertion.Write);
       return new RdTextBufferState(changes, versionBeforeTypingSession, assertedMasterText, assertedSlaveText).WithId(_id);
     };
-    public static CtxReadDelegate<RdTextBufferChange> ReadRdTextBufferChangeNullable = RdTextBufferChange.ReadDelegate.NullableClass();
 
     public static CtxWriteDelegate<RdTextBufferState> Write = (ctx, writer, value) =>
     {
       value.RdId.Write(writer);
-      RdProperty<RdTextBufferChange>.Write(ctx, writer, value._Changes);
+      RdProperty<RdTextBufferChange?>.Write(ctx, writer, value._Changes);
       RdProperty<TextBufferVersion>.Write(ctx, writer, value._VersionBeforeTypingSession);
       RdProperty<RdAssertion>.Write(ctx, writer, value._AssertedMasterText);
       RdProperty<RdAssertion>.Write(ctx, writer, value._AssertedSlaveText);
     };
-    public static CtxWriteDelegate<RdTextBufferChange> WriteRdTextBufferChangeNullable = RdTextBufferChange.WriteDelegate.NullableClass();
+
     //custom body
     //equals trait
     //hash code trait

--- a/rd-net/RdFramework/Text/Impl/RdTextBuffer.cs
+++ b/rd-net/RdFramework/Text/Impl/RdTextBuffer.cs
@@ -21,8 +21,7 @@ namespace JetBrains.Rd.Text.Impl
     private readonly List<RdTextBufferChange> myChangesToConfirmOrRollback;
     private readonly IViewableProperty<RdTextChange> myTextChanged;
 
-    [CanBeNull]
-    private TextBufferTypingSession myActiveSession;
+    private TextBufferTypingSession? myActiveSession;
 
     public bool IsCommitting => myActiveSession != null && myActiveSession.IsCommitting;
 
@@ -140,7 +139,7 @@ namespace JetBrains.Rd.Text.Impl
       myChangesToConfirmOrRollback.Clear();
     }
 
-    public IScheduler Scheduler { get; set; }
+    public IScheduler? Scheduler { get; set; }
 
     public void Fire(RdTextChange change)
     {

--- a/rd-net/RdFramework/Text/Intrinsics/RdTextChange.cs
+++ b/rd-net/RdFramework/Text/Intrinsics/RdTextChange.cs
@@ -21,9 +21,9 @@ namespace JetBrains.Rd.Text.Intrinsics
     public readonly int FullTextLength;
     public readonly RdTextChangeKind Kind;
 
-    [NotNull] public readonly string New;
+    public readonly string New;
 
-    [NotNull] public readonly string Old;
+    public readonly string Old;
 
     public readonly int StartOffset;
 

--- a/rd-net/RdFramework/Text/Intrinsics/RdTextChangeSerializer.cs
+++ b/rd-net/RdFramework/Text/Intrinsics/RdTextChangeSerializer.cs
@@ -1,3 +1,5 @@
+using JetBrains.Diagnostics;
+
 namespace JetBrains.Rd.Text.Intrinsics
 {
   public static class RdTextChangeSerializer
@@ -6,8 +8,8 @@ namespace JetBrains.Rd.Text.Intrinsics
     {
       var kind = (RdTextChangeKind)stream.ReadInt();
       var startOffset = stream.ReadInt();
-      var oldText = stream.ReadString();
-      var newText = stream.ReadString();
+      var oldText = stream.ReadString().NotNull("oldText");
+      var newText = stream.ReadString().NotNull("newText");
       var fullTextLength = stream.ReadInt();
       return new RdTextChange(kind, startOffset, oldText, newText, fullTextLength);
     };

--- a/rd-net/RdFramework/Util/DictionaryEx.cs
+++ b/rd-net/RdFramework/Util/DictionaryEx.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using JetBrains.Diagnostics;
 using JetBrains.Lifetimes;
@@ -9,8 +10,8 @@ namespace JetBrains.Rd.Util
   static class DictionaryEx
   {
     [Pure]
-    internal static TValue GetOrDefault<TKey, TValue>(
-      [NotNull] this Dictionary<TKey, TValue> dictionary, [NotNull] TKey key, TValue @default = default(TValue))
+    internal static TValue? GetOrDefault<TKey, TValue>(
+      this Dictionary<TKey, TValue> dictionary, [DisallowNull] TKey key, TValue? @default = default(TValue))
     {
       if (dictionary == null) throw new ArgumentNullException(nameof(dictionary));
 
@@ -20,7 +21,7 @@ namespace JetBrains.Rd.Util
     
     [MustUseReturnValue]
     internal static TValue GetOrCreate<TKey, TValue>(
-      [NotNull] this IDictionary<TKey, TValue> dictionary, [NotNull] TKey key, [InstantHandle, NotNull] Func<TValue> factory)
+      this IDictionary<TKey, TValue> dictionary, [DisallowNull] TKey key, [InstantHandle] Func<TValue> factory)
     {
       if (dictionary == null) throw new ArgumentNullException(nameof(dictionary));
       if (factory == null) throw new ArgumentNullException(nameof(factory));
@@ -31,8 +32,8 @@ namespace JetBrains.Rd.Util
     }
 
     public static void BlockingAddUnique<TKey, TValue>(
-      [NotNull] this IDictionary<TKey, TValue> dictionary, Lifetime lifetime, [NotNull] object @lock, TKey key,
-      TValue value)
+      this IDictionary<TKey, TValue> dictionary, Lifetime lifetime, object @lock, TKey key,
+      TValue value) where TKey: notnull
     {
 
       lifetime.TryBracket(() =>

--- a/rd-net/RdFramework/Util/PrettyPrinter.cs
+++ b/rd-net/RdFramework/Util/PrettyPrinter.cs
@@ -102,8 +102,7 @@ namespace JetBrains.Rd.Util
 
   public static class PrintableEx
   {
-    [NotNull]
-    public static string PrintToString([CanBeNull] this IPrintable printable, int? collectionMaxLength = null)
+    public static string PrintToString(this IPrintable? printable, int? collectionMaxLength = null)
     {
       if (printable == null)
       {

--- a/rd-net/Test.Cross/Test.Cross.csproj
+++ b/rd-net/Test.Cross/Test.Cross.csproj
@@ -7,6 +7,7 @@
         <Configurations>CrossTests</Configurations>
         <Platforms>AnyCPU</Platforms>
         <OutputType>Exe</OutputType>
+        <Nullable>disable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/rd-net/Test.Lifetimes/Test.Lifetimes.csproj
+++ b/rd-net/Test.Lifetimes/Test.Lifetimes.csproj
@@ -9,6 +9,7 @@
         <Configurations>Debug;Release;CrossTests</Configurations>
         <Platforms>AnyCPU</Platforms>
         <RollForward>LatestMajor</RollForward>
+        <Nullable>disable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/rd-net/Test.Lifetimes/Test.Lifetimes.csproj
+++ b/rd-net/Test.Lifetimes/Test.Lifetimes.csproj
@@ -8,7 +8,6 @@
         <RootNamespace>Test.Lifetimes</RootNamespace>
         <Configurations>Debug;Release;CrossTests</Configurations>
         <Platforms>AnyCPU</Platforms>
-        <LangVersion>8</LangVersion>
         <RollForward>LatestMajor</RollForward>
     </PropertyGroup>
 

--- a/rd-net/Test.RdFramework/Test.RdFramework.csproj
+++ b/rd-net/Test.RdFramework/Test.RdFramework.csproj
@@ -9,6 +9,7 @@
         <Platforms>AnyCPU</Platforms>
         <RollForward>LatestMajor</RollForward>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <Nullable>disable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/rd-net/Test.Reflection.App/Test.Reflection.App.csproj
+++ b/rd-net/Test.Reflection.App/Test.Reflection.App.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net461</TargetFramework>
     <IsPackable>false</IsPackable>
     <RollForward>LatestMajor</RollForward>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/rd-net/global.json
+++ b/rd-net/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.0",
+    "version": "5.0",
     "rollForward": "major"
   }
 }


### PR DESCRIPTION
Nullable references types are enabled and warnings are eliminated in Lifetimes, RdFramework, RdFramework.Reflection projects
Except for a few places (like SerializationCtx, InternRoot, ByteBufferAsyncProcessor) the process went smoothly.

Also, third party licenses are ordered and collected in common place (thrid party notice)