### PR TITLE
Convert asserts to runtime checks

### DIFF
--- a/rd-net/Directory.Build.props
+++ b/rd-net/Directory.Build.props
@@ -14,7 +14,8 @@
     -->
     <Nullable Condition="'$(TargetFramework)' == 'net35'">disable</Nullable>
     <Nullable Condition="'$(Nullable)' == ''">enable</Nullable>
-    
+
+    <DefineConstants>JET_MODE_ASSERT</DefineConstants>
     <!-- TODO: CS8632 is redundant here but added to suppress inspections in ReSharper/Rider, see RSRP-489331 -->
     <NoWarn Condition="'$(TargetFramework)' == 'net35'">nullable;CS8632</NoWarn>
   </PropertyGroup>

--- a/rd-net/Lifetimes/Diagnostics/Assertion.cs
+++ b/rd-net/Lifetimes/Diagnostics/Assertion.cs
@@ -23,7 +23,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void Assert([DoesNotReturnIf(false)] bool condition, [CallerArgumentExpression("condition")] string? message = null)
     {
-      if (Mode.Assertion && !condition)
+      if (Mode.IsAssertion && !condition)
       {
         Fail(message ?? "");
       }
@@ -35,7 +35,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void Assert([DoesNotReturnIf(false)] bool condition, [InterpolatedStringHandlerArgument("condition")] ref JetConditionalInterpolatedStringHandler handler)
     {
-      if (Mode.Assertion && !condition)
+      if (Mode.IsAssertion && !condition)
       {
         Fail(handler.ToStringAndClear());
       }
@@ -46,7 +46,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void AssertCurrentThread(Thread thread)
     {
-      if (Mode.Assertion && Thread.CurrentThread != thread)
+      if (Mode.IsAssertion && Thread.CurrentThread != thread)
       {
         Fail("Current thread <{0}> is not equal to referent thread <{1}>", Thread.CurrentThread.ToThreadString(), thread.ToThreadString());
       }
@@ -57,7 +57,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void Assert<T>([DoesNotReturnIf(false)] bool condition, string message, T? arg)
     {
-      if (Mode.Assertion && !condition)
+      if (Mode.IsAssertion && !condition)
       {
         Fail(message, arg);
       }
@@ -68,7 +68,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void Assert<T1,T2>([DoesNotReturnIf(false)] bool condition, string message, T1? arg1, T2? arg2)
     {
-      if (Mode.Assertion && !condition)
+      if (Mode.IsAssertion && !condition)
       {
         Fail(message, arg1, arg2);
       }
@@ -79,7 +79,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void Assert<T1, T2, T3>([DoesNotReturnIf(false)] bool condition, string message, T1? arg1, T2? arg2, T3? arg3)
     {
-      if (Mode.Assertion && !condition)
+      if (Mode.IsAssertion && !condition)
       {
         Fail(message, arg1, arg2, arg3);
       }
@@ -90,7 +90,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void Assert<T1, T2, T3, T4>([DoesNotReturnIf(false)] bool condition, string message, T1? arg1, T2? arg2, T3? arg3, T4? arg4)
     {
-      if (Mode.Assertion && !condition)
+      if (Mode.IsAssertion && !condition)
       {
         Fail(message, arg1, arg2, arg3, arg4);
       }
@@ -101,7 +101,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void Assert([DoesNotReturnIf(false)] bool condition, string message, params object?[] args)
     {
-      if (Mode.Assertion && !condition)
+      if (Mode.IsAssertion && !condition)
       {
         Fail(message, args);
       }

--- a/rd-net/Lifetimes/Diagnostics/Assertion.cs
+++ b/rd-net/Lifetimes/Diagnostics/Assertion.cs
@@ -23,7 +23,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void Assert([DoesNotReturnIf(false)] bool condition, [CallerArgumentExpression("condition")] string? message = null)
     {
-      if (!condition)
+      if (Mode.Assertion && !condition)
       {
         Fail(message ?? "");
       }
@@ -35,7 +35,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void Assert([DoesNotReturnIf(false)] bool condition, [InterpolatedStringHandlerArgument("condition")] ref JetConditionalInterpolatedStringHandler handler)
     {
-      if (!condition)
+      if (Mode.Assertion && !condition)
       {
         Fail(handler.ToStringAndClear());
       }
@@ -46,7 +46,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void AssertCurrentThread(Thread thread)
     {
-      if (Thread.CurrentThread != thread)
+      if (Mode.Assertion && Thread.CurrentThread != thread)
       {
         Fail("Current thread <{0}> is not equal to referent thread <{1}>", Thread.CurrentThread.ToThreadString(), thread.ToThreadString());
       }
@@ -57,7 +57,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void Assert<T>([DoesNotReturnIf(false)] bool condition, string message, T? arg)
     {
-      if (!condition)
+      if (Mode.Assertion && !condition)
       {
         Fail(message, arg);
       }
@@ -68,7 +68,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void Assert<T1,T2>([DoesNotReturnIf(false)] bool condition, string message, T1? arg1, T2? arg2)
     {
-      if (!condition)
+      if (Mode.Assertion && !condition)
       {
         Fail(message, arg1, arg2);
       }
@@ -79,7 +79,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void Assert<T1, T2, T3>([DoesNotReturnIf(false)] bool condition, string message, T1? arg1, T2? arg2, T3? arg3)
     {
-      if (!condition)
+      if (Mode.Assertion && !condition)
       {
         Fail(message, arg1, arg2, arg3);
       }
@@ -90,7 +90,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void Assert<T1, T2, T3, T4>([DoesNotReturnIf(false)] bool condition, string message, T1? arg1, T2? arg2, T3? arg3, T4? arg4)
     {
-      if (!condition)
+      if (Mode.Assertion && !condition)
       {
         Fail(message, arg1, arg2, arg3, arg4);
       }
@@ -101,7 +101,7 @@ namespace JetBrains.Diagnostics
     [Conditional("JET_MODE_ASSERT")]
     public static void Assert([DoesNotReturnIf(false)] bool condition, string message, params object?[] args)
     {
-      if (!condition)
+      if (Mode.Assertion && !condition)
       {
         Fail(message, args);
       }

--- a/rd-net/Lifetimes/Diagnostics/Mode.cs
+++ b/rd-net/Lifetimes/Diagnostics/Mode.cs
@@ -4,5 +4,21 @@ namespace JetBrains.Diagnostics;
 
 public static class Mode
 {
-  public static readonly bool Assertion = AppDomain.CurrentDomain.GetData("JET_MODE_ASSERT") as bool? == true;
+  /// <summary>
+  /// Whether asserts are enabled. Can be configured by setting JET_MODE_ASSERT = true/false in Current App Domain storage.
+  /// </summary>
+  public static readonly bool Assertion;
+
+  /// <summary>
+  /// True if JET_MODE_ASSERT wasn't specified at the moment of static constructor invocation and default value was
+  /// used instead.
+  /// </summary>
+  public static readonly bool UndefinedAssertion;
+
+  static Mode()
+  {
+    var data = AppDomain.CurrentDomain.GetData("JET_MODE_ASSERT") as bool?;
+    Assertion = data == true;
+    UndefinedAssertion = !data.HasValue;
+  }
 }

--- a/rd-net/Lifetimes/Diagnostics/Mode.cs
+++ b/rd-net/Lifetimes/Diagnostics/Mode.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace JetBrains.Diagnostics;
+
+public static class Mode
+{
+  public static readonly bool Assertion = AppDomain.CurrentDomain.GetData("JET_MODE_ASSERT") as bool? == true;
+}

--- a/rd-net/Lifetimes/Diagnostics/Mode.cs
+++ b/rd-net/Lifetimes/Diagnostics/Mode.cs
@@ -7,18 +7,18 @@ public static class Mode
   /// <summary>
   /// Whether asserts are enabled. Can be configured by setting JET_MODE_ASSERT = true/false in Current App Domain storage.
   /// </summary>
-  public static readonly bool Assertion;
+  public static readonly bool IsAssertion;
 
   /// <summary>
   /// True if JET_MODE_ASSERT wasn't specified at the moment of static constructor invocation and default value was
   /// used instead.
   /// </summary>
-  public static readonly bool UndefinedAssertion;
+  public static readonly bool IsAssertionUndefined;
 
   static Mode()
   {
     var data = AppDomain.CurrentDomain.GetData("JET_MODE_ASSERT") as bool?;
-    Assertion = data == true;
-    UndefinedAssertion = !data.HasValue;
+    IsAssertion = data == true;
+    IsAssertionUndefined = !data.HasValue;
   }
 }

--- a/rd-net/Lifetimes/Lifetimes.csproj
+++ b/rd-net/Lifetimes/Lifetimes.csproj
@@ -10,8 +10,6 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <NoWarn>$(NoWarn),1591,1570,1574</NoWarn>
         
-        <DefineConstants Condition="'$(Configuration)' == 'Debug'">JET_MODE_ASSERT</DefineConstants>
-        
         <Configurations>Debug;Release;CrossTests</Configurations>
         
         <Platforms>AnyCPU</Platforms>

--- a/rd-net/Lifetimes/Serialization/UnsafeReader.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeReader.cs
@@ -62,12 +62,19 @@ namespace JetBrains.Serialization
     private void AssertLength(int size)
     {
       var alreadyRead = (int)(myPtr - myInitialPtr);
-      Assertion.Assert(alreadyRead + size <= myMaxlen, "Can't read from unsafe reader: alreadyRead={0} size={1} maxlen={2}. " +
-                                                 "Usually this happens when you change serialization format and forget to clear previous entries from disk. " +
-                                                 "For example, you forgot to advance persistent caches version - do this in 'SolutionCaches' and 'ShellCaches' classes)."
-                                                 , alreadyRead, size, myMaxlen);
+      if (alreadyRead + size > myMaxlen)
+      {
+        ThrowOutOfRange(size, alreadyRead);
+      }
     }
 
+    private void ThrowOutOfRange(int size, int alreadyRead)
+    {
+      Assertion.Fail("Can't read from unsafe reader: alreadyRead={0} size={1} maxlen={2}. " +
+                                "Usually this happens when you change serialization format and forget to clear previous entries from disk. " +
+                                "For example, you forgot to advance persistent caches version - do this in 'SolutionCaches' and 'ShellCaches' classes)."
+        , alreadyRead, size, myMaxlen);
+    }
 
 
     #region Primitive readers

--- a/rd-net/Lifetimes/Serialization/UnsafeReader.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeReader.cs
@@ -53,7 +53,7 @@ namespace JetBrains.Serialization
 
     public void Skip(int bytes)
     {
-      if (Mode.Assertion) AssertLength(bytes);
+      if (Mode.IsAssertion) AssertLength(bytes);
       myPtr += bytes;
     }
 
@@ -80,7 +80,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public byte* ReadRaw(int count)
     {
-      if (Mode.Assertion) AssertLength(count);
+      if (Mode.IsAssertion) AssertLength(count);
       var res = myPtr;
       myPtr += count;
       return res;
@@ -89,7 +89,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public bool ReadBoolean()
     {
-      if (Mode.Assertion) AssertLength(sizeof(byte));
+      if (Mode.IsAssertion) AssertLength(sizeof(byte));
 
       return *(myPtr++) != 0;
     }
@@ -97,7 +97,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public byte ReadByte()
     {
-      if (Mode.Assertion) AssertLength(sizeof(byte));
+      if (Mode.IsAssertion) AssertLength(sizeof(byte));
 
       return *(myPtr++);
     }
@@ -112,7 +112,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public char ReadChar()
     {
-      if (Mode.Assertion) AssertLength(sizeof(char));
+      if (Mode.IsAssertion) AssertLength(sizeof(char));
 
       var x = (char*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -122,7 +122,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public decimal ReadDecimal()
     {
-      if (Mode.Assertion) AssertLength(sizeof(decimal));
+      if (Mode.IsAssertion) AssertLength(sizeof(decimal));
 
       var x = (decimal*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -132,7 +132,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public double ReadDouble()
     {
-      if (Mode.Assertion) AssertLength(sizeof(double));
+      if (Mode.IsAssertion) AssertLength(sizeof(double));
 
       var x = (double*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -142,7 +142,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public float ReadFloat()
     {
-      if (Mode.Assertion) AssertLength(sizeof(float));
+      if (Mode.IsAssertion) AssertLength(sizeof(float));
 
       var x = (float*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -152,7 +152,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public Int16 ReadInt16()
     {
-      if (Mode.Assertion) AssertLength(sizeof(Int16));
+      if (Mode.IsAssertion) AssertLength(sizeof(Int16));
 
       var x = (Int16*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -168,7 +168,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public Int32 ReadInt32()
     {
-      if (Mode.Assertion) AssertLength(sizeof(Int32));
+      if (Mode.IsAssertion) AssertLength(sizeof(Int32));
 
       var x = (Int32*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -203,7 +203,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public Int64 ReadInt64()
     {
-      if (Mode.Assertion) AssertLength(sizeof(Int64));
+      if (Mode.IsAssertion) AssertLength(sizeof(Int64));
 
       var x = (Int64*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -227,7 +227,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public UInt16 ReadUInt16()
     {
-      if (Mode.Assertion) AssertLength(sizeof(UInt16));
+      if (Mode.IsAssertion) AssertLength(sizeof(UInt16));
 
       var x = (UInt16*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -237,7 +237,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public UInt32 ReadUInt32()
     {
-      if (Mode.Assertion) AssertLength(sizeof(UInt32));
+      if (Mode.IsAssertion) AssertLength(sizeof(UInt32));
 
       var x = (UInt32*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -247,7 +247,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public UInt64 ReadUInt64()
     {
-      if (Mode.Assertion) AssertLength(sizeof(UInt64));
+      if (Mode.IsAssertion) AssertLength(sizeof(UInt64));
 
       var x = (UInt64*)myPtr;
       myPtr = (byte*)(x + 1);

--- a/rd-net/Lifetimes/Serialization/UnsafeReader.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeReader.cs
@@ -53,12 +53,10 @@ namespace JetBrains.Serialization
 
     public void Skip(int bytes)
     {
-      AssertLength(bytes);
+      if (Mode.Assertion) AssertLength(bytes);
       myPtr += bytes;
     }
 
-    [Conditional("JET_MODE_ASSERT")]
-    // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
     private void AssertLength(int size)
     {
       var alreadyRead = (int)(myPtr - myInitialPtr);
@@ -82,7 +80,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public byte* ReadRaw(int count)
     {
-      AssertLength(count);
+      if (Mode.Assertion) AssertLength(count);
       var res = myPtr;
       myPtr += count;
       return res;
@@ -91,7 +89,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public bool ReadBoolean()
     {
-      AssertLength(sizeof(byte));
+      if (Mode.Assertion) AssertLength(sizeof(byte));
 
       return *(myPtr++) != 0;
     }
@@ -99,7 +97,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public byte ReadByte()
     {
-      AssertLength(sizeof(byte));
+      if (Mode.Assertion) AssertLength(sizeof(byte));
 
       return *(myPtr++);
     }
@@ -114,7 +112,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public char ReadChar()
     {
-      AssertLength(sizeof(char));
+      if (Mode.Assertion) AssertLength(sizeof(char));
 
       var x = (char*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -124,7 +122,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public decimal ReadDecimal()
     {
-      AssertLength(sizeof(decimal));
+      if (Mode.Assertion) AssertLength(sizeof(decimal));
 
       var x = (decimal*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -134,7 +132,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public double ReadDouble()
     {
-      AssertLength(sizeof(double));
+      if (Mode.Assertion) AssertLength(sizeof(double));
 
       var x = (double*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -144,7 +142,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public float ReadFloat()
     {
-      AssertLength(sizeof(float));
+      if (Mode.Assertion) AssertLength(sizeof(float));
 
       var x = (float*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -154,7 +152,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public Int16 ReadInt16()
     {
-      AssertLength(sizeof(Int16));
+      if (Mode.Assertion) AssertLength(sizeof(Int16));
 
       var x = (Int16*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -170,7 +168,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public Int32 ReadInt32()
     {
-      AssertLength(sizeof(Int32));
+      if (Mode.Assertion) AssertLength(sizeof(Int32));
 
       var x = (Int32*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -205,7 +203,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public Int64 ReadInt64()
     {
-      AssertLength(sizeof(Int64));
+      if (Mode.Assertion) AssertLength(sizeof(Int64));
 
       var x = (Int64*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -229,7 +227,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public UInt16 ReadUInt16()
     {
-      AssertLength(sizeof(UInt16));
+      if (Mode.Assertion) AssertLength(sizeof(UInt16));
 
       var x = (UInt16*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -239,7 +237,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public UInt32 ReadUInt32()
     {
-      AssertLength(sizeof(UInt32));
+      if (Mode.Assertion) AssertLength(sizeof(UInt32));
 
       var x = (UInt32*)myPtr;
       myPtr = (byte*)(x + 1);
@@ -249,7 +247,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public UInt64 ReadUInt64()
     {
-      AssertLength(sizeof(UInt64));
+      if (Mode.Assertion) AssertLength(sizeof(UInt64));
 
       var x = (UInt64*)myPtr;
       myPtr = (byte*)(x + 1);

--- a/rd-net/Lifetimes/Threading/Channel.cs
+++ b/rd-net/Lifetimes/Threading/Channel.cs
@@ -92,10 +92,11 @@ namespace JetBrains.Threading
     #endregion
 
 
-    #region Diagnostics    
-    [Conditional("JET_MODE_ASSERT")]
+    #region Diagnostics
     private void AssertState()
     {
+      if (!Mode.Assertion) return;
+
       lock (myLock)
       {
         Assertion.Assert(mySenders.Count <= myMessages.Count

--- a/rd-net/Lifetimes/Threading/Channel.cs
+++ b/rd-net/Lifetimes/Threading/Channel.cs
@@ -95,7 +95,7 @@ namespace JetBrains.Threading
     #region Diagnostics
     private void AssertState()
     {
-      if (!Mode.Assertion) return;
+      if (!Mode.IsAssertion) return;
 
       lock (myLock)
       {

--- a/rd-net/Lifetimes/Util/BitSlice.cs
+++ b/rd-net/Lifetimes/Util/BitSlice.cs
@@ -34,7 +34,7 @@ namespace JetBrains.Util.Util
     [AssertionMethod]
     protected void AssertSliceFitsHostType<T>()
     {
-      if (!Mode.Assertion) return;
+      if (!Mode.IsAssertion) return;
 
       var type = typeof(T);      
       var maxBit = type == typeof(int) ? 31
@@ -48,7 +48,7 @@ namespace JetBrains.Util.Util
     [AssertionMethod]
     private void AssertValueFitsSlice(int value)
     {
-      if (!Mode.Assertion) return;
+      if (!Mode.IsAssertion) return;
 
       Assertion.Assert(value >= 0, "[{0}] must be >= 0; actual: {1}", nameof(value), value);
       Assertion.Assert(value <= Mask, "[{0}] must be <= {1} to fit {2}; actual: {3}", nameof(value), Mask, this, value);

--- a/rd-net/Lifetimes/Util/BitSlice.cs
+++ b/rd-net/Lifetimes/Util/BitSlice.cs
@@ -31,9 +31,11 @@ namespace JetBrains.Util.Util
     
     #region Assertions
 
-    [AssertionMethod, Conditional("JET_MODE_ASSERT")]
+    [AssertionMethod]
     protected void AssertSliceFitsHostType<T>()
     {
+      if (!Mode.Assertion) return;
+
       var type = typeof(T);      
       var maxBit = type == typeof(int) ? 31
         : type == typeof(long) ? 64
@@ -43,9 +45,11 @@ namespace JetBrains.Util.Util
       Assertion.Assert(HiBit <= maxBit, "{0} doesn't fit into host type {1}; must be inside [0, {2}]", this, type, maxBit);
     }
 
-    [AssertionMethod, Conditional("JET_MODE_ASSERT")]
+    [AssertionMethod]
     private void AssertValueFitsSlice(int value)
     {
+      if (!Mode.Assertion) return;
+
       Assertion.Assert(value >= 0, "[{0}] must be >= 0; actual: {1}", nameof(value), value);
       Assertion.Assert(value <= Mask, "[{0}] must be <= {1} to fit {2}; actual: {3}", nameof(value), Mask, this, value);
     }

--- a/rd-net/Lifetimes/Util/LocalStopwatch.cs
+++ b/rd-net/Lifetimes/Util/LocalStopwatch.cs
@@ -53,7 +53,7 @@ namespace JetBrains.Util
 
     private void AssertTimeStamp()
     {
-      if (!Mode.Assertion) return;
+      if (!Mode.IsAssertion) return;
       Assertion.Assert(myStartTimeStamp != 0, $"{nameof(LocalStopwatch)} must be created using `{nameof(StartNew)}` method");
     }
   }

--- a/rd-net/Lifetimes/Util/LocalStopwatch.cs
+++ b/rd-net/Lifetimes/Util/LocalStopwatch.cs
@@ -51,9 +51,9 @@ namespace JetBrains.Util
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     private long GetElapsedDateTimeTicks() => unchecked((long)(ElapsedTicks * ourTickFrequency));
 
-    [Conditional("JET_MODE_ASSERT")]
     private void AssertTimeStamp()
     {
+      if (!Mode.Assertion) return;
       Assertion.Assert(myStartTimeStamp != 0, $"{nameof(LocalStopwatch)} must be created using `{nameof(StartNew)}` method");
     }
   }

--- a/rd-net/RdFramework.Reflection/RdFramework.Reflection.csproj
+++ b/rd-net/RdFramework.Reflection/RdFramework.Reflection.csproj
@@ -10,8 +10,6 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <NoWarn>$(NoWarn),1591,1570,1574</NoWarn>
 
-        <DefineConstants Condition="'$(Configuration)' == 'Debug'">JET_MODE_ASSERT</DefineConstants>
-
         <Configurations>Debug;Release;CrossTests</Configurations>
 
         <Platforms>AnyCPU</Platforms>

--- a/rd-net/RdFramework.Reflection/ReflectionRdActivator.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionRdActivator.cs
@@ -114,7 +114,7 @@ namespace JetBrains.Rd.Reflection
     /// <returns></returns>
     public object Activate(Type type)
     {
-      if (Mode.Assertion)
+      if (Mode.IsAssertion)
       {
         myCurrentActivationChain = myCurrentActivationChain ?? new Queue<Type>();
         myCurrentActivationChain.Clear(); // clear previous attempts to activate different types
@@ -128,7 +128,7 @@ namespace JetBrains.Rd.Reflection
 
     private object ActivateRd(Type type)
     {
-      if (Mode.Assertion)
+      if (Mode.IsAssertion)
       {
         Assertion.Assert(myCurrentActivationChain != null, "myCurrentActivationChain != null");
         Assertion.Assert(!myCurrentActivationChain.Contains(type),
@@ -154,7 +154,7 @@ namespace JetBrains.Rd.Reflection
 
       ReflectionInitInternal(instance);
 
-      if (Mode.Assertion)
+      if (Mode.IsAssertion)
         myCurrentActivationChain!.Dequeue();
 
       return instance;
@@ -162,7 +162,7 @@ namespace JetBrains.Rd.Reflection
 
     public object ReflectionInit(object instance)
     {
-      if (Mode.Assertion)
+      if (Mode.IsAssertion)
       {
         myCurrentActivationChain = myCurrentActivationChain ?? new Queue<Type>();
         myCurrentActivationChain.Clear(); // clear previous attempts to activate different types

--- a/rd-net/RdFramework.Reflection/ReflectionSerializersFactory.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionSerializersFactory.cs
@@ -129,7 +129,7 @@ namespace JetBrains.Rd.Reflection
     {
       lock (myLock)
       {
-        if (Mode.Assertion)
+        if (Mode.IsAssertion)
           myCurrentSerializersChain.Clear();
         return GetOrRegisterStaticSerializerInternal(type, instance);
       }
@@ -143,7 +143,7 @@ namespace JetBrains.Rd.Reflection
       // RdModels only
       if (!mySerializers.TryGetValue(type, out var serializerPair))
       {
-        if (Mode.Assertion)
+        if (Mode.IsAssertion)
           myCurrentSerializersChain.Enqueue(type);
 
         using (new FirstChanceExceptionInterceptor.ThreadLocalDebugInfo(type))
@@ -162,7 +162,7 @@ namespace JetBrains.Rd.Reflection
           }
         }
 
-        if (Mode.Assertion)
+        if (Mode.IsAssertion)
           myCurrentSerializersChain.Dequeue();
 
         if (!mySerializers.TryGetValue(type, out serializerPair))
@@ -206,7 +206,7 @@ namespace JetBrains.Rd.Reflection
         Assertion.AssertNotNull(serializerPair, $"Unable to Create serializer for type {serializerType.ToString(true)}");
         if (serializerPair == null)
         {
-          if (Mode.Assertion)
+          if (Mode.IsAssertion)
             Assertion.Fail($"Unable to create serializer for {serializerType.ToString(true)}: circular dependency detected: {String.Join(" -> ", myCurrentSerializersChain.Select(t => t.ToString(true)).ToArray())}");
           throw new Assertion.AssertionException($"Undetected circular dependency during serializing {serializerType.ToString(true)}. Enable Assertion mode to get detailed information.");
         }

--- a/rd-net/RdFramework/RdFramework.csproj
+++ b/rd-net/RdFramework/RdFramework.csproj
@@ -10,8 +10,6 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <NoWarn>$(NoWarn),1591,1570,1574</NoWarn>
 
-        <DefineConstants Condition="'$(Configuration)' == 'Debug'">JET_MODE_ASSERT</DefineConstants>
-        
         <Configurations>Debug;Release;CrossTests</Configurations>
         
         <Platforms>AnyCPU</Platforms>

--- a/rd-net/Test.Cross/Test.Cross.csproj
+++ b/rd-net/Test.Cross/Test.Cross.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <RootNamespace>Test.RdCross</RootNamespace>
-        <DefineConstants>JET_MODE_ASSERT</DefineConstants>
         <Configurations>CrossTests</Configurations>
         <Platforms>AnyCPU</Platforms>
         <OutputType>Exe</OutputType>

--- a/rd-net/Test.Lifetimes/Serialization/UnsafeMarshallersTest.cs
+++ b/rd-net/Test.Lifetimes/Serialization/UnsafeMarshallersTest.cs
@@ -1,9 +1,14 @@
 ﻿using System.Collections.Generic;
+#if NET461
+using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+#endif
 using JetBrains.Serialization;
 using NUnit.Framework;
 
 namespace Test.Lifetimes.Serialization
-{  
+{
   public unsafe class UnsafeMarshallersTest : LifetimesTestBase
   {
     [Test]
@@ -44,6 +49,7 @@ namespace Test.Lifetimes.Serialization
         reader = UnsafeReader.CreateReader(cookie.Data, cookie.Count);
       }
 
+
       Assert.False(reader.ReadBoolean());
       Assert.True(reader.ReadBoolean());
       Assert.AreEqual(0, reader.ReadByte());
@@ -72,5 +78,104 @@ namespace Test.Lifetimes.Serialization
       CollectionAssert.AreEqual(new List<string>(), reader.ReadCollection(UnsafeReader.StringDelegate, n => new List<string>(n)));
       CollectionAssert.AreEqual(new List<string> {"d", "e"}, reader.ReadCollection(UnsafeReader.StringDelegate, n => new List<string>(n)));
     }
+
+#if NET461
+    private UnsafeWriter.Cookie myCookie;
+    private UnsafeReader myReader;
+
+    [Test, Explicit("Check performance implication of asserts in UnsafeReader")]
+    public void Bdn()
+    {
+      // Some results from my machine
+      //
+      // on x64
+      //   BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19044
+      //   AMD Ryzen 7 PRO 5850U with Radeon Graphics, 1 CPU, 16 logical and 8 physical cores
+      //     [Host]     : .NET Framework 4.8 (4.8.4515.0), X64 RyuJIT
+      //     DefaultJob : .NET Framework 4.8 (4.8.4515.0), X64 RyuJIT
+      //
+      // Base: asserts are deleted from the source code.
+      // | Method |     Mean |    Error |   StdDev |
+      // |------- |---------:|---------:|---------:|
+      // |      M | 12.52 ns | 0.127 ns | 0.118 ns |
+      //
+      // Mode.Assertion disabled
+      // | Method |     Mean |    Error |   StdDev |
+      // |------- |---------:|---------:|---------:|
+      // |      M | 13.56 ns | 0.261 ns | 0.231 ns |
+      //
+      // Mode.Assertion enabled
+      //   | Method |     Mean |    Error |   StdDev |
+      //   |------- |---------:|---------:|---------:|
+      //   |      M | 31.96 ns | 0.156 ns | 0.130 ns |
+      //
+      // on x86
+      //   BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19044
+      //   AMD Ryzen 7 PRO 5850U with Radeon Graphics, 1 CPU, 16 logical and 8 physical cores
+      //     [Host]     : .NET Framework 4.8 (4.8.4515.0), X86 LegacyJIT
+      //     DefaultJob : .NET Framework 4.8 (4.8.4515.0), X86 LegacyJIT
+      //
+      // Base: asserts are deleted from the source code.
+      // | Method |     Mean |    Error |   StdDev |
+      // |------- |---------:|---------:|---------:|
+      // |      M | 29.00 ns | 0.054 ns | 0.050 ns |
+      //
+      // Mode.Assertion disabled
+      // | Method |     Mean |    Error |   StdDev |
+      // |------- |---------:|---------:|---------:|
+      // |      M | 29.90 ns | 0.109 ns | 0.097 ns |
+      //
+      // Mode.Assertion enabled
+      // | Method |     Mean |    Error |   StdDev |
+      // |------- |---------:|---------:|---------:|
+      // |      M | 44.71 ns | 0.033 ns | 0.028 ns |
+      BenchmarkRunner.Run<UnsafeMarshallersTest>();
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+      AppDomain.CurrentDomain.SetData("JET_MODE_ASSERT", true); // comment to disable asserts
+
+      myCookie = UnsafeWriter.NewThreadLocalWriter();
+      myCookie.Writer.Write(false);
+      myCookie.Writer.Write(true);
+      myCookie.Writer.Write((byte)0);
+      myCookie.Writer.Write((byte)10);
+      myCookie.Writer.Write('y');
+      myCookie.Writer.Write('й');
+      myCookie.Writer.Write(1234.5678m);
+      myCookie.Writer.Write(1234.5678d);
+      myCookie.Writer.Write((short)1000);
+      myCookie.Writer.Write((int)1001);
+      myCookie.Writer.Write((long)-1002);
+      myCookie.Writer.Write("(long)-1002");
+      myReader = UnsafeReader.CreateReader(myCookie.Data, myCookie.Count);
+    }
+
+    [GlobalCleanup]
+    public void Teardown()
+    {
+      myCookie.Dispose();
+    }
+
+    [Benchmark]
+    public void M()
+    {
+      myReader.Reset(myCookie.Data, myCookie.Count);
+      var v0 = myReader.ReadBoolean();
+      var v1 = myReader.ReadBoolean();
+      var v2 = myReader.ReadByte();
+      var v3 = myReader.ReadByte();
+      var v4 = myReader.ReadChar();
+      var v5 = myReader.ReadChar();
+      var v6 = myReader.ReadDecimal();
+      var v7 = myReader.ReadDouble();
+      var v8 = myReader.ReadInt16();
+      var v9 = myReader.ReadInt32();
+      var v10 = myReader.ReadInt64();
+      var v11 = myReader.ReadString();
+    }
+#endif
   }
 }

--- a/rd-net/Test.Lifetimes/SetupFixture.cs
+++ b/rd-net/Test.Lifetimes/SetupFixture.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Test.Lifetimes;
+
+[SetUpFixture, TestFixture]
+public class SetupFixture
+{
+  [OneTimeSetUp]
+  public void Setup()
+  {
+    AppDomain.CurrentDomain.SetData("JET_MODE_ASSERT", true);
+  }
+}

--- a/rd-net/Test.Lifetimes/Test.Lifetimes.csproj
+++ b/rd-net/Test.Lifetimes/Test.Lifetimes.csproj
@@ -10,8 +10,6 @@
         <Platforms>AnyCPU</Platforms>
         <RollForward>LatestMajor</RollForward>
         <Nullable>disable</Nullable>
-
-        <DefineConstants Condition="'$(Configuration)' == 'Debug'">JET_MODE_ASSERT</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup>

--- a/rd-net/Test.RdFramework/Reflection/TestVerification.cs
+++ b/rd-net/Test.RdFramework/Reflection/TestVerification.cs
@@ -29,7 +29,7 @@ namespace Test.RdFramework.Reflection
     [TestCase(typeof(ModelCalls.ModelInvalidCalls))]
     public void TestError(Type type)
     {
-      Assert.True(Mode.Assertion);
+      Assert.True(Mode.IsAssertion);
       var serializer = new ReflectionSerializersFactory(new SimpleTypesCatalog());
       var activator = new ReflectionRdActivator(serializer, null);
       var exception = Assert.Throws<Assertion.AssertionException>(() => activator.Activate(type));

--- a/rd-net/Test.RdFramework/Reflection/TestVerification.cs
+++ b/rd-net/Test.RdFramework/Reflection/TestVerification.cs
@@ -29,6 +29,7 @@ namespace Test.RdFramework.Reflection
     [TestCase(typeof(ModelCalls.ModelInvalidCalls))]
     public void TestError(Type type)
     {
+      Assert.True(Mode.Assertion);
       var serializer = new ReflectionSerializersFactory(new SimpleTypesCatalog());
       var activator = new ReflectionRdActivator(serializer, null);
       var exception = Assert.Throws<Assertion.AssertionException>(() => activator.Activate(type));

--- a/rd-net/Test.RdFramework/SetupFixture.cs
+++ b/rd-net/Test.RdFramework/SetupFixture.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Test.RdFramework;
+
+[SetUpFixture, TestFixture]
+public class SetupFixture
+{
+  [OneTimeSetUp]
+  public void Setup()
+  {
+    AppDomain.CurrentDomain.SetData("JET_MODE_ASSERT", true);
+  }
+}

--- a/rd-net/Test.RdFramework/Test.RdFramework.csproj
+++ b/rd-net/Test.RdFramework/Test.RdFramework.csproj
@@ -4,7 +4,6 @@
 
         <DebugType>Full</DebugType>
         <IsPackable>false</IsPackable>
-        <DefineConstants>JET_MODE_ASSERT</DefineConstants>
         <Configurations>Debug;Release;CrossTests</Configurations>
         <Platforms>AnyCPU</Platforms>
         <RollForward>LatestMajor</RollForward>


### PR DESCRIPTION
Convert asserts from conditional compilation to Mode.Assertion. It will help avoid having two separate checked version of RdFramework and Lifetimes.

Checks with static readonly bool fields can be can be optimized by JIT compiler.