### PR TITLE
rd-gen: support defaults for attributed strings

### DIFF
--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/Functions.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/Functions.kt
@@ -9,7 +9,6 @@ import com.jetbrains.rd.generator.nova.Member.Reactive.Stateful.Map
 import com.jetbrains.rd.generator.nova.Member.Reactive.Stateful.Set
 import com.jetbrains.rd.generator.nova.Member.Reactive.Task
 import com.jetbrains.rd.util.PublicApi
-import java.lang.IllegalArgumentException
 
 val ProtocolInternScope = InternScope(null, "Protocol")
 
@@ -72,6 +71,7 @@ fun BindableDeclaration.property(name: String, defaultValue: Boolean) = append(P
 fun BindableDeclaration.property(name: String, defaultValue: Int) = append(Property(name, PredefinedType.int, defaultValue))
 fun BindableDeclaration.property(name: String, defaultValue: Double) = append(Property(name, PredefinedType.double, defaultValue))
 fun BindableDeclaration.property(name: String, defaultValue: String) = append(Property(name, PredefinedType.string, defaultValue))
+fun BindableDeclaration.property(name: String, valueType: ScalarAttributedType<PredefinedType.string>, defaultValue: String) = append(Property(name, valueType, defaultValue))
 fun BindableDeclaration.property(name: String, defaultValue: Member.Const) = append(Property(name, PredefinedType.string, defaultValue))
 fun BindableDeclaration.property(name: String, defaultValue: Member.Const, vararg attributes: KnownAttrs) =
     append(Property(name, PredefinedType.string.attrs(*attributes), defaultValue))
@@ -146,9 +146,9 @@ fun <T> T.attrs(vararg attributes: KnownAttrs): ScalarAttributedType<T> where T 
     return ScalarAttributedType(this, attrs)
 }
 
-val nlsString: ScalarAttributedType<PredefinedType> get() = PredefinedType.string.attrs(KnownAttrs.Nls)
-val nonNlsString: ScalarAttributedType<PredefinedType> get() = PredefinedType.string.attrs(KnownAttrs.NonNls)
-val nlsSafeString: ScalarAttributedType<PredefinedType> get() = PredefinedType.string.attrs(KnownAttrs.NlsSafe)
+val nlsString: ScalarAttributedType<PredefinedType.string> get() = PredefinedType.string.attrs(KnownAttrs.Nls)
+val nonNlsString: ScalarAttributedType<PredefinedType.string> get() = PredefinedType.string.attrs(KnownAttrs.NonNls)
+val nlsSafeString: ScalarAttributedType<PredefinedType.string> get() = PredefinedType.string.attrs(KnownAttrs.NlsSafe)
 
 /**
  * Marks this key a light key. Light keys don't maintain a value set and send values un-interned.

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/Members.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/Members.kt
@@ -147,11 +147,15 @@ fun Member.Field.default(value: Long) : Member.Field {
 }
 
 fun Member.Field.default(value: String) : Member.Field {
-    if (type !== PredefinedType.string && type !is Enum) {
-        throw GeneratorException("Default value string does not match field type")
+    if (type === PredefinedType.string
+        || (type is ScalarAttributedType<*> && type.itemType === PredefinedType.string)
+        || type is Enum
+    ) {
+        defaultValue = value
+        return this
     }
-    defaultValue = value
-    return this
+
+    throw GeneratorException("Default value string does not match field type")
 }
 
 fun Member.Field.default(value: Boolean) : Member.Field {

--- a/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/kotlin/DefaultNlsValuesTest.kt
+++ b/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/test/cases/generator/kotlin/DefaultNlsValuesTest.kt
@@ -1,0 +1,23 @@
+package com.jetbrains.rd.generator.test.cases.generator.kotlin
+
+import com.jetbrains.rd.generator.nova.*
+import com.jetbrains.rd.generator.testframework.KotlinRdGenOutputTest
+import org.junit.jupiter.api.Test
+
+class DefaultNlsValuesTest : KotlinRdGenOutputTest() {
+    companion object {
+        private const val testName = "defaultNlsValues"
+    }
+
+    override val testName = Companion.testName
+
+    object DefaultNlsValuesRoot : Root(*generators(testName, "DefaultNlsValuesRoot")) {
+        val classModel = classdef {
+            field("fff", nlsString).default("123")
+            property("ppp", nlsString, "123")
+        }
+    }
+
+    @Test
+    fun test1() = doTest<DefaultNlsValuesRoot>(DefaultNlsValuesRoot::class.java)
+}

--- a/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/testframework/CSharpRdGenOutputTest.kt
+++ b/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/testframework/CSharpRdGenOutputTest.kt
@@ -3,65 +3,24 @@ package com.jetbrains.rd.generator.testframework
 import com.jetbrains.rd.generator.nova.FlowTransform
 import com.jetbrains.rd.generator.nova.IGenerator
 import com.jetbrains.rd.generator.nova.csharp.CSharp50Generator
-import com.jetbrains.rd.generator.nova.generateRdModel
-import com.jetbrains.rd.generator.nova.kotlin.Kotlin11Generator
-import com.jetbrains.rd.util.reflection.toPath
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.BeforeEach
 import java.io.File
-import java.nio.file.Paths
 
-abstract class CSharpRdGenOutputTest {
+abstract class CSharpRdGenOutputTest : RdGenOutputTestBase() {
     companion object {
         protected fun csGeneratedSourcesDir(testName: String) = "build/$testName/testOutputCs/"
         private fun csAsIsGeneratedSourcesDir(testName: String) = "${csGeneratedSourcesDir(testName)}/asis"
         private fun csReversedGeneratedSourcesDir(testName: String) = "${csGeneratedSourcesDir(testName)}/reversed"
-        private fun ktReversedGeneratedSourcesDir(testName: String) = "build/$testName/testOutputKtReversed"
-        private fun ktGeneratedSourcesDir(testName: String) = "build/$testName/testOutputKt"
 
         fun generators(testName: String, namespace: String): Array<IGenerator> = arrayOf(
             CSharp50Generator(FlowTransform.AsIs, namespace, File(csAsIsGeneratedSourcesDir(testName))),
             CSharp50Generator(FlowTransform.Reversed, namespace, File(csReversedGeneratedSourcesDir(testName))),
-            Kotlin11Generator(FlowTransform.AsIs, namespace, File(ktGeneratedSourcesDir(testName))),
-            Kotlin11Generator(FlowTransform.Reversed, namespace, File(ktReversedGeneratedSourcesDir(testName)))
         )
     }
 
-    abstract val testName: String
-    private val testFolder
-        get() = File("build/$testName")
+    override val fileExtensionNoDot = "cs"
+    override val generatedSourcesDir
+        get() = csGeneratedSourcesDir(testName)
 
-    protected inline fun <reified TModel> doTest(vararg models: Class<*>) {
-        val classLoader = TModel::class.java.classLoader
-        val containingPackage = TModel::class.java.`package`.name
-        val transformations = listOf("asis", "reversed")
-
-        generateRdModel(classLoader, arrayOf(containingPackage), true)
-
-        for (transform in transformations) {
-            for (model in models) {
-                val goldFileResourcePath = "testData/$testName/$transform/${model.simpleName}.cs"
-                val goldFile = classLoader.getResource(goldFileResourcePath)?.toPath()
-                Assertions.assertNotNull(goldFile, "Resource $goldFileResourcePath should exist")
-                val generatedFile = Paths.get(csGeneratedSourcesDir(testName), transform, "${model.simpleName}.Generated.cs").toFile()
-
-                val goldText = processText(goldFile!!.readLines())
-                val generatedText = processText(generatedFile.readLines())
-
-                Assertions.assertEquals(
-                    goldText,
-                    generatedText,
-                    "Generated and gold sources should be the same for model class ${model.simpleName}, transformation $transform"
-                )
-            }
-        }
-    }
-
-    @BeforeEach
-    fun cleanup() {
-        testFolder.deleteRecursively()
-    }
-
-    protected fun processText(s : List<String>) = s.filter { !it.startsWith("//") && !it.startsWith("  ///") }
-        .joinToString("\n") { it }
+    override fun processLines(lines: List<String>) =
+        lines.filter { !it.startsWith("//") && !it.startsWith("  ///") }
 }

--- a/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/testframework/KotlinRdGenOutputTest.kt
+++ b/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/testframework/KotlinRdGenOutputTest.kt
@@ -1,0 +1,23 @@
+package com.jetbrains.rd.generator.testframework
+
+import com.jetbrains.rd.generator.nova.FlowTransform
+import com.jetbrains.rd.generator.nova.IGenerator
+import com.jetbrains.rd.generator.nova.kotlin.Kotlin11Generator
+import java.io.File
+
+abstract class KotlinRdGenOutputTest : RdGenOutputTestBase() {
+    companion object {
+        protected fun ktGeneratedSourcesDir(testName: String) = "build/$testName/testOutputKt"
+        private fun ktAsIsGeneratedSourcesDir(testName: String) = "${ktGeneratedSourcesDir(testName)}/asis"
+        private fun ktReversedGeneratedSourcesDir(testName: String) = "${ktGeneratedSourcesDir(testName)}/reversed"
+
+        fun generators(testName: String, namespace: String): Array<IGenerator> = arrayOf(
+            Kotlin11Generator(FlowTransform.AsIs, namespace, File(ktAsIsGeneratedSourcesDir(testName))),
+            Kotlin11Generator(FlowTransform.Reversed, namespace, File(ktReversedGeneratedSourcesDir(testName)))
+        )
+    }
+
+    override val fileExtensionNoDot = "kt"
+    override val generatedSourcesDir
+        get() = ktGeneratedSourcesDir(testName)
+}

--- a/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/testframework/RdGenOutputTestBase.kt
+++ b/rd-kt/rd-gen/src/test/kotlin/com/jetbrains/rd/generator/testframework/RdGenOutputTestBase.kt
@@ -1,0 +1,52 @@
+package com.jetbrains.rd.generator.testframework
+
+import com.jetbrains.rd.generator.nova.generateRdModel
+import com.jetbrains.rd.util.reflection.toPath
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import java.io.File
+import java.nio.file.Paths
+
+abstract class RdGenOutputTestBase {
+
+    protected abstract val testName: String
+    private val testFolder
+        get() = File("build/$testName")
+
+    protected abstract val fileExtensionNoDot: String
+    protected abstract val generatedSourcesDir: String
+
+    protected inline fun <reified TModel> doTest(vararg models: Class<*>) {
+        val classLoader = TModel::class.java.classLoader
+        val containingPackage = TModel::class.java.`package`.name
+        val transformations = listOf("asis", "reversed")
+
+        generateRdModel(classLoader, arrayOf(containingPackage), true)
+
+        for (transform in transformations) {
+            for (model in models) {
+                val goldFileResourcePath = "testData/$testName/$transform/${model.simpleName}.$fileExtensionNoDot"
+                val goldFile = classLoader.getResource(goldFileResourcePath)?.toPath()
+                Assertions.assertNotNull(goldFile, "Resource $goldFileResourcePath should exist")
+                val generatedFile = Paths.get(generatedSourcesDir, transform, "${model.simpleName}.Generated.$fileExtensionNoDot").toFile()
+
+                val goldText = processText(goldFile!!.readLines())
+                val generatedText = processText(generatedFile.readLines())
+
+                Assertions.assertEquals(
+                    goldText,
+                    generatedText,
+                    "Generated and gold sources should be the same for model class ${model.simpleName}, transformation $transform"
+                )
+            }
+        }
+    }
+
+    @BeforeEach
+    fun cleanup() {
+        testFolder.deleteRecursively()
+    }
+
+    protected open fun processLines(lines: List<String>) = lines.map { it.trimEnd() }
+    protected fun processText(lines: List<String>) = processLines(lines).joinToString("\n")
+}

--- a/rd-kt/rd-gen/src/test/resources/testData/defaultNlsValues/asis/DefaultNlsValuesRoot.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/defaultNlsValues/asis/DefaultNlsValuesRoot.kt
@@ -1,0 +1,137 @@
+@file:Suppress("EXPERIMENTAL_API_USAGE","EXPERIMENTAL_UNSIGNED_LITERALS","PackageDirectoryMismatch","UnusedImport","unused","LocalVariableName","CanBeVal","PropertyName","EnumEntryName","ClassName","ObjectPropertyName","UnnecessaryVariable","SpellCheckingInspection")
+package DefaultNlsValuesRoot
+
+import com.jetbrains.rd.framework.*
+import com.jetbrains.rd.framework.base.*
+import com.jetbrains.rd.framework.impl.*
+
+import com.jetbrains.rd.util.lifetime.*
+import com.jetbrains.rd.util.reactive.*
+import com.jetbrains.rd.util.string.*
+import com.jetbrains.rd.util.*
+import kotlin.reflect.KClass
+import kotlin.jvm.JvmStatic
+
+
+
+/**
+ * #### Generated from [DefaultNlsValuesTest.kt:14]
+ */
+class DefaultNlsValuesRoot private constructor(
+) : RdExtBase() {
+    //companion
+    
+    companion object : ISerializersOwner {
+        
+        override fun registerSerializersCore(serializers: ISerializers)  {
+            serializers.register(ClassModel)
+            DefaultNlsValuesRoot.register(serializers)
+        }
+        
+        
+        @JvmStatic
+        fun create(lifetime: Lifetime, protocol: IProtocol): DefaultNlsValuesRoot  {
+            DefaultNlsValuesRoot.register(protocol.serializers)
+            
+            return DefaultNlsValuesRoot().apply {
+                identify(protocol.identity, RdId.Null.mix("DefaultNlsValuesRoot"))
+                bind(lifetime, protocol, "DefaultNlsValuesRoot")
+            }
+        }
+        
+        
+        const val serializationHash = -5102364007078219213L
+        
+    }
+    override val serializersOwner: ISerializersOwner get() = DefaultNlsValuesRoot
+    override val serializationHash: Long get() = DefaultNlsValuesRoot.serializationHash
+    
+    //fields
+    //methods
+    //initializer
+    //secondary constructor
+    //equals trait
+    //hash code trait
+    //pretty print
+    override fun print(printer: PrettyPrinter)  {
+        printer.println("DefaultNlsValuesRoot (")
+        printer.print(")")
+    }
+    //deepClone
+    override fun deepClone(): DefaultNlsValuesRoot   {
+        return DefaultNlsValuesRoot(
+        )
+    }
+    //contexts
+}
+
+
+/**
+ * #### Generated from [DefaultNlsValuesTest.kt:15]
+ */
+class ClassModel private constructor(
+    val fff: @org.jetbrains.annotations.Nls String = "123",
+    private val _ppp: RdProperty<@org.jetbrains.annotations.Nls String>
+) : RdBindableBase() {
+    //companion
+    
+    companion object : IMarshaller<ClassModel> {
+        override val _type: KClass<ClassModel> = ClassModel::class
+        
+        @Suppress("UNCHECKED_CAST")
+        override fun read(ctx: SerializationCtx, buffer: AbstractBuffer): ClassModel  {
+            val _id = RdId.read(buffer)
+            val fff = buffer.readString()
+            val _ppp = RdProperty.read(ctx, buffer, __StringSerializer)
+            return ClassModel(fff, _ppp).withId(_id)
+        }
+        
+        override fun write(ctx: SerializationCtx, buffer: AbstractBuffer, value: ClassModel)  {
+            value.rdid.write(buffer)
+            buffer.writeString(value.fff)
+            RdProperty.write(ctx, buffer, value._ppp)
+        }
+        
+        private val __StringSerializer = FrameworkMarshallers.String
+        
+    }
+    //fields
+    val ppp: IProperty<@org.jetbrains.annotations.Nls String> get() = _ppp
+    //methods
+    //initializer
+    init {
+        _ppp.optimizeNested = true
+    }
+    
+    init {
+        bindableChildren.add("ppp" to _ppp)
+    }
+    
+    //secondary constructor
+    constructor(
+        fff: @org.jetbrains.annotations.Nls String = "123"
+    ) : this(
+        fff,
+        RdProperty<@org.jetbrains.annotations.Nls String>("123", __StringSerializer)
+    )
+    
+    //equals trait
+    //hash code trait
+    //pretty print
+    override fun print(printer: PrettyPrinter)  {
+        printer.println("ClassModel (")
+        printer.indent {
+            print("fff = "); fff.print(printer); println()
+            print("ppp = "); _ppp.print(printer); println()
+        }
+        printer.print(")")
+    }
+    //deepClone
+    override fun deepClone(): ClassModel   {
+        return ClassModel(
+            fff,
+            _ppp.deepClonePolymorphic()
+        )
+    }
+    //contexts
+}

--- a/rd-kt/rd-gen/src/test/resources/testData/defaultNlsValues/reversed/DefaultNlsValuesRoot.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/defaultNlsValues/reversed/DefaultNlsValuesRoot.kt
@@ -1,0 +1,137 @@
+@file:Suppress("EXPERIMENTAL_API_USAGE","EXPERIMENTAL_UNSIGNED_LITERALS","PackageDirectoryMismatch","UnusedImport","unused","LocalVariableName","CanBeVal","PropertyName","EnumEntryName","ClassName","ObjectPropertyName","UnnecessaryVariable","SpellCheckingInspection")
+package DefaultNlsValuesRoot
+
+import com.jetbrains.rd.framework.*
+import com.jetbrains.rd.framework.base.*
+import com.jetbrains.rd.framework.impl.*
+
+import com.jetbrains.rd.util.lifetime.*
+import com.jetbrains.rd.util.reactive.*
+import com.jetbrains.rd.util.string.*
+import com.jetbrains.rd.util.*
+import kotlin.reflect.KClass
+import kotlin.jvm.JvmStatic
+
+
+
+/**
+ * #### Generated from [DefaultNlsValuesTest.kt:14]
+ */
+class DefaultNlsValuesRoot private constructor(
+) : RdExtBase() {
+    //companion
+    
+    companion object : ISerializersOwner {
+        
+        override fun registerSerializersCore(serializers: ISerializers)  {
+            serializers.register(ClassModel)
+            DefaultNlsValuesRoot.register(serializers)
+        }
+        
+        
+        @JvmStatic
+        fun create(lifetime: Lifetime, protocol: IProtocol): DefaultNlsValuesRoot  {
+            DefaultNlsValuesRoot.register(protocol.serializers)
+            
+            return DefaultNlsValuesRoot().apply {
+                identify(protocol.identity, RdId.Null.mix("DefaultNlsValuesRoot"))
+                bind(lifetime, protocol, "DefaultNlsValuesRoot")
+            }
+        }
+        
+        
+        const val serializationHash = -5102364007078219213L
+        
+    }
+    override val serializersOwner: ISerializersOwner get() = DefaultNlsValuesRoot
+    override val serializationHash: Long get() = DefaultNlsValuesRoot.serializationHash
+    
+    //fields
+    //methods
+    //initializer
+    //secondary constructor
+    //equals trait
+    //hash code trait
+    //pretty print
+    override fun print(printer: PrettyPrinter)  {
+        printer.println("DefaultNlsValuesRoot (")
+        printer.print(")")
+    }
+    //deepClone
+    override fun deepClone(): DefaultNlsValuesRoot   {
+        return DefaultNlsValuesRoot(
+        )
+    }
+    //contexts
+}
+
+
+/**
+ * #### Generated from [DefaultNlsValuesTest.kt:15]
+ */
+class ClassModel private constructor(
+    val fff: @org.jetbrains.annotations.Nls String = "123",
+    private val _ppp: RdProperty<@org.jetbrains.annotations.Nls String>
+) : RdBindableBase() {
+    //companion
+    
+    companion object : IMarshaller<ClassModel> {
+        override val _type: KClass<ClassModel> = ClassModel::class
+        
+        @Suppress("UNCHECKED_CAST")
+        override fun read(ctx: SerializationCtx, buffer: AbstractBuffer): ClassModel  {
+            val _id = RdId.read(buffer)
+            val fff = buffer.readString()
+            val _ppp = RdProperty.read(ctx, buffer, __StringSerializer)
+            return ClassModel(fff, _ppp).withId(_id)
+        }
+        
+        override fun write(ctx: SerializationCtx, buffer: AbstractBuffer, value: ClassModel)  {
+            value.rdid.write(buffer)
+            buffer.writeString(value.fff)
+            RdProperty.write(ctx, buffer, value._ppp)
+        }
+        
+        private val __StringSerializer = FrameworkMarshallers.String
+        
+    }
+    //fields
+    val ppp: IProperty<@org.jetbrains.annotations.Nls String> get() = _ppp
+    //methods
+    //initializer
+    init {
+        _ppp.optimizeNested = true
+    }
+    
+    init {
+        bindableChildren.add("ppp" to _ppp)
+    }
+    
+    //secondary constructor
+    constructor(
+        fff: @org.jetbrains.annotations.Nls String = "123"
+    ) : this(
+        fff,
+        RdProperty<@org.jetbrains.annotations.Nls String>("123", __StringSerializer)
+    )
+    
+    //equals trait
+    //hash code trait
+    //pretty print
+    override fun print(printer: PrettyPrinter)  {
+        printer.println("ClassModel (")
+        printer.indent {
+            print("fff = "); fff.print(printer); println()
+            print("ppp = "); _ppp.print(printer); println()
+        }
+        printer.print(")")
+    }
+    //deepClone
+    override fun deepClone(): ClassModel   {
+        return ClassModel(
+            fff,
+            _ppp.deepClonePolymorphic()
+        )
+    }
+    //contexts
+}


### PR DESCRIPTION
This PR will allow us to use the following two constructs w.r.t. `nlsString`:
```kotlin
        val classModel = classdef {
            field("fff", nlsString).default("123")
            property("ppp", nlsString, "123")
        }
```

Before this, the first line will break in generation time, and the second one won't compile.

Also, I've refactored the test framework further to be able to write rd-gen tests in a more simple way for Kotlin (as I already did before for C#).