### PR TITLE
LogEx: rename Trace() -> WhenTrace()

### DIFF
--- a/rd-net/Lifetimes/Diagnostics/LogEx.cs
+++ b/rd-net/Lifetimes/Diagnostics/LogEx.cs
@@ -433,13 +433,13 @@ namespace JetBrains.Diagnostics
     /// </code>
     /// Usage:
     /// <code>
-    ///   logger.Trace()?.Log($"some messages with {HeavyComputation()}")
+    ///   logger.WhenTrace()?.Log($"some messages with {HeavyComputation()}")
     /// </code>
     /// </summary>
     /// <param name="logger"/>
     /// <returns>struct <see cref="LogWithLevel"/>(<paramref name="logger"/>, <see cref="LoggingLevel.TRACE"/>) if <see cref="IsTraceEnabled"/>;
     /// null otherwise</returns>
-    [PublicAPI] public static LogWithLevel? Trace(this ILog logger)
+    [PublicAPI] public static LogWithLevel? WhenTrace(this ILog logger)
     {
       return LogWithLevel.CreateIfEnabled(logger, LoggingLevel.TRACE);
     }
@@ -452,16 +452,22 @@ namespace JetBrains.Diagnostics
     /// </code>
     /// Usage:
     /// <code>
-    ///   logger.Verbose()?.Log($"some messages with {HeavyComputation()}")
+    ///   logger.WhenVerbose()?.Log($"some messages with {HeavyComputation()}")
     /// </code>
     /// </summary>
     /// <param name="logger"></param>
     /// <returns>struct <see cref="LogWithLevel"/>(<paramref name="logger"/>, <see cref="LoggingLevel.VERBOSE"/>) if <see cref="IsVersboseEnabled"/>;
     /// null otherwise</returns>
-    [PublicAPI] public static LogWithLevel? Verbose(this ILog logger)
+    [PublicAPI] public static LogWithLevel? WhenVerbose(this ILog logger)
     {
       return LogWithLevel.CreateIfEnabled(logger, LoggingLevel.VERBOSE);
     }
+
+    [Obsolete("Renamed to WhenTrace")]
+    public static LogWithLevel? Trace(this ILog logger) => logger.WhenTrace();
+
+    [Obsolete("Renamed to WhenVerbose")]
+    public static LogWithLevel? Verbose(this ILog logger) => logger.WhenVerbose();
 
     #endregion
   }

--- a/rd-net/RdFramework/Base/RdReactiveBase.cs
+++ b/rd-net/RdFramework/Base/RdReactiveBase.cs
@@ -14,8 +14,8 @@ namespace JetBrains.Rd.Base
     internal static readonly ILog ourLogReceived = Protocol.Logger.GetSublogger("RECV");
     internal static readonly ILog ourLogSend = Protocol.Logger.GetSublogger("SEND");
     
-    internal static LogWithLevel? ReceiveTrace => ourLogReceived.Trace();
-    internal static LogWithLevel? SendTrace => ourLogSend.Trace();
+    internal static LogWithLevel? ReceiveTrace => ourLogReceived.WhenTrace();
+    internal static LogWithLevel? SendTrace => ourLogSend.WhenTrace();
 
 
     #region Identification

--- a/rd-net/RdFramework/Impl/Protocol.cs
+++ b/rd-net/RdFramework/Impl/Protocol.cs
@@ -13,7 +13,7 @@ namespace JetBrains.Rd.Impl
   {
     public static readonly ILog Logger = Log.GetLog("protocol");
     public static readonly ILog InitLogger = Logger.GetSublogger("INIT");
-    public static LogWithLevel? InitTrace = InitLogger.Trace();
+    public static LogWithLevel? InitTrace = InitLogger.WhenTrace();
 
     /// <summary>
     /// Should match textual RdId of protocol intern root in Kotlin/js/cpp counterpart

--- a/rd-net/RdFramework/Impl/SocketWire.cs
+++ b/rd-net/RdFramework/Impl/SocketWire.cs
@@ -264,12 +264,12 @@ namespace JetBrains.Rd.Impl
               {
                 if (!HeartbeatAlive.Value) // only on change
                 {
-                  Log.Trace()?.Log($"Connection is alive after receiving PING {Id}: " +
-                                   $"receivedTimestamp: {receivedTimestamp}, " +
-                                   $"receivedCounterpartTimestamp: {receivedCounterpartTimestamp}, " +
-                                   $"currentTimeStamp: {myCurrentTimeStamp}, " +
-                                   $"counterpartTimestamp: {myCounterpartTimestamp}, " +
-                                   $"counterpartNotionTimestamp: {myCounterpartNotionTimestamp}");
+                  Log.WhenTrace()?.Log($"Connection is alive after receiving PING {Id}: " +
+                                       $"receivedTimestamp: {receivedTimestamp}, " +
+                                       $"receivedCounterpartTimestamp: {receivedCounterpartTimestamp}, " +
+                                       $"currentTimeStamp: {myCurrentTimeStamp}, " +
+                                       $"counterpartTimestamp: {myCounterpartTimestamp}, " +
+                                       $"counterpartNotionTimestamp: {myCounterpartNotionTimestamp}");
                 }
                 HeartbeatAlive.Value = true;
               }
@@ -344,10 +344,10 @@ namespace JetBrains.Rd.Impl
           {
             if (HeartbeatAlive.Value) // log only on change
             {
-              Log.Trace()?.Log($"Disconnect detected while sending PING {Id}: " +
-                               $"currentTimeStamp: {myCurrentTimeStamp}, " +
-                               $"counterpartTimestamp: {myCounterpartTimestamp}, " +
-                               $"counterpartNotionTimestamp: {myCounterpartNotionTimestamp}");
+              Log.WhenTrace()?.Log($"Disconnect detected while sending PING {Id}: " +
+                                   $"currentTimeStamp: {myCurrentTimeStamp}, " +
+                                   $"counterpartTimestamp: {myCounterpartTimestamp}, " +
+                                   $"counterpartNotionTimestamp: {myCounterpartNotionTimestamp}");
             }
             HeartbeatAlive.Value = false;
           }


### PR DESCRIPTION
 Currently `Trace()` isn't distingushable in completion from regular `Trace(string)`.

To promote this API I suggest to add prefix `When`