### PR TITLE
TaskEx::NoAwait enchancement

### DIFF
--- a/rd-net/Lifetimes/Threading/TaskEx.cs
+++ b/rd-net/Lifetimes/Threading/TaskEx.cs
@@ -22,7 +22,7 @@ namespace JetBrains.Threading
             {
                 if (t.Exception != null && !t.Exception.IsOperationCanceled())
                     Log.Root.Error(t.Exception);
-            }, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted);
+            }, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.NotOnRanToCompletion);
         }
 
         


### PR DESCRIPTION
Enchancement for changes from [this PR](https://github.com/JetBrains/rd/pull/334) based on [similar issue](https://github.com/dotnet/orleans/issues/4728) in Orleans project.
 - Observe `Task.Exception` not only for faulted tasks, but for canceled tasks as well. This is supposed to prevent creating additional pressure on the finalizer queue from `TaskExceptionHolder.Finalize()`
 - Explicitly cache continuation action