### PR TITLE
RdReflection: asserts for consistency

### DIFF
--- a/rd-net/RdFramework.Reflection/BindableChildrenUtil.cs
+++ b/rd-net/RdFramework.Reflection/BindableChildrenUtil.cs
@@ -34,7 +34,7 @@ namespace JetBrains.Rd.Reflection
       {
         var t = instance.GetType();
         var header = t.Name + " (";
-        var bindableMembers = SerializerReflectionUtil.GetBindableMembers(t.GetTypeInfo());
+        var bindableMembers = SerializerReflectionUtil.GetBindableFields(t.GetTypeInfo());
         var getters = bindableMembers.Select(ReflectionUtil.GetGetter).ToArray();
         var intros = bindableMembers.Select(mi => $"{mi.Name} = ").ToArray();
 
@@ -74,7 +74,7 @@ namespace JetBrains.Rd.Reflection
       if (fillBindableFields == null)
       {
         var t = type;
-        var bindableMembers = SerializerReflectionUtil.GetBindableMembers(t.GetTypeInfo()).ToArray();
+        var bindableMembers = SerializerReflectionUtil.GetBindableFields(t.GetTypeInfo()).ToArray();
         var getters = bindableMembers.Select(ReflectionUtil.GetGetter).ToArray();
 
         fillBindableFields = (obj) =>

--- a/rd-net/RdFramework.Reflection/ReflectionSerializersFactory.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionSerializersFactory.cs
@@ -261,18 +261,6 @@ namespace JetBrains.Rd.Reflection
       mySerializers.Add(typeof(T), serializerPair);
     }
 
-    public static Type? GetRpcInterface(TypeInfo typeInfo)
-    {
-      if (typeInfo.GetCustomAttribute<RdExtAttribute>() is RdExtAttribute rdExt && rdExt.RdRpcInterface != null)
-        return rdExt.RdRpcInterface;
-
-      foreach (var @interface in typeInfo.GetInterfaces()) 
-        if (ReflectionSerializerVerifier.IsRpcAttributeDefined(@interface)) 
-          return @interface;
-
-      return null;
-    }
-
     /// <summary>
     /// Register serializers for either <see cref="RdExtAttribute"/> or <see cref="RdModelAttribute"/>
     /// </summary>
@@ -294,7 +282,7 @@ namespace JetBrains.Rd.Reflection
         return;
       }*/
 
-      var memberInfos = SerializerReflectionUtil.GetBindableMembers(typeInfo);
+      var memberInfos = SerializerReflectionUtil.GetBindableFields(typeInfo);
       var memberSetters = memberInfos.Select(ReflectionUtil.GetSetter).ToArray();
       var memberGetters = memberInfos.Select(ReflectionUtil.GetGetter).ToArray();
 

--- a/rd-net/RdFramework.Reflection/ScalarSerializer.cs
+++ b/rd-net/RdFramework.Reflection/ScalarSerializer.cs
@@ -202,7 +202,7 @@ namespace JetBrains.Rd.Reflection
       TypeInfo typeInfo = typeof(T).GetTypeInfo();
       var allowNullable = ReflectionSerializerVerifier.CanBeNull(typeInfo);
 
-      var memberInfos = SerializerReflectionUtil.GetBindableMembers(typeInfo);
+      var memberInfos = SerializerReflectionUtil.GetBindableFields(typeInfo);
       var memberSetters = memberInfos.Select(ReflectionUtil.GetSetter).ToArray();
       var memberGetters = memberInfos.Select(ReflectionUtil.GetGetter).ToArray();
 

--- a/rd-net/RdFramework.Reflection/SerializerReflectionUtil.cs
+++ b/rd-net/RdFramework.Reflection/SerializerReflectionUtil.cs
@@ -130,7 +130,7 @@ namespace JetBrains.Rd.Reflection
     /// Get lists of members which take part in object serialization.
     /// Can be used for RdExt, RdModel and any RdScalar.
     /// </summary>
-    internal static FieldInfo[] GetBindableMembers(TypeInfo typeInfo)
+    internal static FieldInfo[] GetBindableFields(TypeInfo typeInfo)
     {
 /*
       var rpcInterface = GetRpcInterface();

--- a/rd-net/Test.RdFramework/Reflection/ProxyGeneratorCornerCasesTests.cs
+++ b/rd-net/Test.RdFramework/Reflection/ProxyGeneratorCornerCasesTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Collections.Viewable;
 using JetBrains.Diagnostics;
@@ -125,6 +126,17 @@ namespace Test.RdFramework.Reflection
       });
     }
 
+    [Test]
+    public void TestDifferentBindableSets()
+    {
+      Assert.Throws<Assertion.AssertionException>(() =>
+      {
+        WithExtsProxy<DifferenceInBindableFields, IDifferenceInBindableFields>((c, s) =>
+        {
+        });
+      });
+    }
+
     [RdRpc]
     public interface IUnexpectedInterfaceType
     {
@@ -152,6 +164,18 @@ namespace Test.RdFramework.Reflection
       {
         ViewableProperty = new ViewableProperty<string>();
       }
+    }
+    [RdRpc]
+    public interface IDifferenceInBindableFields
+    {
+      IViewableProperty<string> ViewableProperty { get; }
+    }
+
+    [RdExt]
+    public class DifferenceInBindableFields : RdExtReflectionBindableBase, IDifferenceInBindableFields
+    {
+      public IViewableProperty<string> NotInTheInterface { get; }
+      public IViewableProperty<string> ViewableProperty { get; }
     }
   }
 }

--- a/rd-net/Test.RdFramework/Reflection/ProxyGeneratorPropertiesTest.cs
+++ b/rd-net/Test.RdFramework/Reflection/ProxyGeneratorPropertiesTest.cs
@@ -83,9 +83,12 @@ namespace Test.RdFramework.Reflection
     [Test]
     public void TestOnlyRpcAreSynchronized()
     {
-      var client = CFacade.InitBind(new PartSync(), TestLifetime, ClientProtocol);
-      var proxy = SFacade.ActivateProxy<IPartSync>(TestLifetime, ServerProtocol);
-      Assertion.Assert(((RdExtReflectionBindableBase)proxy).Connected.Value, "((RdReflectionBindableBase)proxy).Connected.Value");
+      Assert.Throws<Assertion.AssertionException>(() =>
+      {
+        var client = CFacade.InitBind(new PartSync(), TestLifetime, ClientProtocol);
+        var proxy = SFacade.ActivateProxy<IPartSync>(TestLifetime, ServerProtocol);
+        Assertion.Assert(((RdExtReflectionBindableBase)proxy).Connected.Value, "((RdReflectionBindableBase)proxy).Connected.Value");
+      });
     }
   }
 }

--- a/rd-net/Test.RdFramework/Reflection/ProxyGeneratorTestBase.cs
+++ b/rd-net/Test.RdFramework/Reflection/ProxyGeneratorTestBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,6 +8,7 @@ using JetBrains.Diagnostics;
 using JetBrains.Rd.Base;
 using JetBrains.Rd.Reflection;
 using JetBrains.Threading;
+using NUnit.Framework;
 
 namespace Test.RdFramework.Reflection
 {
@@ -21,6 +23,11 @@ namespace Test.RdFramework.Reflection
 
       await YieldToServer();
       var proxy = SFacade.ActivateProxy<TInterface>(TestLifetime, ServerProtocol);
+
+      CollectionAssert.AreEquivalent(
+        ((IReflectionBindable)client).BindableChildren.Select(m => m.Key),
+        ((IReflectionBindable)proxy).BindableChildren.Select(m => m.Key)
+      );
 
       await Wait();
 

--- a/rd-net/Test.RdFramework/Reflection/RdReflectionTestBase.cs
+++ b/rd-net/Test.RdFramework/Reflection/RdReflectionTestBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Rd.Base;
 using JetBrains.Rd.Impl;
@@ -65,6 +66,12 @@ namespace Test.RdFramework.Reflection
     {
       var c = CFacade.Activator.ActivateBind<T1>(TestLifetime, ClientProtocol);
       var s = SFacade.ActivateProxy<T2>(TestLifetime, ServerProtocol);
+      
+      CollectionAssert.AreEquivalent(
+        ((IReflectionBindable)c).BindableChildren.Select(m => m.Key),
+        ((IReflectionBindable)s).BindableChildren.Select(m => m.Key)
+      );
+
       run(c, s);
     }
 

--- a/rd-net/Test.RdFramework/Reflection/TestReflectionSerialization.cs
+++ b/rd-net/Test.RdFramework/Reflection/TestReflectionSerialization.cs
@@ -65,17 +65,18 @@ namespace Test.RdFramework.Reflection
 
       var animal = CFacade.Activator.Activate<Animal>();
       var cm = animal.NestedRdModel;
-      cm.IList.Add(2);
       cm.Prop.Value = "val";
-      cm.List.Add("val2");
-      cm.Set.Add("val3");
-      cm.Map["x"] = "val";
       cm.RegularFieldInModel = "f";
-      
+
       c.PolyProperty.Value = animal;
       var sm = s.PolyProperty.Value.NestedRdModel;
       Assert.NotNull(sm);
       Assert.AreNotSame(sm, cm);
+
+      cm.IList.Add(2);
+      cm.List.Add("val2");
+      cm.Set.Add("val3");
+      cm.Map["x"] = "val";
 
       CollectionAssert.AreEqual(cm.IList, sm.IList);
       CollectionAssert.AreEqual(cm.List, sm.List);

--- a/rd-net/Test.RdFramework/Reflection/TestVerification.cs
+++ b/rd-net/Test.RdFramework/Reflection/TestVerification.cs
@@ -8,6 +8,9 @@ namespace Test.RdFramework.Reflection
   [TestFixture]
   public class TestVerification
   {
+
+    // These checks are disabled in release
+#if DEBUG
     [TestCase(typeof(NotRdModelData))]
     // [TestCase(typeof(CantHavePrivateFieldError))]
     [TestCase(typeof(NotRdModelData))]
@@ -20,7 +23,7 @@ namespace Test.RdFramework.Reflection
     // injected into another, but the activation for each of RdExt should be processed independently.
     // [TestCase(typeof(CircularDependencyExtError))]
     // [TestCase(typeof(CircularDependencyExt2Error))]
-    
+
     [TestCase(typeof(CircularDependencyInModelError))]
     [TestCase(typeof(CircularDependencyNestedModel1Error))]
     [TestCase(typeof(ModelCalls.ModelInvalidCalls))]
@@ -32,6 +35,7 @@ namespace Test.RdFramework.Reflection
 
       Console.WriteLine(exception);
     }
+#endif
 
     [Test]
     public void TestActivation()


### PR DESCRIPTION
Check and compare BindableChildren collections for detecting cases when connection between members cannot be established because of different API on proxy and implementation sides.