### PR TITLE
Fixed datetime rounding

### DIFF
--- a/rd-cpp/src/rd_framework_cpp/src/main/protocol/Buffer.cpp
+++ b/rd-cpp/src/rd_framework_cpp/src/main/protocol/Buffer.cpp
@@ -190,7 +190,7 @@ int64_t TICKS_PER_MILLISECOND = 10000000;
 DateTime Buffer::read_date_time()
 {
 	int64_t time_in_ticks = read_integral<int64_t>();
-	time_t t = static_cast<time_t>((time_in_ticks - TICKS_AT_EPOCH) / TICKS_PER_MILLISECOND);
+	time_t t = static_cast<time_t>(time_in_ticks / TICKS_PER_MILLISECOND - TICKS_AT_EPOCH / TICKS_PER_MILLISECOND);
 	return DateTime{t};
 }
 

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Serializers.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Serializers.kt
@@ -155,7 +155,7 @@ fun AbstractBuffer.readGuid(): UUID = this.readUuid()
 
 fun AbstractBuffer.readDateTime(): Date {
     val timeInTicks = readLong()
-    val timeInMillisecondsSinceEpoch = (timeInTicks - TICKS_AT_EPOCH) / TICKS_PER_MILLISECOND
+    val timeInMillisecondsSinceEpoch = timeInTicks / TICKS_PER_MILLISECOND - TICKS_AT_EPOCH / TICKS_PER_MILLISECOND
     return Date(timeInMillisecondsSinceEpoch)
 }
 

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/serialization/SerializersTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/serialization/SerializersTest.kt
@@ -2,12 +2,22 @@ package com.jetbrains.rd.framework.test.cases.serialization
 
 import com.jetbrains.rd.framework.*
 import com.jetbrains.rd.util.string.RName
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class SerializersTest {
 
+    @Test
+    fun read_date_should_floor_negative_millis() {
+        val buffer = UnsafeBuffer(ByteArray(100))
+        buffer.writeLong(621355950301790001) // 1969-12-31 23:30:30.1790001 in ticks
+        buffer.rewind()
 
+        val dateTime = buffer.readDateTime()
+
+        assertEquals (dateTime.time, -1769821) // 1969-12-31 23:30:30.179, NOT 1969-12-31 23:30:30.180
+    }
 
     @Test
     fun testReadArray() {

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/serialization/SerializersTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/serialization/SerializersTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 class SerializersTest {
 
     @Test
-    fun read_date_should_floor_negative_millis() {
+    fun readDateShouldFloorNegativeMillis() {
         val buffer = UnsafeBuffer(ByteArray(100))
         buffer.writeLong(621355950301790001) // 1969-12-31 23:30:30.1790001 in ticks
         buffer.rewind()


### PR DESCRIPTION
Right now, when number of ticks is converted to the number of milliseconds since epoch, truncation is performed.
This approach:
- works as **floor** operation for dates that are greater than epoch. (1970-01-01T00:00:00Z)
- works as **ceil** operation for dates that are less than epoch.

Which basically means that:

- milliseconds for dates that are greater than epoch are rounded down.
- milliseconds for dates that are less than epoch are rounded up.

This wierd behavior is caused by the fact that the result of this expression is negative for dates that are less than epoch:

`
val ticks = timeInTicks - TICKS_AT_EPOCH
`

Example:
1970-12-31 23:30:30.1790001 is delivered as 1970-12-31 23:30:30.179.
1969-12-31 23:30:30.1790001 is delivered as 1969-12-31 23:30:30.180.

To fix the problem I perform truncation first and subtraction after.