### PR TITLE
Fix races in LifetimeDefinition

### DIFF
--- a/rd-net/Lifetimes/Lifetimes/LifetimeDefinition.cs
+++ b/rd-net/Lifetimes/Lifetimes/LifetimeDefinition.cs
@@ -969,11 +969,7 @@ namespace JetBrains.Lifetimes
     private CancellationTokenSource CreateCtsLazily()
     {
       if (myCts != null) return myCts;
-      
-      var cts = new CancellationTokenSource();
-      Memory.Barrier();
-      //to suppress reordering of init and ctor visible from outside
-      myCts = cts;
+      Interlocked.CompareExchange(ref myCts, new CancellationTokenSource(), null);
       
       //But MarkCanceledRecursively may already happen, so we need to help Cancel source
       if (Status != LifetimeStatus.Alive)

--- a/rd-net/Lifetimes/Lifetimes/LifetimeDefinition.cs
+++ b/rd-net/Lifetimes/Lifetimes/LifetimeDefinition.cs
@@ -542,10 +542,10 @@ namespace JetBrains.Lifetimes
       myResources = null;
       myResCount = 0;
       
-      //In fact we shouldn't make cts null, because it should provide stable CancellationToken to finish enclosing tasks in Canceled state (not Faulted)
+      //In fact we shouldn't make it, because it should provide stable CancellationToken to finish enclosing tasks in Canceled state (not Faulted)
       //But to avoid memory leaks we must do it. So if you 1) run task with alive lifetime 2) terminate lifetime 3) in task invoke ThrowIfNotAlive() you can obtain `Faulted` state rather than `Canceled`. But it doesn't matter in `async-await` programming.     
       if (!ReferenceEquals(this, Terminated))
-        myCts = null;
+        myCts = Terminated.myCts;
       
       var statusIncrementedSuccessfully = IncrementStatusIfEqualsTo(LifetimeStatus.Terminating);
       Assertion.Assert(statusIncrementedSuccessfully, "{0}: bad status for destructuring finish", this);

--- a/rd-net/Test.Lifetimes/Lifetimes/LifetimeTest.cs
+++ b/rd-net/Test.Lifetimes/Lifetimes/LifetimeTest.cs
@@ -1224,6 +1224,30 @@ namespace Test.Lifetimes.Lifetimes
       Assert.True(lf.IsNotAlive);
     }
     
+
+    [Test]
+    public void CancellationTokenStressTest()
+    {
+      var cancel = new CancellationTokenSource(1000).Token;
+      
+      var def = new LifetimeDefinition();
+      Task.WaitAll(
+        Task.Run(() =>
+        {
+          while (!cancel.IsCancellationRequested)
+          {
+            def.Terminate();
+            Thread.Yield();
+            def = new LifetimeDefinition();
+          }
+        }),
+        Task.Run(() =>
+        {
+          while (!cancel.IsCancellationRequested) 
+            def.ToCancellationToken();
+        }));
+    }
+
 #endif
 
     [Test]

--- a/rd-net/Test.Lifetimes/Lifetimes/LifetimeTest.cs
+++ b/rd-net/Test.Lifetimes/Lifetimes/LifetimeTest.cs
@@ -1248,6 +1248,51 @@ namespace Test.Lifetimes.Lifetimes
         }));
     }
 
+    [Test]
+    public void CancellationTokenActualCancellationStressTest()
+    {
+      var cancel = new CancellationTokenSource(1000).Token;
+      
+      var sum = 0;
+      var def = Lifetime.Define();
+      Task.WaitAll(
+        Task.Run(() =>
+        {
+          while (!cancel.IsCancellationRequested)
+          {
+            def.Terminate();
+            Thread.Yield();
+            def = new LifetimeDefinition();
+          }
+        }),
+        Task.Run(CheckerProc),
+        Task.Run(CheckerProc),
+        Task.Run(CheckerProc),
+        Task.Run(CheckerProc),
+        Task.Run(CheckerProc),
+        Task.Run(CheckerProc)
+      );
+
+      void CheckerProc()
+      {
+        var cache = def;
+        var localSum = 0;
+        while (!cancel.IsCancellationRequested)
+        {
+          if (def != cache)
+          {
+            cache = def;
+            Interlocked.Increment(ref localSum);
+            cache.ToCancellationToken().Register(() => Interlocked.Decrement(ref localSum));
+          }
+        }
+        cache.Terminate();
+        Interlocked.Add(ref sum, localSum);
+      }
+
+      Assert.AreEqual(0, sum);
+    }
+
 #endif
 
     [Test]


### PR DESCRIPTION
This pull request fixes two issues regarding CancellationTokenSource in LifetimeDefinition:

  * First issue with destruction may lead to the null reference exception when cancellation token is being requested on terminating lifetime (kudos to @Denis-Korneev for noticing the failed test on teamcity and suggested fix)
 * Second issue is that not all subscribers are guaranteed to be notified about cancellation because of the error in the initialization of myCts.