### PR TITLE
Performance: short-circuit Bind0 for collections

### DIFF
--- a/rd-net/RdFramework/Base/IRdBindable.cs
+++ b/rd-net/RdFramework/Base/IRdBindable.cs
@@ -84,7 +84,11 @@ namespace JetBrains.Rd.Base
 
       var cnt = 0;
       foreach (var item in items)
-        (item as IRdBindable).BindEx(lifetime, parent, name + "[" + cnt++ + "]");
+      {
+        if (item is not IRdBindable bindable)
+          return;
+        bindable.BindEx(lifetime, parent, name + "[" + cnt++ + "]");
+      }
     }
 
 


### PR DESCRIPTION
There are two issues that cause this method to take a significant amount of time. 

```
  100%   <View>b__0  •  64 ms  •  JetBrains.Collections.Viewable.ReactiveEx+<>c__DisplayClass18_0`2.<View>b__0(AddRemove, K, V)
    75,6%   <Init>b__0  •  48 ms  •  JetBrains.Rd.Impl.RdMap`2+<>c__DisplayClass31_0.<Init>b__0(Lifetime, K, V)
      73,0%   BindPolymorphic  •  47 ms  •  JetBrains.Rd.Base.RdBindableEx.BindPolymorphic(Object, Lifetime, IRdDynamic, String)
        73,0%   Bind0  •  47 ms  •  JetBrains.Rd.Base.RdBindableEx.Bind0(IEnumerable, Lifetime, IRdDynamic, String)
        ► 31,6%   GetValue  •  20 ms  •  System.Array.GetValue(Int32)
        ► 22,8%   Concat  •  15 ms  •  System.String.Concat(String, String, String, String)
        ► 10,8%   COMNumber::FormatInt32  •  6,9 ms  •  clr.dll!COMNumber::FormatInt32
        ► 5,65%   get_CurrentInfo  •  3,6 ms  •  System.Globalization.NumberFormatInfo.get_CurrentInfo()
          1,63%   get_Current  •  1,0 ms  •  System.Array+SZArrayEnumerator.get_Current()
          0,50%   [Unknown]  •  0,3 ms
    ► 2,61%   ToString  •  1,7 ms  •  JetBrains.DocumentModel.RunningDocumentId.ToString()
    13,0%   [Unknown]  •  8,3 ms
  ► 8,26%   <View>b__0  •  5,3 ms  •  JetBrains.Collections.Viewable.ReactiveEx+<>c__DisplayClass12_0`2.<View>b__0(Lifetime, K, V)
  ► 3,13%   get_Item  •  2,0 ms  •  System.Collections.Generic.Dictionary`2.get_Item(TKey)

#stacktrace
```


1.	There are a lot of strings being produced as names, even when they are not required (e.g. item is not bindable)
2.	It is reasonable to introduce a contract that either all items are bindable or neither. In that case we can omit iterating over the collection of ints, for example. And it makes the implementation of Bind0 consistent with IsBindable.
