### PR TITLE
Drop default constructors of RdList, RdMap, etc

### DIFF
--- a/rd-net/RdFramework/Impl/RdList.cs
+++ b/rd-net/RdFramework/Impl/RdList.cs
@@ -27,8 +27,6 @@ namespace JetBrains.Rd.Impl
     private readonly ViewableList<V> myList = new ViewableList<V>();
        
     
-    public RdList() : this(Polymorphic<V>.Read, Polymorphic<V>.Write) {}
-
     public RdList(CtxReadDelegate<V> readValue, CtxWriteDelegate<V> writeValue, long nextVersion = 1L)
     {
       myNextVersion = nextVersion;

--- a/rd-net/RdFramework/Impl/RdMap.cs
+++ b/rd-net/RdFramework/Impl/RdMap.cs
@@ -20,8 +20,6 @@ namespace JetBrains.Rd.Impl
   {
     private readonly ViewableMap<K, V> myMap = new ViewableMap<K, V>();
 
-    public RdMap() : this(Polymorphic<K>.Read, Polymorphic<K>.Write, Polymorphic<V>.Read, Polymorphic<V>.Write) {}
-
     public RdMap(CtxReadDelegate<K> readKey, CtxWriteDelegate<K> writeKey, CtxReadDelegate<V> readValue, CtxWriteDelegate<V> writeValue)
     {
       ValueCanBeNull = false;

--- a/rd-net/RdFramework/Impl/RdProperty.cs
+++ b/rd-net/RdFramework/Impl/RdProperty.cs
@@ -18,8 +18,6 @@ namespace JetBrains.Rd.Impl
 
     public override event PropertyChangedEventHandler? PropertyChanged;
 
-    public RdProperty() : this(Polymorphic<T>.Read, Polymorphic<T>.Write) {}
-
     public RdProperty(CtxReadDelegate<T> readValue, CtxWriteDelegate<T> writeValue)
     {
       ReadValueDelegate = readValue;

--- a/rd-net/RdFramework/Impl/RdSet.cs
+++ b/rd-net/RdFramework/Impl/RdSet.cs
@@ -15,8 +15,6 @@ namespace JetBrains.Rd.Impl
   {
     private readonly IViewableSet<T> mySet;
 
-    public RdSet() : this(Polymorphic<T>.Read, Polymorphic<T>.Write) {}
-
     public RdSet(CtxReadDelegate<T> readValue, CtxWriteDelegate<T> writeValue, IViewableSet<T>? backingSet)
     {
       ValueCanBeNull = false;

--- a/rd-net/RdFramework/Impl/RdSignal.cs
+++ b/rd-net/RdFramework/Impl/RdSignal.cs
@@ -41,10 +41,6 @@ namespace JetBrains.Rd.Impl
     public IScheduler? Scheduler { get; set; }
 
 
-    public RdSignal() : this(Polymorphic<T>.Read, Polymorphic<T>.Write)
-    {
-    }
-
     public RdSignal(CtxReadDelegate<T> readValue, CtxWriteDelegate<T> writeValue)
     {
       ReadValueDelegate = readValue;

--- a/rd-net/RdFramework/Tasks/RdCall.cs
+++ b/rd-net/RdFramework/Tasks/RdCall.cs
@@ -48,11 +48,6 @@ namespace JetBrains.Rd.Tasks
       WriteResponseDelegate = writeResponse;
     }
 
-    public RdCall() : this(Polymorphic<TReq>.Read, Polymorphic<TReq>.Write, Polymorphic<TRes>.Read, Polymorphic<TRes>.Write)
-    {
-    }
-
-
     protected override void Init(Lifetime lifetime)
     {
       base.Init(lifetime);

--- a/rd-net/Test.RdFramework/Contexts/RdContextBasicTest.cs
+++ b/rd-net/Test.RdFramework/Contexts/RdContextBasicTest.cs
@@ -53,8 +53,8 @@ namespace Test.RdFramework.Contexts
     {
       var key = heavy ? TestKeyHeavy.Instance : (RdContext<string>) TestKeyLight.Instance;
       
-      var serverSignal = BindToServer(LifetimeDefinition.Lifetime, new RdSignal<string>(), 1);
-      var clientSignal = BindToClient(LifetimeDefinition.Lifetime, new RdSignal<string>(), 1);
+      var serverSignal = BindToServer(LifetimeDefinition.Lifetime, NewRdSignal<string>(), 1);
+      var clientSignal = BindToClient(LifetimeDefinition.Lifetime, NewRdSignal<string>(), 1);
 
       key.RegisterOn(ClientProtocol.Serializers);
       ServerProtocol.Contexts.RegisterContext(key);

--- a/rd-net/Test.RdFramework/Contexts/RdContextEarlyDeliveryTest.cs
+++ b/rd-net/Test.RdFramework/Contexts/RdContextEarlyDeliveryTest.cs
@@ -114,13 +114,13 @@ namespace Test.RdFramework.Contexts
       myServerWire.AutoTransmitMode = true;
       myClientWire.AutoTransmitMode = true;
       
-      var serverSignal = BindToServer(LifetimeDefinition.Lifetime, new RdSignal<string>(), 1);
+      var serverSignal = BindToServer(LifetimeDefinition.Lifetime, NewRdSignal<string>(), 1);
 
       using var _ = key.UpdateValue("1");
       
       serverSignal.Fire("");
 
-      var clientSignal = BindToClient(LifetimeDefinition.Lifetime, new RdSignal<string>(), 1);
+      var clientSignal = BindToClient(LifetimeDefinition.Lifetime, NewRdSignal<string>(), 1);
 
       Lifetime.Using(lt =>
       {

--- a/rd-net/Test.RdFramework/Contexts/RdPerContextMapTest.cs
+++ b/rd-net/Test.RdFramework/Contexts/RdPerContextMapTest.cs
@@ -19,8 +19,8 @@ namespace Test.RdFramework.Contexts
     {
       var key = RdContextBasicTest.TestKeyHeavy.Instance;
 
-      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => new RdMap<int, string>());
-      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => new RdMap<int, string>());
+      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => NewRdMap<int, string>());
+      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => NewRdMap<int, string>());
 
       var server1Cid = "Server-1";
       var client1Cid = "Client-1";
@@ -50,8 +50,8 @@ namespace Test.RdFramework.Contexts
     {
       var key = RdContextBasicTest.TestKeyHeavy.Instance;
 
-      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => new RdMap<int, string>());
-      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => new RdMap<int, string>());
+      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => NewRdMap<int, string>());
+      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => NewRdMap<int, string>());
 
       var server1Cid = "Server-1";
       var client1Cid = "Client-1";
@@ -80,8 +80,8 @@ namespace Test.RdFramework.Contexts
     {
       var key = RdContextBasicTest.TestKeyHeavy.Instance;
 
-      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => new RdMap<int, string>());
-      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => new RdMap<int, string>());
+      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => NewRdMap<int, string>());
+      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => NewRdMap<int, string>());
 
       var server1Cid = "Server-1";
       var client1Cid = "Client-1";
@@ -107,8 +107,8 @@ namespace Test.RdFramework.Contexts
     {
       var key = RdContextBasicTest.TestKeyHeavy.Instance;
 
-      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => new RdMap<int, string>());
-      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => new RdMap<int, string>());
+      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => NewRdMap<int, string>());
+      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => NewRdMap<int, string>());
 
       var server1Cid = "Server-1";
       var client1Cid = "Client-1";
@@ -142,8 +142,8 @@ namespace Test.RdFramework.Contexts
     {
       var key = RdContextBasicTest.TestKeyHeavy.Instance;
 
-      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => new RdMap<int, string>());
-      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => new RdMap<int, string>());
+      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => NewRdMap<int, string>());
+      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => NewRdMap<int, string>());
 
       var server1Cid = "Server-1";
       var client1Cid = "Client-1";
@@ -176,8 +176,8 @@ namespace Test.RdFramework.Contexts
     {
       var key = RdContextBasicTest.TestKeyHeavy.Instance;
 
-      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => new RdMap<int, string>());
-      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => new RdMap<int, string>());
+      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => NewRdMap<int, string>());
+      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => NewRdMap<int, string>());
 
       var server1Cid = "Server-1";
 
@@ -208,8 +208,8 @@ namespace Test.RdFramework.Contexts
     {
       var key = RdContextBasicTest.TestKeyHeavy.Instance;
 
-      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => new RdMap<int, string>());
-      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => new RdMap<int, string>());
+      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => NewRdMap<int, string>());
+      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key, _ => NewRdMap<int, string>());
 
       var server1Cid = "Server-1";
 
@@ -244,8 +244,8 @@ namespace Test.RdFramework.Contexts
       var key1 = RdContextBasicTest.TestKeyHeavy.Instance;
       var key2 = RdContextBasicTest.TestKey2.Instance;
 
-      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key1, _ => new RdMap<int, string>());
-      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key1, _ => new RdMap<int, string>());
+      var serverMap = new RdPerContextMap<string, RdMap<int, string>>(key1, _ => NewRdMap<int, string>());
+      var clientMap = new RdPerContextMap<string, RdMap<int, string>>(key1, _ => NewRdMap<int, string>());
 
       var server1Cid = "Server-1";
       var server2Cid = "Server-2";

--- a/rd-net/Test.RdFramework/RdIdHierarchyGuardTest.cs
+++ b/rd-net/Test.RdFramework/RdIdHierarchyGuardTest.cs
@@ -17,8 +17,8 @@ namespace Test.RdFramework
     [Test]    
     public void Test()
     {
-      var serverMap = BindToServer(LifetimeDefinition.Lifetime, new RdMap<int, Model> { IsMaster = true }, ourMapKey);
-      var clientMap = BindToClient(LifetimeDefinition.Lifetime, new RdMap<int, Model> { IsMaster = false }, ourMapKey);      
+      var serverMap = BindToServer(LifetimeDefinition.Lifetime, NewRdMap<int, Model>(isMaster: true), ourMapKey);
+      var clientMap = BindToClient(LifetimeDefinition.Lifetime, NewRdMap<int, Model>(isMaster: false), ourMapKey);
 
       ServerProtocol.Serializers.Register(Model.Read, Model.Write);
       ClientProtocol.Serializers.Register(Model.Read, Model.Write);
@@ -49,7 +49,7 @@ namespace Test.RdFramework
 
       public Model()
       {
-        myValue = new RdProperty<int>();
+        myValue = NewRdProperty<int>();
       }
 
       private Model(RdProperty<int> modelProperty)

--- a/rd-net/Test.RdFramework/RdListTest.cs
+++ b/rd-net/Test.RdFramework/RdListTest.cs
@@ -16,8 +16,8 @@ namespace Test.RdFramework
     [Test]
     public void Test1()
     {
-      var serverList = BindToServer(TestLifetime, new RdList<string> { OptimizeNested = true }, ourKey);
-      var clientList = BindToClient(TestLifetime, new RdList<string> { OptimizeNested = true }, ourKey);
+      var serverList = BindToServer(TestLifetime, NewRdList<string>(optimizeNested: true), ourKey);
+      var clientList = BindToClient(TestLifetime, NewRdList<string>(optimizeNested: true), ourKey);
 
       Assert.True(serverList.Count == 0);
       Assert.True(clientList.Count == 0);
@@ -47,8 +47,8 @@ namespace Test.RdFramework
     [Test]
     public void Test2()
     {
-      var serverList = BindToServer(TestLifetime, new RdList<string> { OptimizeNested = true}, ourKey);
-      var clientList = BindToClient(TestLifetime, new RdList<string> { OptimizeNested = true }, ourKey);
+      var serverList = BindToServer(TestLifetime, NewRdList<string>(optimizeNested: true), ourKey);
+      var clientList = BindToClient(TestLifetime, NewRdList<string>(optimizeNested: true), ourKey);
 
       var log = new List<string>();
       clientList.Advise(TestLifetime, (e) => log.Add(e.Kind + " " + e.Index + " " + e.NewValue));   
@@ -71,8 +71,8 @@ namespace Test.RdFramework
     [Test]
     public void TestLifetimes1()
     {
-      var serverList = BindToServer(TestLifetime, new RdList<string> { OptimizeNested = true }, ourKey);
-      var clientList = BindToClient(TestLifetime, new RdList<string> { OptimizeNested = true }, ourKey);
+      var serverList = BindToServer(TestLifetime, NewRdList<string>(optimizeNested: true), ourKey);
+      var clientList = BindToClient(TestLifetime, NewRdList<string>(optimizeNested: true), ourKey);
 
       var itemRemoved = "";
 
@@ -90,8 +90,8 @@ namespace Test.RdFramework
     [Test]
     public void TestLifetimes2()
     {
-      var serverList = BindToServer(LifetimeDefinition.Lifetime, new RdList<string> { OptimizeNested = true }, ourKey);
-      var clientList = BindToClient(LifetimeDefinition.Lifetime, new RdList<string> { OptimizeNested = true }, ourKey);
+      var serverList = BindToServer(LifetimeDefinition.Lifetime, NewRdList<string>(optimizeNested: true), ourKey);
+      var clientList = BindToClient(LifetimeDefinition.Lifetime, NewRdList<string>(optimizeNested: true), ourKey);
 
       var itemRemovedServer = false;
       var itemRemovedClient = false;
@@ -121,8 +121,8 @@ namespace Test.RdFramework
     [Test]
     public void TestNullability()
     {
-      var serverList = BindToServer(LifetimeDefinition.Lifetime, new RdList<string> {OptimizeNested = true}, ourKey);
-      var clientList = BindToClient(LifetimeDefinition.Lifetime, new RdList<string> {OptimizeNested = true}, ourKey);
+      var serverList = BindToServer(LifetimeDefinition.Lifetime, NewRdList<string>(optimizeNested: true), ourKey);
+      var clientList = BindToClient(LifetimeDefinition.Lifetime, NewRdList<string>(optimizeNested: true), ourKey);
 
       Assert.Throws<ArgumentNullException>(() => { serverList.Add(null); });
       ServerWire.TransmitAllMessages();

--- a/rd-net/Test.RdFramework/RdMapTest.cs
+++ b/rd-net/Test.RdFramework/RdMapTest.cs
@@ -17,8 +17,8 @@ namespace Test.RdFramework
     [Test]
     public void Test1()
     {
-      var serverMap = BindToServer(LifetimeDefinition.Lifetime, new RdMap<int, string> { IsMaster = true, OptimizeNested = true }, ourKey);
-      var clientMap = BindToClient(LifetimeDefinition.Lifetime, new RdMap<int, string> { IsMaster = false, OptimizeNested = true }, ourKey);
+      var serverMap = BindToServer(LifetimeDefinition.Lifetime, NewRdMap<int, string>(isMaster: true, optimizeNested: true), ourKey);
+      var clientMap = BindToClient(LifetimeDefinition.Lifetime, NewRdMap<int, string>(isMaster: false, optimizeNested: true), ourKey);
 
       Assert.True(serverMap.Count == 0);
       Assert.True(clientMap.Count == 0);
@@ -55,8 +55,8 @@ namespace Test.RdFramework
     [Test]
     public void Test2()
     {
-      var serverMap = BindToServer(LifetimeDefinition.Lifetime, new RdMap<int, string> {IsMaster = true, OptimizeNested = true}, ourKey);
-      var clientMap = BindToClient(LifetimeDefinition.Lifetime, new RdMap<int, string> { IsMaster = false, OptimizeNested = true }, ourKey);
+      var serverMap = BindToServer(LifetimeDefinition.Lifetime, NewRdMap<int, string>(isMaster: true, optimizeNested: true), ourKey);
+      var clientMap = BindToClient(LifetimeDefinition.Lifetime, NewRdMap<int, string>(isMaster: false, optimizeNested: true), ourKey);
 
       var log = new List<string>();
       clientMap.Advise(LifetimeDefinition.Lifetime, (e) => log.Add(e.Kind + " " + e.Key + " " + e.NewValue));   
@@ -81,8 +81,8 @@ namespace Test.RdFramework
     [Test]
     public void TestLifetimes1()
     {
-      var serverMap = BindToServer(LifetimeDefinition.Lifetime, new RdMap<int, string> { IsMaster = true, OptimizeNested = true }, ourKey);
-      var clientMap = BindToClient(LifetimeDefinition.Lifetime, new RdMap<int, string> { IsMaster = false, OptimizeNested = true }, ourKey);
+      var serverMap = BindToServer(LifetimeDefinition.Lifetime, NewRdMap<int, string>(isMaster: true, optimizeNested: true), ourKey);
+      var clientMap = BindToClient(LifetimeDefinition.Lifetime, NewRdMap<int, string>(isMaster: false, optimizeNested: true), ourKey);
 
       var itemRemoved = "";
 
@@ -99,8 +99,8 @@ namespace Test.RdFramework
     [Test]
     public void TestLifetimes2()
     {
-      var serverMap = BindToServer(LifetimeDefinition.Lifetime, new RdMap<int, string> { IsMaster = true, OptimizeNested = true }, ourKey);
-      var clientMap = BindToClient(LifetimeDefinition.Lifetime, new RdMap<int, string> { IsMaster = false, OptimizeNested = true }, ourKey);
+      var serverMap = BindToServer(LifetimeDefinition.Lifetime, NewRdMap<int, string>(isMaster: true, optimizeNested: true), ourKey);
+      var clientMap = BindToClient(LifetimeDefinition.Lifetime, NewRdMap<int, string>(isMaster: false, optimizeNested: true), ourKey);
 
       var itemRemovedServer = false;
       var itemRemovedClient = false;
@@ -131,8 +131,8 @@ namespace Test.RdFramework
     [Test]
     public void TestNullability()
     {
-      var serverMap = BindToServer(LifetimeDefinition.Lifetime, new RdMap<string, string> {IsMaster = true, OptimizeNested = true}, ourKey);
-      var clientMap = BindToClient(LifetimeDefinition.Lifetime, new RdMap<string, string> {IsMaster = false, OptimizeNested = true}, ourKey);
+      var serverMap = BindToServer(LifetimeDefinition.Lifetime, NewRdMap<string, string>(isMaster: true, optimizeNested: true), ourKey);
+      var clientMap = BindToClient(LifetimeDefinition.Lifetime, NewRdMap<string, string>(isMaster: false, optimizeNested: true), ourKey);
 
       Assert.Throws<Assertion.AssertionException>(() => { serverMap.Add("", null); });
       Assert.Throws<ArgumentNullException>(() => { serverMap.Add(null, ""); });

--- a/rd-net/Test.RdFramework/RdPropertyTest.cs
+++ b/rd-net/Test.RdFramework/RdPropertyTest.cs
@@ -11,16 +11,11 @@ namespace Test.RdFramework
   {
     private static readonly int ourKey = 1;
 
-//    private static RdProperty<string> CreateProperty(IProtocol protocol, bool isMaster)
-//    {
-//      return new RdProperty<string>(Lifetime.Eternal, protocol, ourKey, isMaster);
-//    }
-
     [Test]
     public void Test1()
     {
-      var serverProperty = BindToServer(LifetimeDefinition.Lifetime, new RdProperty<string> { IsMaster = true }, ourKey);
-      var clientProperty = BindToClient(LifetimeDefinition.Lifetime, new RdProperty<string> { IsMaster = false }, ourKey);
+      var serverProperty = BindToServer(LifetimeDefinition.Lifetime, NewRdProperty<string>(isMaster: true), ourKey);
+      var clientProperty = BindToClient(LifetimeDefinition.Lifetime, NewRdProperty<string>(isMaster: false), ourKey);
 
       // Everything is empty
       Assert.False(serverProperty.Maybe.HasValue);
@@ -47,8 +42,8 @@ namespace Test.RdFramework
     [Test]
     public void Test2()
     {
-      var serverProperty = BindToServer(LifetimeDefinition.Lifetime, new RdProperty<string> { IsMaster = true }, ourKey);
-      var clientProperty = BindToClient(LifetimeDefinition.Lifetime, new RdProperty<string> { IsMaster = false }, ourKey);
+      var serverProperty = BindToServer(LifetimeDefinition.Lifetime, NewRdProperty<string>(isMaster: true), ourKey);
+      var clientProperty = BindToClient(LifetimeDefinition.Lifetime, NewRdProperty<string>(isMaster: false), ourKey);
 
       // Server -> Client
       serverProperty.SetValue("Server value 1");
@@ -72,8 +67,8 @@ namespace Test.RdFramework
     [Test]
     public void Test3()
     {
-      var serverProperty = BindToServer(LifetimeDefinition.Lifetime, new RdProperty<string> { IsMaster = true }, ourKey);
-      var clientProperty = BindToClient(LifetimeDefinition.Lifetime, new RdProperty<string> { IsMaster = false }, ourKey);
+      var serverProperty = BindToServer(LifetimeDefinition.Lifetime, NewRdProperty<string>(isMaster: true), ourKey);
+      var clientProperty = BindToClient(LifetimeDefinition.Lifetime, NewRdProperty<string>(isMaster: false), ourKey);
 
       // Client -> Server
       clientProperty.SetValue("Client value 1");
@@ -97,8 +92,8 @@ namespace Test.RdFramework
     [Test]
     public void Test4()
     {
-      var serverProperty = BindToServer(LifetimeDefinition.Lifetime, new RdProperty<string> { IsMaster = true }, ourKey);
-      var clientProperty = BindToClient(LifetimeDefinition.Lifetime, new RdProperty<string> { IsMaster = false }, ourKey);
+      var serverProperty = BindToServer(LifetimeDefinition.Lifetime, NewRdProperty<string>(isMaster: true), ourKey);
+      var clientProperty = BindToClient(LifetimeDefinition.Lifetime, NewRdProperty<string>(isMaster: false), ourKey);
 
       serverProperty.SetValue("Server value 1");
       ServerWire.TransmitOneMessage();
@@ -122,8 +117,8 @@ namespace Test.RdFramework
     [Test]
     public void Test5()
     {
-      var serverProperty = BindToServer(LifetimeDefinition.Lifetime, new RdProperty<string> { IsMaster = true }, ourKey);
-      var clientProperty = BindToClient(LifetimeDefinition.Lifetime, new RdProperty<string> { IsMaster = false }, ourKey);
+      var serverProperty = BindToServer(LifetimeDefinition.Lifetime, NewRdProperty<string>(isMaster: true), ourKey);
+      var clientProperty = BindToClient(LifetimeDefinition.Lifetime, NewRdProperty<string>(isMaster: false), ourKey);
 
       serverProperty.SetValue("Server value 1");
       ServerWire.TransmitOneMessage();
@@ -150,8 +145,8 @@ namespace Test.RdFramework
     [Test]
     public void TestNullability()
     {
-      var serverProperty = BindToServer(LifetimeDefinition.Lifetime, new RdProperty<string> { IsMaster = true }, ourKey);
-      var clientProperty = BindToClient(LifetimeDefinition.Lifetime, new RdProperty<string> { IsMaster = false }, ourKey);
+      var serverProperty = BindToServer(LifetimeDefinition.Lifetime, NewRdProperty<string>(isMaster: true), ourKey);
+      var clientProperty = BindToClient(LifetimeDefinition.Lifetime, NewRdProperty<string>(isMaster: false), ourKey);
 
       serverProperty.SetValue("Server value 1");
       Assert.Throws<Assertion.AssertionException>(() => { serverProperty.SetValue(null); });

--- a/rd-net/Test.RdFramework/RdSetTest.cs
+++ b/rd-net/Test.RdFramework/RdSetTest.cs
@@ -16,8 +16,8 @@ namespace Test.RdFramework
     [Test]
     public void Test1()
     {
-      var serverSet = BindToServer(LifetimeDefinition.Lifetime, new RdSet<int>(), ourKey);
-      var clientSet = BindToClient(LifetimeDefinition.Lifetime, new RdSet<int>(), ourKey);
+      var serverSet = BindToServer(LifetimeDefinition.Lifetime, NewRdSet<int>(), ourKey);
+      var clientSet = BindToClient(LifetimeDefinition.Lifetime, NewRdSet<int>(), ourKey);
 
       ServerWire.AutoTransmitMode = true;
       ClientWire.AutoTransmitMode = true;
@@ -52,8 +52,8 @@ namespace Test.RdFramework
     [Test]
     public void TestNullability()
     {
-      var serverSet = BindToServer(LifetimeDefinition.Lifetime, new RdSet<string> {IsMaster = true}, ourKey);
-      var clientSet = BindToClient(LifetimeDefinition.Lifetime, new RdSet<string> {IsMaster = false}, ourKey);
+      var serverSet = BindToServer(LifetimeDefinition.Lifetime, NewRdSet<string>(isMaster: true), ourKey);
+      var clientSet = BindToClient(LifetimeDefinition.Lifetime, NewRdSet<string>(isMaster: false), ourKey);
 
       serverSet.Add("Value");
       Assert.Throws<Assertion.AssertionException>(() => { serverSet.Add(null); });

--- a/rd-net/Test.RdFramework/RdSignalTest.cs
+++ b/rd-net/Test.RdFramework/RdSignalTest.cs
@@ -14,8 +14,8 @@ namespace Test.RdFramework
     [Test]
     public void TestFireSignal()
     {
-      var serverSignal = BindToServer(LifetimeDefinition.Lifetime, new RdSignal<string>(), ourKey);
-      var clientSignal = BindToClient(LifetimeDefinition.Lifetime, new RdSignal<string>(), ourKey);
+      var serverSignal = BindToServer(LifetimeDefinition.Lifetime, NewRdSignal<string>(), ourKey);
+      var clientSignal = BindToClient(LifetimeDefinition.Lifetime, NewRdSignal<string>(), ourKey);
 
       var results = new List<string>();
       clientSignal.Advise(LifetimeDefinition.Lifetime, value => results.Add(value));
@@ -30,8 +30,8 @@ namespace Test.RdFramework
     [Test]
     public void TestNullability()
     {
-      var serverSignal = BindToServer(LifetimeDefinition.Lifetime, new RdSignal<string>(), ourKey);
-      var clientSignal = BindToClient(LifetimeDefinition.Lifetime, new RdSignal<string>(), ourKey);
+      var serverSignal = BindToServer(LifetimeDefinition.Lifetime, NewRdSignal<string>(), ourKey);
+      var clientSignal = BindToClient(LifetimeDefinition.Lifetime, NewRdSignal<string>(), ourKey);
 
       var results = new List<string>();
       clientSignal.Advise(LifetimeDefinition.Lifetime, value => results.Add(value));

--- a/rd-net/Test.RdFramework/RdTaskTest.cs
+++ b/rd-net/Test.RdFramework/RdTaskTest.cs
@@ -26,7 +26,7 @@ namespace Test.RdFramework
 
     private RdCall<TIn, TOut> CreateEndpoint<TIn, TOut>(Func<TIn, TOut> handler, IScheduler cancellationScheduler = null, IScheduler handlerScheduler = null)
     {
-      var res = new RdCall<TIn, TOut>();
+      var res = NewRdCall<TIn, TOut>();
       res.Set(handler, cancellationScheduler, handlerScheduler);
       return res;
     }
@@ -39,7 +39,7 @@ namespace Test.RdFramework
       ClientWire.AutoTransmitMode = true;
       ServerWire.AutoTransmitMode = true;
 
-      var serverEntity = BindToServer(LifetimeDefinition.Lifetime, new RdCall<int, string>(), ourKey);
+      var serverEntity = BindToServer(LifetimeDefinition.Lifetime, NewRdCall<int, string>(), ourKey);
       var clientEntity = BindToClient(LifetimeDefinition.Lifetime, CreateEndpoint<int, string>(x => x.ToString()), ourKey);
 
 
@@ -57,7 +57,7 @@ namespace Test.RdFramework
       ClientWire.AutoTransmitMode = true;
       ServerWire.AutoTransmitMode = true;
 
-      var serverEntity = BindToServer(LifetimeDefinition.Lifetime, new RdCall<string, string>(), ourKey);
+      var serverEntity = BindToServer(LifetimeDefinition.Lifetime, NewRdCall<string, string>(), ourKey);
       var clientEntity = BindToClient(LifetimeDefinition.Lifetime, CreateEndpoint<string, string>(x => x.ToString()), ourKey);
       clientEntity.Set((lf, req) => RdTask<string>.Successful(req == null ? "NULL" : null));
 
@@ -83,7 +83,7 @@ namespace Test.RdFramework
       ClientWire.AutoTransmitMode = true;
       ServerWire.AutoTransmitMode = true;
       
-      var serverEntity = BindToServer(LifetimeDefinition.Lifetime, new RdCall<Unit, string>(), ourKey);
+      var serverEntity = BindToServer(LifetimeDefinition.Lifetime, NewRdCall<Unit, string>(), ourKey);
       var clientEntity = BindToClient(LifetimeDefinition.Lifetime, CreateEndpoint<Unit, string>(x => x.ToString()), ourKey);
 
       bool handlerFinished = false; 
@@ -151,7 +151,7 @@ namespace Test.RdFramework
       var call1 = new RdCall<Unit, RdSignal<int>>(Serializers.ReadVoid, Serializers.WriteVoid, RdSignal<int>.Read, RdSignal<int>.Write);
       var call2 = new RdCall<Unit, RdSignal<int>>(Serializers.ReadVoid, Serializers.WriteVoid, RdSignal<int>.Read, RdSignal<int>.Write);
 
-      var respSignal = new RdSignal<int>();
+      var respSignal = NewRdSignal<int>();
       var endpointLfTerminated = false;
       call2.Set((endpointLf, _) =>
       {
@@ -194,8 +194,8 @@ namespace Test.RdFramework
 
       var scheduler = SingleThreadScheduler.RunOnSeparateThread(TestLifetime, "Background scheduler");
 
-      var callsite = BindToServer(LifetimeDefinition.Lifetime, new RdCall<int, string>(), ourKey);
-      var endpoint = BindToClient(LifetimeDefinition.Lifetime, new RdCall<int, string>(), ourKey);
+      var callsite = BindToServer(LifetimeDefinition.Lifetime, NewRdCall<int, string>(), ourKey);
+      var endpoint = BindToClient(LifetimeDefinition.Lifetime, NewRdCall<int, string>(), ourKey);
       
       Assert.IsFalse(scheduler.IsActive);
 

--- a/rd-net/Test.RdFramework/SocketProxyTest.cs
+++ b/rd-net/Test.RdFramework/SocketProxyTest.cs
@@ -33,10 +33,10 @@ namespace Test.RdFramework
 
           var clientProtocol = SocketWireTest.Client(lifetime, proxy.Port);
 
-          var sp = new RdSignal<int>().Static(1);
+          var sp = NewRdSignal<int>().Static(1);
           sp.Bind(lifetime, serverProtocol, SocketWireTest.Top);
 
-          var cp = new RdSignal<int>().Static(1);
+          var cp = NewRdSignal<int>().Static(1);
           cp.Bind(lifetime, clientProtocol, SocketWireTest.Top);
 
           var serverLog = new List<int>();

--- a/rd-net/Test.RdFramework/SocketWireTest.cs
+++ b/rd-net/Test.RdFramework/SocketWireTest.cs
@@ -80,9 +80,9 @@ namespace Test.RdFramework
         var serverProtocol = Server(lifetime);
         var clientProtocol = Client(lifetime, serverProtocol);
 
-        var sp = new RdProperty<int>().Static(1);
+        var sp = NewRdProperty<int>().Static(1);
         sp.Bind(lifetime, serverProtocol, Top);
-        var cp = new RdProperty<int>().Static(1);
+        var cp = NewRdProperty<int>().Static(1);
         cp.Bind(lifetime, clientProtocol, Top);
 
         cp.SetValue(1);
@@ -100,9 +100,9 @@ namespace Test.RdFramework
         var serverProtocol = Server(lifetime);
         var clientProtocol = Client(lifetime, serverProtocol);
 
-        var sp = new RdProperty<int>().Static(1);
+        var sp = NewRdProperty<int>().Static(1);
         sp.Bind(lifetime, serverProtocol, Top);
-        var cp = new RdProperty<int>().Static(1);
+        var cp = NewRdProperty<int>().Static(1);
         cp.Bind(lifetime, clientProtocol, Top);
 
         var log = new List<int>();
@@ -128,9 +128,9 @@ namespace Test.RdFramework
         var serverProtocol = Server(lifetime);
         var clientProtocol = Client(lifetime, serverProtocol);
 
-        var sp = new RdProperty<string>().Static(1);
+        var sp = NewRdProperty<string>().Static(1);
         sp.Bind(lifetime, serverProtocol, Top);
-        var cp = new RdProperty<string>().Static(1);
+        var cp = NewRdProperty<string>().Static(1);
         cp.Bind(lifetime, clientProtocol, Top);
 
         cp.SetValue("1");
@@ -161,13 +161,13 @@ namespace Test.RdFramework
         var port = FindFreePort();
         var clientProtocol = Client(lifetime, port);
 
-        var cp = new RdProperty<int>().Static(1);
+        var cp = NewRdProperty<int>().Static(1);
         cp.Bind(lifetime, clientProtocol, Top);
         cp.SetValue(1);
 
         Thread.Sleep(2000);
         var serverProtocol = Server(lifetime, port);
-        var sp = new RdProperty<int>().Static(1);
+        var sp = NewRdProperty<int>().Static(1);
         sp.Bind(lifetime, serverProtocol, Top);
 
         var prev = sp.Maybe;
@@ -211,7 +211,7 @@ namespace Test.RdFramework
         SynchronousScheduler.Instance.SetActive(lifetime);
         var protocol = Server(lifetime);
         Thread.Sleep(100);
-        var p = new RdProperty<int>().Static(1);
+        var p = NewRdProperty<int>().Static(1);
         p.Bind(lifetime, protocol, Top);
         p.SetValue(1);
         p.SetValue(2);
@@ -251,7 +251,7 @@ namespace Test.RdFramework
         SynchronousScheduler.Instance.SetActive(lifetime);
         var protocol = Client(lifetime, FindFreePort());
         Thread.Sleep(100);
-        var p = new RdProperty<int>().Static(1);
+        var p = NewRdProperty<int>().Static(1);
         p.Bind(lifetime, protocol, Top);
         p.SetValue(1);
         p.SetValue(2);
@@ -281,10 +281,10 @@ namespace Test.RdFramework
         var serverProtocol = Server(lifetime);
         var clientProtocol = Client(lifetime, serverProtocol);
 
-        var sp = new RdSignal<int>().Static(1);
+        var sp = NewRdSignal<int>().Static(1);
         sp.Bind(lifetime, serverProtocol, Top);
 
-        var cp = new RdSignal<int>().Static(1);
+        var cp = NewRdSignal<int>().Static(1);
         cp.Bind(lifetime, clientProtocol, Top);
 
         var log = new List<int>();
@@ -319,7 +319,7 @@ namespace Test.RdFramework
           SynchronousScheduler.Instance.SetActive(lifetime);
           var serverProtocol = Server(lifetime, null);
           
-          var sp = new RdProperty<int>().Static(1);
+          var sp = NewRdProperty<int>().Static(1);
           sp.Bind(lifetime, serverProtocol, Top);
           sp.IsMaster = false;
 
@@ -335,7 +335,7 @@ namespace Test.RdFramework
           Lifetime.Using(lf =>
           {
             var clientProtocol = Client(lf, serverProtocol);
-            var cp = new RdProperty<int>().Static(1);
+            var cp = NewRdProperty<int>().Static(1);
             cp.IsMaster = true;
             cp.Bind(lf, clientProtocol, Top);
             cp.SetValue(1);            
@@ -346,11 +346,11 @@ namespace Test.RdFramework
           
           Lifetime.Using(lf =>
           {
-            sp = new RdProperty<int>().Static(2);
+            sp = NewRdProperty<int>().Static(2);
             sp.Bind(lifetime, serverProtocol, Top);
             
             var clientProtocol = Client(lf, serverProtocol);
-            var cp = new RdProperty<int>().Static(2);
+            var cp = NewRdProperty<int>().Static(2);
             cp.Bind(lf, clientProtocol, Top);
             cp.SetValue(2);
             WaitAndAssert(sp, 2);
@@ -361,7 +361,7 @@ namespace Test.RdFramework
           Lifetime.Using(lf =>
           {                        
             var clientProtocol = Client(lf, serverProtocol);
-            var cp = new RdProperty<int>().Static(2);
+            var cp = NewRdProperty<int>().Static(2);
             cp.Bind(lf, clientProtocol, Top);
             cp.SetValue(3);      
             WaitAndAssert(sp, 3, 2);

--- a/rd-net/Test.RdFramework/Util/ReactiveFactory.cs
+++ b/rd-net/Test.RdFramework/Util/ReactiveFactory.cs
@@ -1,0 +1,46 @@
+﻿global using static Test.RdFramework.Util.ReactiveFactory;
+
+using JetBrains.Rd.Impl;
+using JetBrains.Rd.Tasks;
+
+namespace Test.RdFramework.Util;
+
+/// <summary>
+/// Test-only helper to simplify creating of reactive primitives with polymorphic serializers
+/// </summary>
+public static class ReactiveFactory
+{
+  public static RdProperty<T> NewRdProperty<T>(bool isMaster = false)
+  {
+    return new RdProperty<T>(Polymorphic<T>.Read, Polymorphic<T>.Write) { IsMaster = isMaster };
+  }
+
+  public static RdSignal<T> NewRdSignal<T>()
+  {
+    return new RdSignal<T>(Polymorphic<T>.Read, Polymorphic<T>.Write);
+  }
+
+  public static RdList<T> NewRdList<T>(bool optimizeNested = false)
+  {
+    return new RdList<T>(Polymorphic<T>.Read, Polymorphic<T>.Write) { OptimizeNested = optimizeNested };
+  }
+
+  public static RdSet<T> NewRdSet<T>(bool isMaster = false)
+  {
+    return new RdSet<T>(Polymorphic<T>.Read, Polymorphic<T>.Write) { IsMaster = isMaster };
+  }
+
+  public static RdMap<TKey, TValue> NewRdMap<TKey, TValue>(bool isMaster = false, bool optimizeNested = false)
+  {
+    return new RdMap<TKey, TValue>(Polymorphic<TKey>.Read, Polymorphic<TKey>.Write, Polymorphic<TValue>.Read, Polymorphic<TValue>.Write)
+    {
+      IsMaster = isMaster, 
+      OptimizeNested = optimizeNested
+    };
+  }
+
+  public static RdCall<TReq, TRes> NewRdCall<TReq, TRes>()
+  {
+    return new RdCall<TReq, TRes>(Polymorphic<TReq>.Read, Polymorphic<TReq>.Write, Polymorphic<TRes>.Read, Polymorphic<TRes>.Write);
+  }
+}


### PR DESCRIPTION
They aren't used anywhere except tests

And using them in RdReflection may lead to fatal consequences. You may accidentally create an object on one side with Polymorphic serializer, and the infrastructure will create non-polymorphic serializer on the other side. It leads to really frustrating bugs. It could fail in random places without proper error message that serializers are different.

Removing these default constructors should reduce the probability of such mistakes.