### PR TITLE
Unify top-level and nested ext generation + fire on local ext creation

### DIFF
--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/ExtCreationInfo.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/ExtCreationInfo.kt
@@ -9,3 +9,8 @@ data class ExtCreationInfo(
     val hash: Long,
     val ext: RdExtBase?
 )
+
+data class ExtCreationInfoEx(
+    val info: ExtCreationInfo,
+    val isLocal: Boolean
+)

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Interfaces.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Interfaces.kt
@@ -37,7 +37,7 @@ interface IProtocol : IRdDynamic {
 
     val contexts : ProtocolContexts
 
-    val extCreated: ISignal<ExtCreationInfo>
+    val extCreated: ISignal<ExtCreationInfoEx>
 
     fun <T: RdExtBase> getOrCreateExtension(clazz: KClass<T>, create: () -> T): T
     fun <T: RdExtBase> tryGetExtension(clazz: KClass<T>): T?

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdBindableBase.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdBindableBase.kt
@@ -89,8 +89,9 @@ abstract class RdBindableBase : IRdBindable, IPrintable {
 
     private fun <T:Any> getOrCreateExtension0(name: String, clazz: KClass<T>, highPriorityExtension: Boolean = false, create: () -> T) : T {
         Sync.lock(extensions) {
-            val res = extensions.getOrPut(name) {
+            val res = extensions[name] ?: run {
                 val newExtension = create()
+                extensions[name] = newExtension
                 if (newExtension is IRdBindable) {
                     bindableChildren.add(if (highPriorityExtension) 0 else bindableChildren.size, name to newExtension)
                     bindLifetime?.let {

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/kotlin/Kotlin11Generator.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/kotlin/Kotlin11Generator.kt
@@ -625,13 +625,7 @@ open class Kotlin11Generator(
             + "${decl.root.sanitizedName(decl)}.register(protocol.serializers)"
             println()
 
-            + "return ${decl.name}().apply {"
-            indent {
-                val quotedName = "\"${decl.name}\""
-                + "identify(protocol.identity, RdId.Null.mix($quotedName))"
-                + "bind(lifetime, protocol, $quotedName)"
-            }
-            +"}"
+            + "return ${decl.name}()"
         }
     }
 

--- a/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/asis/ExampleModelNova.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/asis/ExampleModelNova.kt
@@ -56,10 +56,7 @@ class ExampleModelNova private constructor(
         fun create(lifetime: Lifetime, protocol: IProtocol): ExampleModelNova  {
             ExampleRootNova.register(protocol.serializers)
             
-            return ExampleModelNova().apply {
-                identify(protocol.identity, RdId.Null.mix("ExampleModelNova"))
-                bind(lifetime, protocol, "ExampleModelNova")
-            }
+            return ExampleModelNova()
         }
         
         

--- a/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/reversed/ExampleModelNova.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/reversed/ExampleModelNova.kt
@@ -56,10 +56,7 @@ class ExampleModelNova private constructor(
         fun create(lifetime: Lifetime, protocol: IProtocol): ExampleModelNova  {
             ExampleRootNova.register(protocol.serializers)
             
-            return ExampleModelNova().apply {
-                identify(protocol.identity, RdId.Null.mix("ExampleModelNova"))
-                bind(lifetime, protocol, "ExampleModelNova")
-            }
+            return ExampleModelNova()
         }
         
         

--- a/rd-net/RdFramework/Impl/Protocol.cs
+++ b/rd-net/RdFramework/Impl/Protocol.cs
@@ -115,7 +115,7 @@ namespace JetBrains.Rd.Impl
     
     public ISignal<ExtCreationInfo> ExtCreated { get; }
     
-    public RdSignal<ExtCreationInfo> ExtConfirmation { get; }
+    private RdSignal<ExtCreationInfo> ExtConfirmation { get; }
 
     private ThreadLocal<bool> ExtIsLocal { get; }
 


### PR DESCRIPTION
1. Method `create` for top-level extensions is generated without `identify`/`bind` now, same as for nested extensions. `identify` and `bind` is done in `Protocol.getOrCreateExtension` now so you can freely create instances of `Ext` and only one will be bound after getting to protocol extension map.
2. `Protocol.extCreated` signal is fired for local changes too, to support listeners on local side to handle new extensions.