### PR TITLE
Improvments

### DIFF
--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/util/LifetimeCoroutineUtil.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/util/LifetimeCoroutineUtil.kt
@@ -111,6 +111,10 @@ fun Lifetime.createTerminatedAfter(duration: Duration, terminationContext: Corou
         }
     }
 
+
+/**
+ * Creates a [coroutineScope] that will be cancelled on the passed lifetime termination
+ **/
 suspend fun <T> lifetimedCoroutineScope(lifetime: Lifetime, action: suspend CoroutineScope.() -> T) = coroutineScope {
     if (!lifetime.isEternal)
         lifetime.createNested().synchronizeWith(coroutineContext[Job]!!)

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/util/LifetimeCoroutineUtil.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/util/LifetimeCoroutineUtil.kt
@@ -59,6 +59,7 @@ fun <T> Lifetime.startAsync(
     block: suspend CoroutineScope.() -> T
 ) = startAsync(scheduler.asCoroutineDispatcher, start, block)
 
+@Deprecated("Use launch without lifetime or lifetimedCoroutineScope")
 fun CoroutineScope.launchChild(
     lifetime: Lifetime,
     context: CoroutineContext = EmptyCoroutineContext,
@@ -66,6 +67,7 @@ fun CoroutineScope.launchChild(
     block: suspend CoroutineScope.() -> Unit
 ) = launch(context, start, block).also { job -> lifetime.createNested().synchronizeWith(job) }
 
+@Deprecated("Use launch method without lifetime or lifetimedCoroutineScope")
 fun CoroutineScope.launchChild(
     lifetime: Lifetime,
     scheduler: IScheduler,
@@ -73,6 +75,7 @@ fun CoroutineScope.launchChild(
     block: suspend CoroutineScope.() -> Unit
 ) = launchChild(lifetime, scheduler.asCoroutineDispatcher, start, block)
 
+@Deprecated("Use async without lifetime or lifetimedCoroutineScope")
 fun <T> CoroutineScope.startChildAsync(
     lifetime: Lifetime,
     context: CoroutineContext = EmptyCoroutineContext,
@@ -80,6 +83,7 @@ fun <T> CoroutineScope.startChildAsync(
     block: suspend CoroutineScope.() -> T
 ) = async(context, start, block).also { job -> lifetime.createNested().synchronizeWith(job) }
 
+@Deprecated("Use async without lifetime or lifetimedCoroutineScope")
 fun <T> CoroutineScope.startChildAsync(
     lifetime: Lifetime,
     scheduler: IScheduler,
@@ -88,11 +92,8 @@ fun <T> CoroutineScope.startChildAsync(
 ) = startChildAsync(lifetime, scheduler.asCoroutineDispatcher, start, block)
 
 suspend fun <T> withContext(lifetime: Lifetime, context: CoroutineContext, block: suspend CoroutineScope.() -> T): T =
-    withContext(context) {
-        if (!lifetime.isEternal)
-            lifetime.createNested().synchronizeWith(coroutineContext[Job]!!)
-
-        block()
+    lifetimedCoroutineScope(lifetime) {
+        withContext(context, block)
     }
 
 suspend fun <T> withContext(scheduler: IScheduler, block: suspend CoroutineScope.() -> T): T =
@@ -109,3 +110,10 @@ fun Lifetime.createTerminatedAfter(duration: Duration, terminationContext: Corou
             nested.terminate()
         }
     }
+
+suspend fun <T> lifetimedCoroutineScope(lifetime: Lifetime, action: suspend CoroutineScope.() -> T) = coroutineScope {
+    if (!lifetime.isEternal)
+        lifetime.createNested().synchronizeWith(coroutineContext[Job]!!)
+
+    action()
+}

--- a/rd-net/Lifetimes/Diagnostics/LogEx.cs
+++ b/rd-net/Lifetimes/Diagnostics/LogEx.cs
@@ -184,7 +184,36 @@ namespace JetBrains.Diagnostics
       {
         logger.Log(LoggingLevel.VERBOSE, messageHandler.ToStringAndClear());
       }      
-    }    
+    }
+
+    /// <summary>
+    /// Log the message if <see cref="LoggingLevel.VERBOSE"/> is enabled, otherwise the message will not be logged, moreover, no calculations (including method calls) will be performed.
+    /// <br />
+    /// <br />
+    /// For example, the code below
+    /// <code>
+    /// logger.Verbose(ex, $"{DoSmthSlow()}");
+    /// </code>
+    /// 
+    /// will be compiled into
+    /// 
+    /// <code>
+    /// var handler = new JetLogVerboseInterpolatedStringHandler(logger, out var isEnabled);
+    /// if (isEnabled)
+    ///   handler.Append(DoSmthSlow());
+    /// logger.Verbose(ex, ref handler);
+    /// </code>
+    /// </summary>
+    /// <param name="logger"></param>
+    /// <param name="ex"></param>
+    /// <param name="messageHandler"></param>
+    public static void Verbose(this ILog logger, Exception ex, [InterpolatedStringHandlerArgument("logger")] ref JetLogVerboseInterpolatedStringHandler messageHandler)
+    {
+      if (messageHandler.IsEnabled)
+      {
+        logger.Verbose(ex, messageHandler.ToStringAndClear());
+      }
+    }
 #endif
 
     [StringFormatMethod("message")]
@@ -269,7 +298,36 @@ namespace JetBrains.Diagnostics
       {
         logger.Log(LoggingLevel.INFO, messageHandler.ToStringAndClear());
       }      
-    }    
+    }
+
+    /// <summary>
+    /// Log the message if <see cref="LoggingLevel.INFO"/> is enabled, otherwise the message will not be logged, moreover, no calculations (including method calls) will be performed.
+    /// <br />
+    /// <br />
+    /// For example, the code below
+    /// <code>
+    /// logger.Info(ex, $"{DoSmthSlow()}");
+    /// </code>
+    /// 
+    /// will be compiled into
+    /// 
+    /// <code>
+    /// var handler = new JetLogInfoInterpolatedStringHandler(logger, out var isEnabled);
+    /// if (isEnabled)
+    ///   handler.Append(DoSmthSlow());
+    /// logger.Info(ex, ref handler);
+    /// </code>
+    /// </summary>
+    /// <param name="logger"></param>
+    /// <param name="ex"></param>
+    /// <param name="messageHandler"></param>
+    public static void Info(this ILog logger, Exception ex, [InterpolatedStringHandlerArgument("logger")] ref JetLogInfoInterpolatedStringHandler messageHandler)
+    {
+      if (messageHandler.IsEnabled)
+      {
+        logger.Info(ex, messageHandler.ToStringAndClear());
+      }
+    }
 #endif
 
     [StringFormatMethod("message")]
@@ -319,7 +377,36 @@ namespace JetBrains.Diagnostics
       {
         logger.Log(LoggingLevel.WARN, messageHandler.ToStringAndClear());
       }      
-    }    
+    }
+
+    /// Log the message if <see cref="LoggingLevel.WARN"/> is enabled, otherwise the message will not be logged, moreover, no calculations (including method calls) will be performed.
+    /// <br />
+    /// <br />
+    /// For example, the code below
+    /// <code>
+    /// logger.Warn(ex, $"{DoSmthSlow()}");
+    /// </code>
+    /// 
+    /// will be compiled into
+    /// 
+    /// <code>
+    /// var handler = new JetLogWarnInterpolatedStringHandler(logger, out var isEnabled);
+    /// if (isEnabled)
+    ///   handler.Append(DoSmthSlow());
+    /// logger.Warn(ex, ref handler);
+    /// </code>
+    /// </summary>
+    /// <param name="logger"></param>
+    /// <param name="ex"></param>
+    /// <param name="messageHandler"></param>
+    public static void Warn(this ILog logger, Exception ex, [InterpolatedStringHandlerArgument("logger")] ref JetLogWarnInterpolatedStringHandler messageHandler)
+    {
+      if (messageHandler.IsEnabled)
+      {
+        logger.Warn(ex, messageHandler.ToStringAndClear());
+      }
+    }
+
 #endif
 
     [StringFormatMethod("message")]
@@ -370,7 +457,37 @@ namespace JetBrains.Diagnostics
       {
         logger.Log(LoggingLevel.ERROR, messageHandler.ToStringAndClear());
       }      
-    }    
+    }
+
+    /// <summary>
+    /// Log the message if <see cref="LoggingLevel.ERROR"/> is enabled, otherwise the message will not be logged, moreover, no calculations (including method calls) will be performed.
+    /// <br />
+    /// <br />
+    /// For example, the code below
+    /// <code>
+    /// logger.Error(ex, $"{DoSmthSlow()}");
+    /// </code>
+    /// 
+    /// will be compiled into
+    /// 
+    /// <code>
+    /// var handler = new JetLogErrorInterpolatedStringHandler(logger, out var isEnabled);
+    /// if (isEnabled)
+    ///   handler.Append(DoSmthSlow());
+    /// logger.Error(ex, ref handler);
+    /// </code>
+    /// </summary>
+    /// <param name="logger"></param>
+    /// <param name="ex"></param>
+    /// <param name="messageHandler"></param>
+    [StringFormatMethod("message")]
+    public static void Error(this ILog logger, Exception ex, [InterpolatedStringHandlerArgument("logger")] ref JetLogErrorInterpolatedStringHandler messageHandler)
+    {
+      if (messageHandler.IsEnabled)
+      {
+        logger.Error(ex, messageHandler.ToStringAndClear());
+      }
+    }
 #endif
 
     [StringFormatMethod("message")]


### PR DESCRIPTION
Introduce lifetimedCoroutineScope
Deprecate launchChild and startChildAsync api (It is now preferable to use only launch and async (without lifetime) or use lifetimedCoroutineScope
Add overloads for LogEx with String Interpolated Handlers