### PR TITLE
Improve coroutines api

### DIFF
--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/TaskInterfaces.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/TaskInterfaces.kt
@@ -131,6 +131,7 @@ interface IRdCall<in TReq, out TRes> {
     fun start(lifetime: Lifetime, request: TReq, responseScheduler: IScheduler? = null): IRdTask<TRes>
 
     suspend fun startSuspending(lifetime: Lifetime, request: TReq, responseScheduler: IScheduler? = null): TRes
+    suspend fun startSuspending(request: TReq, responseScheduler: IScheduler? = null) = startSuspending(Lifetime.Eternal, request, responseScheduler)
 }
 
 /**

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/util/ISourceCoroutineUtil.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/util/ISourceCoroutineUtil.kt
@@ -23,17 +23,35 @@ fun <T> ISource<T>.nextValueAsync(
     }
 }
 
+fun <T : Any> ISource<T?>.nextNotNullValueAsync(lifetime: Lifetime): Deferred<T> = CompletableDeferred<T>().also { d ->
+    val nestedDef = lifetime.createNested().apply {
+        synchronizeWith(d)
+    }
+
+    advise(nestedDef.lifetime) {
+        if (it != null) {
+            d.complete(it)
+        }
+    }
+}
+
+suspend fun <T> ISource<T>.nextValue(
+    lifetime: Lifetime = Lifetime.Eternal,
+    condition: (T) -> Boolean = { true }
+): T = lifetime.usingNested { // unsubscribe if coroutine was cancelled
+    nextValueAsync(it, condition).await()
+}
+
 fun ISource<Boolean>.nextTrueValueAsync(lifetime: Lifetime) = nextValueAsync(lifetime) { it }
 fun ISource<Boolean>.nextFalseValueAsync(lifetime: Lifetime) = nextValueAsync(lifetime) { !it }
 
-fun <T> ISource<T>.nextNotNullValueAsync(lifetime: Lifetime) = nextValueAsync(lifetime) { it != null }
+suspend fun ISource<Boolean>.nextTrueValue(lifetime: Lifetime = Lifetime.Eternal) = nextValue(lifetime) { it }
+suspend fun ISource<Boolean>.nextFalseValue(lifetime: Lifetime = Lifetime.Eternal) = nextValue(lifetime) { !it }
 
-suspend fun <T> ISource<T>.nextValue(lifetime: Lifetime, condition: (T) -> Boolean = { true }) = nextValueAsync(lifetime, condition).await()
-
-suspend fun ISource<Boolean>.nextTrueValue(lifetime: Lifetime) = nextTrueValueAsync(lifetime).await()
-suspend fun ISource<Boolean>.nextFalseValue(lifetime: Lifetime) = nextFalseValueAsync(lifetime).await()
-
-suspend fun <T> ISource<T>.nextNotNullValue(lifetime: Lifetime) = nextNotNullValueAsync(lifetime).await()
+suspend fun <T : Any> ISource<T?>.nextNotNullValue(lifetime: Lifetime = Lifetime.Eternal): T =
+    lifetime.usingNested { // unsubscribe if coroutine was cancelled
+        nextNotNullValueAsync(lifetime).await()
+    }
 
 fun<T> ISource<T>.adviseSuspend(lifetime: Lifetime, scheduler: IScheduler, handler: suspend (T) -> Unit) {
     adviseSuspend(lifetime, scheduler.asCoroutineDispatcher(allowInlining = true), handler)

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/CoroutineTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/CoroutineTest.kt
@@ -91,7 +91,25 @@ class CoroutineTest : CoroutineTestBase() {
                 assert(!task.isCompleted)
                 signal.fire("1")
                 assert(task.isCompleted)
-                assertEquals("1", task.await())
+                val result: String = task.await()
+                assertEquals("1", result)
+            }
+
+            kotlin.run {
+                val task = async {
+                    val result: String = signal.nextNotNullValue()
+                    assertEquals("1", result)
+                    return@async result
+                }
+                signal.fire(null)
+                yield()
+                assert(!task.isCompleted)
+
+                signal.fire("1")
+                yield()
+                assert(task.isCompleted)
+                val result: String = task.await()
+                assertEquals("1", result)
             }
         }
 

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdAsyncTaskTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdAsyncTaskTest.kt
@@ -515,10 +515,10 @@ class RdAsyncTaskTest : RdFrameworkTestBase() {
             endpoint.set { _, req -> lifetime.startAsync(scheduler) { req.toString() }.toRdTask() }
 
             runBlocking(scheduler.asCoroutineDispatcher) {
-                var res = callsite.startSuspending(Lifetime.Eternal, 0)
+                var res = callsite.startSuspending(0)
                 assertEquals("0", res)
 
-                res = callsite.startSuspending(Lifetime.Eternal, 1)
+                res = callsite.startSuspending(1)
                 assertEquals("1", res)
             }
 
@@ -536,7 +536,7 @@ class RdAsyncTaskTest : RdFrameworkTestBase() {
 
             runBlocking(scheduler.asCoroutineDispatcher) {
                 val job = launch {
-                    callsite.startSuspending(Lifetime.Eternal, 0)
+                    callsite.startSuspending(0)
                 }
 
                 yield() // wait for startSuspending asynchronously
@@ -566,7 +566,7 @@ class RdAsyncTaskTest : RdFrameworkTestBase() {
 
         runBlocking {
             withTimeout(1000) {
-                val  result = callsite.startSuspending(Lifetime.Eternal, 1)
+                val  result = callsite.startSuspending(1)
                 assertEquals("1", result)
             }
         }


### PR DESCRIPTION
No need to require lifetime for suspend functions
nextNotNullValue should return not-null type to avoid using the `!!` opretator