### PR TITLE
Make changes to fix race condition in extension listener possible

### DIFF
--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/ExtCreationInfo.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/ExtCreationInfo.kt
@@ -1,9 +1,11 @@
 package com.jetbrains.rd.framework
 
+import com.jetbrains.rd.framework.base.RdExtBase
 import com.jetbrains.rd.util.string.RName
 
 data class ExtCreationInfo(
     val rName: RName,
     val rdId: RdId?,
-    val hash: Long
+    val hash: Long,
+    val ext: RdExtBase?
 )

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/MarshallerUtils.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/MarshallerUtils.kt
@@ -46,7 +46,7 @@ internal fun IRdDynamic.createExtSignal(): RdSignal<ExtCreationInfo> {
             val rName = RNameMarshaller.read(buffer)
             val rdId = buffer.readNullable { buffer.readRdId() }
             val hash = buffer.readLong()
-            ExtCreationInfo(rName, rdId, hash)
+            ExtCreationInfo(rName, rdId, hash, null)
         },
         { buffer, (rName, rdId, hash) ->
             RNameMarshaller.write(buffer, rName)

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Protocol.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Protocol.kt
@@ -61,7 +61,7 @@ class Protocol internal constructor(
 
     override val extCreated: ISignal<ExtCreationInfo>
 
-    private val extConfirmation: RdSignal<ExtCreationInfo>
+    val extConfirmation: RdSignal<ExtCreationInfo>
     private val extIsLocal: ThreadLocal<Boolean>
 
     private val extensions = mutableMapOf<KClass<*>, Any>()

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
@@ -54,7 +54,7 @@ abstract class RdExtBase : RdReactiveBase() {
                     it.outOfSyncModels.flowInto(lifetime, super.protocol.outOfSyncModels) { model -> model }
                 }
 
-                val info = ExtCreationInfo(location, (parent as? RdBindableBase)?.containingExt?.rdid, serializationHash)
+                val info = ExtCreationInfo(location, (parent as? RdBindableBase)?.containingExt?.rdid, serializationHash, this)
                 (parentProtocol as Protocol).submitExtCreated(info)
             },
             {

--- a/rd-net/RdFramework/Base/RdExtBase.cs
+++ b/rd-net/RdFramework/Base/RdExtBase.cs
@@ -59,7 +59,7 @@ namespace JetBrains.Rd.Base
         );
 
       var bindableParent = Parent is RdBindableBase bindable ? bindable : null;
-      var info = new ExtCreationInfo(Location, bindableParent?.ContainingExt?.RdId, SerializationHash);
+      var info = new ExtCreationInfo(Location, bindableParent?.ContainingExt?.RdId, SerializationHash, this);
       ((Protocol) parentProtocol).SubmitExtCreated(info);
       parentWire.Advise(lifetime, this);
             

--- a/rd-net/RdFramework/ExtCreationInfo.cs
+++ b/rd-net/RdFramework/ExtCreationInfo.cs
@@ -1,4 +1,5 @@
 ﻿using JetBrains.Diagnostics;
+using JetBrains.Rd.Base;
 
 namespace JetBrains.Rd
 {
@@ -7,12 +8,14 @@ namespace JetBrains.Rd
     public RName Name;
     public RdId? Id;
     public long Hash;
+    public RdExtBase? Ext;
 
-    public ExtCreationInfo(RName name, RdId? id, long hash)
+    public ExtCreationInfo(RName name, RdId? id, long hash, RdExtBase? ext)
     {
       Name = name;
       Id = id;
       Hash = hash;
+      Ext = ext;
     }
   }
 }

--- a/rd-net/RdFramework/Impl/ExtCreatedUtils.cs
+++ b/rd-net/RdFramework/Impl/ExtCreatedUtils.cs
@@ -16,7 +16,7 @@ namespace JetBrains.Rd.Impl
           var rName = ReadRName(reader);
           var rdId = reader.ReadNullableStruct((_, r) => r.ReadRdId(), ctx);
           var hash = reader.ReadLong();
-          return new ExtCreationInfo(rName, rdId, hash);
+          return new ExtCreationInfo(rName, rdId, hash, null);
         },
         (ctx, writer, value) =>
         {

--- a/rd-net/RdFramework/Impl/Protocol.cs
+++ b/rd-net/RdFramework/Impl/Protocol.cs
@@ -115,7 +115,7 @@ namespace JetBrains.Rd.Impl
     
     public ISignal<ExtCreationInfo> ExtCreated { get; }
     
-    private RdSignal<ExtCreationInfo> ExtConfirmation { get; }
+    public RdSignal<ExtCreationInfo> ExtConfirmation { get; }
 
     private ThreadLocal<bool> ExtIsLocal { get; }
 


### PR DESCRIPTION
1. `extConfirmation` signal in Protocol was made public.
2. `ExtCreationInfo` now contains an optional field with the extension instance itself.

The first change may be reverted in the future when we support triggering the signal for local extension creation. The second change should remain anyway but may migrate to another class later.