### PR TITLE
rd-core: first approach to revamping the mutable collections

### DIFF
--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/reactive/ViewableMap.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/reactive/ViewableMap.kt
@@ -5,7 +5,6 @@ import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.put
 import com.jetbrains.rd.util.reactive.IViewableMap.Event
 
-
 class ViewableMap<K : Any, V : Any>() : IMutableViewableMap<K, V> {
 
     private val map = linkedMapOf<K, V>()
@@ -35,6 +34,15 @@ class ViewableMap<K : Any, V : Any>() : IMutableViewableMap<K, V> {
         val oldval = map.remove(key)
         if (oldval != null) change.fire(Event.Remove(key, oldval))
         return oldval
+    }
+
+    override fun remove(key: K, value: V): Boolean {
+        if (map.remove(key, value)) {
+            change.fire(Event.Remove(key, value))
+            return true
+        }
+
+        return false
     }
 
     override fun clear() {

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdSet.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdSet.kt
@@ -3,19 +3,15 @@ package com.jetbrains.rd.framework.impl
 import com.jetbrains.rd.framework.*
 import com.jetbrains.rd.framework.base.*
 import com.jetbrains.rd.util.lifetime.Lifetime
-import com.jetbrains.rd.util.reactive.AddRemove
-import com.jetbrains.rd.util.reactive.IMutableViewableSet
-import com.jetbrains.rd.util.reactive.IViewableSet
-import com.jetbrains.rd.util.reactive.ViewableSet
+import com.jetbrains.rd.util.reactive.*
 import com.jetbrains.rd.util.string.PrettyPrinter
 import com.jetbrains.rd.util.string.print
 import com.jetbrains.rd.util.string.printToString
 import com.jetbrains.rd.util.trace
 
-
 @Suppress("UNUSED_PARAMETER")
 class RdSet<T : Any> constructor(val valueSerializer: ISerializer<T>, private val set: ViewableSet<T>)
-: RdReactiveBase(), IMutableViewableSet<T> by set {
+: RdReactiveBase(), IMutableViewableSet<T> {
 
     companion object {
         fun<T: Any> read(ctx: SerializationCtx, stream: AbstractBuffer, valueSerializer: ISerializer<T>): RdSet<T> = RdSet(valueSerializer).withId(RdId.read(stream))
@@ -59,7 +55,16 @@ class RdSet<T : Any> constructor(val valueSerializer: ISerializer<T>, private va
 
     constructor(valueSerializer: ISerializer<T> = Polymorphic<T>()) : this(valueSerializer, ViewableSet())
 
+    override val size: Int
+        get() = set.size
+    override val change: ISource<IViewableSet.Event<T>>
+        get() = set.change
 
+    override fun contains(element: T): Boolean = set.contains(element)
+
+    override fun containsAll(elements: Collection<T>): Boolean = set.containsAll(elements)
+
+    override fun isEmpty(): Boolean = set.isEmpty()
 
     override fun print(printer: PrettyPrinter) {
         super.print(printer)
@@ -107,7 +112,6 @@ class RdSet<T : Any> constructor(val valueSerializer: ISerializer<T>, private va
     }
 
     override fun clear() = localChange { set.clear() }
-
 
     override fun advise(lifetime: Lifetime, handler: (IViewableSet.Event<T>) -> Unit) {
         if (isBound) assertThreading()

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdListTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdListTest.kt
@@ -155,5 +155,22 @@ class RdListTest : RdFrameworkTestBase() {
                 "finish 0"
         ), log)
     }
+
+    @Test
+    fun testAddAll() {
+        val id = 1
+
+        val serverList = RdList<String>().static(id)
+        val clientList = RdList<String>().static(id)
+
+        clientProtocol.bindStatic(clientList, "top")
+        serverProtocol.bindStatic(serverList, "top")
+
+        serverList.addAll(listOf("foo", "bar"))
+
+        assertEquals(2, clientList.count())
+        assertEquals("foo", clientList[0])
+        assertEquals("bar", clientList[1])
+    }
 }
 

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdMapTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdMapTest.kt
@@ -103,5 +103,20 @@ class RdMapTest : RdFrameworkTestBase() {
                 "finish 1", "finish 2"), log)
     }
 
+    @Test
+    fun testPutAll() {
+        val id = 1
 
+        val serverMap = RdMap<Int, String>().static(id)
+        val clientMap = RdMap<Int, String>().static(id)
+
+        clientProtocol.bindStatic(clientMap, "top")
+        serverProtocol.bindStatic(serverMap, "top")
+
+        serverMap.putAll(mapOf(1 to "foo", 2 to "bar"))
+
+        assertEquals(2, clientMap.count())
+        assertEquals("foo", clientMap[1])
+        assertEquals("bar", clientMap[2])
+    }
 }

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdSetTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdSetTest.kt
@@ -5,6 +5,7 @@ import com.jetbrains.rd.framework.impl.RdSet
 import com.jetbrains.rd.framework.test.util.RdFrameworkTestBase
 import com.jetbrains.rd.util.reactive.AddRemove
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 
@@ -44,5 +45,22 @@ class RdSetTest : RdFrameworkTestBase() {
 
         clientSet.clear()
         assertEquals(listOf(2, 0, 1, 8, 3, -2, -1, -3, -0, -8), log)
+    }
+
+    @Test
+    fun testAddAll() {
+        val id = 1
+
+        val serverSet = RdSet<String>().static(id)
+        val clientSet = RdSet<String>().static(id)
+
+        clientProtocol.bindStatic(clientSet, "top")
+        serverProtocol.bindStatic(serverSet, "top")
+
+        serverSet.addAll(listOf("foo", "bar"))
+
+        assertEquals(2, clientSet.count())
+        assertContains(clientSet, "foo")
+        assertContains(clientSet, "bar")
     }
 }


### PR DESCRIPTION
This is a partial solution for the most problematic areas of #338.

Some less commonly used APIs (such as mutable `keys`, `entries`, and `iterator`) are still broken, though.