### PR TITLE
.NET Framework 3.5: disable NRT

### DIFF
--- a/rd-net/Directory.Build.props
+++ b/rd-net/Directory.Build.props
@@ -5,7 +5,17 @@
     <AssemblyVersion>777.0.0</AssemblyVersion>
     <FileVersion>777.0.0</FileVersion>
     <LangVersion>10.0</LangVersion>
-    <Nullable>enable</Nullable>
+    
+    <!--
+      NOTE: We support .NET 3.5 assemblies for running inside of Unity 2017. It uses an old mcs compiler, which doesn't
+      recognize NRT annotations. Feel free to drop these hacks and revert to nullable: enable after we stop supporting
+      mcs versions without this commit:
+      https://github.com/mono/ikvm-fork/commit/caa8e7f54279a47422626005d228447f5d3670d5 
+    -->
+    <Nullable Condition="'$(TargetFramework)' == 'net35'">disable</Nullable>
+    <Nullable Condition="'$(Nullable)' == ''">enable</Nullable>
+    
+    <NoWarn Condition="'$(TargetFramework)' == 'net35'">nullable</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Condition="'$(TargetFramework)' == 'net461'" Version="1.0.2">

--- a/rd-net/Lifetimes/Lifetimes.csproj
+++ b/rd-net/Lifetimes/Lifetimes.csproj
@@ -8,7 +8,7 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <NoWarn>1591,1570,1574</NoWarn>
+        <NoWarn>$(NoWarn),1591,1570,1574</NoWarn>
         
         <DefineConstants Condition="'$(Configuration)' == 'Debug'">JET_MODE_ASSERT</DefineConstants>
         

--- a/rd-net/RdFramework.Reflection/RdFramework.Reflection.csproj
+++ b/rd-net/RdFramework.Reflection/RdFramework.Reflection.csproj
@@ -8,7 +8,7 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <NoWarn>1591,1570,1574</NoWarn>
+        <NoWarn>$(NoWarn),1591,1570,1574</NoWarn>
 
         <DefineConstants Condition="'$(Configuration)' == 'Debug'">JET_MODE_ASSERT</DefineConstants>
 

--- a/rd-net/RdFramework/RdFramework.csproj
+++ b/rd-net/RdFramework/RdFramework.csproj
@@ -8,7 +8,7 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <NoWarn>1591,1570,1574</NoWarn>
+        <NoWarn>$(NoWarn),1591,1570,1574</NoWarn>
 
         <DefineConstants Condition="'$(Configuration)' == 'Debug'">JET_MODE_ASSERT</DefineConstants>
         


### PR DESCRIPTION
Otherwise, we break mcs compiler in older Unity versions.