### PR TITLE
Added Assertion.FailWithResult

### DIFF
--- a/rd-net/Lifetimes/Diagnostics/Assertion.cs
+++ b/rd-net/Lifetimes/Diagnostics/Assertion.cs
@@ -350,6 +350,61 @@ namespace JetBrains.Diagnostics
       }
     }
 
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    [ContractAnnotation("=> halt")]
+    [StringFormatMethod("message")]
+    [AssertionMethod]
+    [DoesNotReturn]
+    public static T FailWithResult<T>(T result, string message)
+    {
+      Fail(message);
+      return result;
+    }
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    [ContractAnnotation("=> halt")]
+    [StringFormatMethod("message")]
+    [AssertionMethod]
+    [DoesNotReturn]
+    public static T FailWithResult<T>(T result, string message, object? arg)
+    {
+      Fail(message, arg);
+      return result;
+    }
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    [ContractAnnotation("=> halt")]
+    [StringFormatMethod("message")]
+    [AssertionMethod]
+    [DoesNotReturn]
+    public static T FailWithResult<T>(T result, string message, object? arg1, object? arg2)
+    {
+      Fail(message, arg1, arg2);
+      return result;
+    }
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    [ContractAnnotation("=> halt")]
+    [StringFormatMethod("message")]
+    [AssertionMethod]
+    [DoesNotReturn]
+    public static T FailWithResult<T>(T result, string message, object? arg1, object? arg2, object? arg3)
+    {
+      Fail(message, arg1, arg2, arg3);
+      return result;
+    }
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    [ContractAnnotation("=> halt")]
+    [StringFormatMethod("message")]
+    [AssertionMethod]
+    [DoesNotReturn]
+    public static T FailWithResult<T>(T result, string message, params object?[] args)
+    {
+      Fail(message, args);
+      return result;
+    }
+
     [Serializable]
     public class AssertionException : Exception
     {


### PR DESCRIPTION
Added 'Asseriton.FailWithResult' methods that allow throw an assertion exception and return a value where it's expected e.g. default cases of switch expressions over enums

This is useful to assert that some paths shouldn't happen but provide a safe fallback value to satisfy the compiler instead of throwing an exception that won't be limited to debug builds. This is an expression equivalent of `Assertion.Fail(); return false;`
e.g.
```
var isByValue = field.ReferenceKind switch 
{
  ReferenceKind.Value => true,
  ReferenceKind.MutableReference or ReferenceKind.ReadonlyReference => false,
  _ => Assertion.FailWithResult(false, "Unknown reference kind: " + field.ReferenceKind);
}
```