### PR TITLE
Improge Rd Logger

### DIFF
--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/Logger.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/Logger.kt
@@ -55,7 +55,7 @@ class SwitchLogger(private val category: String) : Logger {
     private class Pair(val factory: ILoggerFactory, val logger: Logger)
 }
 
-internal object LoggerFactoryStatic {
+private object LoggerFactoryStatic {
     private val factoryHolder = Statics<ILoggerFactory>()
     val currentFactory get() = factoryHolder.get() ?: ConsoleLoggerFactory
 }

--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/Logger.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/Logger.kt
@@ -30,98 +30,35 @@ interface ILoggerFactory {
     fun getLogger(category: String): Logger
 }
 
-
-class SwitchLogger(category: String) : Logger {
-    private val mediator =  LoggerFactoryStatic.getOrCreateMediator(category)
+class SwitchLogger(private val category: String) : Logger {
+    @Volatile
+    private var cachedPair: Pair? = null
 
     override fun log(level: LogLevel, message: Any?, throwable: Throwable?) {
-        mediator.logger.log(level, message, throwable)
+        getRealLogger().log(level, message, throwable)
     }
 
-    override fun isEnabled(level: LogLevel): Boolean = mediator.logger.isEnabled(level)
+    override fun isEnabled(level: LogLevel): Boolean = getRealLogger().isEnabled(level)
+
+    internal fun getRealLogger(): Logger {
+        var pair = cachedPair
+        while (true) {
+            val currentFactory = LoggerFactoryStatic.currentFactory // currentFactory rarely changes
+            if (pair?.factory === currentFactory)
+                return pair.logger
+
+            pair = Pair(currentFactory, currentFactory.getLogger(category))
+            cachedPair = pair
+        }
+    }
+
+    private class Pair(val factory: ILoggerFactory, val logger: Logger)
 }
 
 internal object LoggerFactoryStatic {
-    @Volatile
-    private var currentFactory: ILoggerFactory = ConsoleLoggerFactory
-    private val concurrentMap = ConcurrentHashMap<String, LoggerMediator>()
-    private val locker = Any()
-
-    init {
-        val tail = Statics<ILoggerFactory>().tail
-        synchronized(locker) {
-
-            // tail.change has no state, so updateMediators will not be called under lock
-            tail.change.advise(Lifetime.Eternal) { factory ->
-                updateMediators(factory ?: ConsoleLoggerFactory)
-            }
-
-            // set default value under lock to avoid a race condition
-            // when tail.change is called during advise
-            currentFactory = tail.value ?: ConsoleLoggerFactory
-        }
-    }
-
-    // this method is expected to be called very rarely
-    private fun updateMediators(factory: ILoggerFactory) {
-        val mediators: List<LoggerMediator>
-        var localFactory: ILoggerFactory
-
-        synchronized(locker) {
-            // getOrCreateMediator ensures actual currentFactory for all new mediators,
-            // so we don't care about mediators added after getting this snapshot.
-            mediators = concurrentMap.values.toList()
-
-            localFactory = factory
-            currentFactory = localFactory
-        }
-
-        val newLoggers = mediators.map {
-            // do not use getLogger under lock
-            localFactory.getLogger(it.category)
-        }
-
-        synchronized(locker) {
-            if (localFactory != currentFactory)
-                return // if currentFactory has been changed, another thread will update all mediators
-
-            mediators.forEachIndexed { index, loggerMediator ->
-                loggerMediator.logger = newLoggers[index]
-            }
-        }
-    }
-
-    fun getOrCreateMediator(category: String): LoggerMediator {
-        while(true) {
-            // do not use a lock here to ensure maximum parallelism when reading
-            val loggerMediator = concurrentMap[category]
-            if (loggerMediator != null)
-                return loggerMediator
-
-            val factory = currentFactory
-            // do not use getLogger under lock
-            val logger = factory.getLogger(category)
-
-            synchronized(locker) {
-                var loggerMediator = concurrentMap[category]
-                if (loggerMediator != null)
-                    return loggerMediator
-
-                if (factory == currentFactory) {
-                    loggerMediator = LoggerMediator(category, logger)
-                    concurrentMap[category] = loggerMediator
-                    return loggerMediator
-                } // else currentFactory has been changed, so we need to re-create logger
-            }
-        }
-    }
+    private val factoryHolder = Statics<ILoggerFactory>()
+    val currentFactory get() = factoryHolder.get() ?: ConsoleLoggerFactory
 }
-
-internal class LoggerMediator(val category: String, @Volatile var logger: Logger) : Logger {
-    override fun log(level: LogLevel, message: Any?, throwable: Throwable?) = logger.log(level, message, throwable)
-    override fun isEnabled(level: LogLevel): Boolean = logger.isEnabled(level)
-}
-
 
 object ConsoleLoggerFactory : ILoggerFactory {
     var minLevelToLog : LogLevel = LogLevel.Debug
@@ -152,7 +89,7 @@ fun defaultLogFormat(category: String, level: LogLevel, message: Any?, throwable
     return "${level.toString().padEnd(5)} | ${category.substringAfterLast('.').padEnd(25)} | ${currentThreadName().padEnd(15)} | ${message?.toString()?:""} ${throwableToPrint?.getThrowableText()?.let { "| $it" }?:""}"
 }
 
-fun getLogger(category: String): Logger = LoggerFactoryStatic.getOrCreateMediator(category)
+fun getLogger(category: String) = SwitchLogger(category)
 fun getLogger(categoryKclass: KClass<*>): Logger = getLogger(qualifiedName(categoryKclass))
 inline fun <reified T> getLogger() = getLogger(T::class)
 

--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/Statics.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/Statics.kt
@@ -2,6 +2,7 @@ package com.jetbrains.rd.util
 
 import com.jetbrains.rd.util.reactive.IViewableList
 import com.jetbrains.rd.util.reactive.ViewableList
+import com.jetbrains.rd.util.reactive.viewableTail
 import kotlin.reflect.KClass
 
 /**
@@ -23,6 +24,8 @@ class Statics<T: Any> private constructor(val kclass: KClass<T>){
 
     private val _stack = ViewableList<T>()
     val stack : IViewableList<T> get() = _stack
+    val tail = stack.viewableTail()
+
 
     fun get() : T? = _stack.lastOrNull()
 
@@ -43,6 +46,4 @@ class Statics<T: Any> private constructor(val kclass: KClass<T>){
     override fun toString(): String {
         return Statics::class.simpleName+"<" + kclass.simpleName +">"
     }
-
-
 }

--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/reactive/Signal.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/reactive/Signal.kt
@@ -14,8 +14,6 @@ open class Signal<T> : ISignal<T> {
         fun priorityAdviseSection(block:() -> Unit) = incrementCookie(cookie, TlsBoxed<Int>::value) { block() }
 
         fun Void() = Signal<Unit>()
-
-        private val logger by lazy { getLogger<Signal<*>>() }
     }
 
 
@@ -33,7 +31,6 @@ open class Signal<T> : ISignal<T> {
         }
     }
 
-
     override fun advise(lifetime : Lifetime, handler: (T) -> Unit) {
         advise0(if (Signal.isPriorityAdvise) priorityListeners else listeners, lifetime, handler)
     }
@@ -47,7 +44,7 @@ open class Signal<T> : ISignal<T> {
                     queue.getAndUpdate { arr ->
                         if (arr.contains(handler)) throw IllegalArgumentException("Duplicate handler: $handler")
                         if (arr.size == 10_000) {
-                            logger.error { "10k handlers were added for a signal; this will cause performance degradation" }
+                            Logger.root.error { "10k handlers were added for a signal; this will cause performance degradation" }
                         }
                         arr.insert(handler, arr.size)
                     }

--- a/rd-kt/rd-core/src/test/kotlin/com/jetbrains/rd/util/test/cases/LoggerTest.kt
+++ b/rd-kt/rd-core/src/test/kotlin/com/jetbrains/rd/util/test/cases/LoggerTest.kt
@@ -1,0 +1,91 @@
+package com.jetbrains.rd.util.test.cases
+
+import com.jetbrains.rd.util.*
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.test.framework.RdTestBase
+import kotlinx.coroutines.*
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicBoolean
+
+class LoggerTest : RdTestBase() {
+    @Test
+    fun manyLoggersStofl() {
+        val list = mutableListOf<Logger>()
+        for (i in 0..10_001)
+            list.add(getLogger("category: $i"))
+
+        list.forEach {
+            it.isEnabled(LogLevel.Info)
+        }
+
+    }
+
+    @Test
+    fun updateFactoryTest() {
+        val statics = Statics<ILoggerFactory>()
+
+        val factory = createLoggerFactory()
+        val logger = getLogger("")
+        assert(logger.getRealLogger() !== factory.LoggerInstance)
+
+        statics.use(factory) {
+            assert(logger.getRealLogger() === factory.LoggerInstance)
+
+            runBlocking {
+
+                suspend fun doTest() {
+                    val finish = AtomicBoolean(false)
+                    val started = AtomicBoolean(false)
+
+                    val tasks = (0 until Runtime.getRuntime().availableProcessors()).map {
+                        async(Dispatchers.Default) {
+                            started.set(true)
+
+                            while (!finish.get()) {
+                                ensureActive()
+                                logger.getRealLogger()
+                            }
+
+                            // return realLogger when the last factory was set
+                            logger.getRealLogger()
+                        }
+                    }
+
+                    spinUntil { started.get() }
+
+                    Lifetime.using { lifetime ->
+                        lifetime.onTermination { finish.set(true) }
+
+                        val n = 100
+                        for (i in 0..n) {
+                            val newFactory = createLoggerFactory()
+                            lifetime.onTermination(statics.push(newFactory))
+                            // check that logger.getRealLogger() is correct after pushing newFactory
+                            assert(logger.getRealLogger() == newFactory.LoggerInstance)
+
+                            if (i == n) {
+                                finish.set(true)
+                                tasks.awaitAll().forEach { realLogger ->
+                                    assert(realLogger === newFactory.LoggerInstance)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                for (i in 0..1000) {
+                    doTest()
+                }
+            }
+        }
+    }
+
+    private fun createLoggerFactory() = object : ILoggerFactory {
+        val LoggerInstance = object : Logger {
+            override fun log(level: LogLevel, message: Any?, throwable: Throwable?) = Unit
+            override fun isEnabled(level: LogLevel) = false
+        }
+
+        override fun getLogger(category: String) = LoggerInstance
+    }
+}

--- a/rd-kt/rd-core/src/test/kotlin/com/jetbrains/rd/util/test/cases/SignalTest.kt
+++ b/rd-kt/rd-core/src/test/kotlin/com/jetbrains/rd/util/test/cases/SignalTest.kt
@@ -1,7 +1,5 @@
 package com.jetbrains.rd.util.test.cases
 
-import com.jetbrains.rd.util.Logger
-import com.jetbrains.rd.util.getLogger
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.lifetime.plusAssign
 import com.jetbrains.rd.util.reactive.*
@@ -47,12 +45,5 @@ class SignalTest : RdTestBase()  {
 
         signal.fire()
         assertEquals(listOf(3, 4, 1, 2, 5), log)
-    }
-
-    @Test
-    fun manyLoggersStofl() {
-        val listOf = mutableListOf<Logger>()
-        for (i in 0..10_001)
-            listOf.add(getLogger("category: $i"))
     }
 }

--- a/rd-kt/rd-core/src/test/kotlin/com/jetbrains/rd/util/test/cases/SignalTest.kt
+++ b/rd-kt/rd-core/src/test/kotlin/com/jetbrains/rd/util/test/cases/SignalTest.kt
@@ -1,5 +1,7 @@
 package com.jetbrains.rd.util.test.cases
 
+import com.jetbrains.rd.util.Logger
+import com.jetbrains.rd.util.getLogger
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.lifetime.plusAssign
 import com.jetbrains.rd.util.reactive.*
@@ -45,5 +47,12 @@ class SignalTest : RdTestBase()  {
 
         signal.fire()
         assertEquals(listOf(3, 4, 1, 2, 5), log)
+    }
+
+    @Test
+    fun manyLoggersStofl() {
+        val listOf = mutableListOf<Logger>()
+        for (i in 0..10_001)
+            listOf.add(getLogger("category: $i"))
     }
 }


### PR DESCRIPTION
Fix stofl in getLogger
Reduce memory consumption
Do not create listener for all SwitchLogger (use cached LoggerMediator) Fix SwitchLogger mem leak
Fix race condition when getLogger is called at the same moment as Statics<ILoggerFactory>().push