### PR TITLE
Serializers: dispose of a redundant comment

### DIFF
--- a/rd-net/RdFramework/Impl/Serializers.cs
+++ b/rd-net/RdFramework/Impl/Serializers.cs
@@ -323,7 +323,6 @@ namespace JetBrains.Rd.Impl
       }
       typeId.Write(writer);
 
-      // Don't dispose this cookie, otherwise it will delete all written data
       var bookmark = new UnsafeWriter.Bookmark(writer);
       writer.Write(0);
       CtxWriteDelegate<object> writerDelegate;


### PR DESCRIPTION
Earlier, `UnsafeWriter.Cookie` was used instead of a `bookmark`, but now it isn't, so the comment is redundant: `Bookmark` is not an `IDisposable`.