### PR TITLE
Mark Property::value and OptProperty::value as @Volatile

### DIFF
--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/reactive/Property.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/reactive/Property.kt
@@ -13,6 +13,7 @@ class Property<T>(defaultValue: T) : IProperty<T>
         value = newValue
     }
 
+    @Volatile
     override var value: T = defaultValue
         set(newValue) {
             if (field == newValue) return
@@ -49,6 +50,7 @@ open class OptProperty<T : Any>() : IOptProperty<T> {
         return false
     }
 
+    @Volatile
     protected var _value: T? = null
 
     override val valueOrNull: T?


### PR DESCRIPTION
Mark Property::value and OptProperty::value as @Volatile to avoid problems with jit-inlining and memory ordering when reading value from different threads