### PR TITLE
rd-net: Improve `RdTask` factory methods usage experience

### DIFF
--- a/rd-net/RdFramework.Reflection/ProxyGenerator.cs
+++ b/rd-net/RdFramework.Reflection/ProxyGenerator.cs
@@ -214,7 +214,8 @@ namespace JetBrains.Rd.Reflection
       if (IsSync(method))
       {
         // Create RdTask
-        il.Emit(OpCodes.Call, returnType.GetMethod(nameof(RdTask.Successful)).NotNull("RdTask.Successful<Unit> not found"));
+        var taskFactoryMethod = typeof(RdTask).GetMethod(nameof(RdTask.Successful))?.MakeGenericMethod(responseType);
+        il.Emit(OpCodes.Call, taskFactoryMethod.NotNull("RdTask.Successful<Unit> not found"));
       }
       else
       {

--- a/rd-net/RdFramework.Reflection/ProxyGenerator.cs
+++ b/rd-net/RdFramework.Reflection/ProxyGenerator.cs
@@ -158,7 +158,7 @@ namespace JetBrains.Rd.Reflection
       Assertion.Assert(!method.IsGenericMethod, "generics are not supported");
       Assertion.Assert(!method.IsStatic, "only instance methods are supported");
 
-      // var type = ModuleBuilder.DefineType(selfType.FullName + "_adapter", 
+      // var type = ModuleBuilder.DefineType(selfType.FullName + "_adapter",
       //   TypeAttributes.Public & TypeAttributes.Sealed & TypeAttributes.Abstract & TypeAttributes.BeforeFieldInit);
       var requestType = GetRequstType(method)[0];
       var responseType = GetResponseType(method, unwrapTask: false);
@@ -214,7 +214,7 @@ namespace JetBrains.Rd.Reflection
       if (IsSync(method))
       {
         // Create RdTask
-        il.Emit(OpCodes.Call, returnType.GetMethod(nameof(RdTask<int>.Successful)).NotNull("RdTask<Unit>.Successful not found"));
+        il.Emit(OpCodes.Call, returnType.GetMethod(nameof(RdTask.Successful)).NotNull("RdTask.Successful<Unit> not found"));
       }
       else
       {
@@ -316,7 +316,7 @@ namespace JetBrains.Rd.Reflection
       foreach (var p in parameters)
       {
         // Lifetime treated as cancellation token
-        if (p.ParameterType != typeof(Lifetime) || p.ParameterType == typeof(CancellationToken)) 
+        if (p.ParameterType != typeof(Lifetime) || p.ParameterType == typeof(CancellationToken))
           list.Add(p.ParameterType);
       }
 
@@ -474,7 +474,7 @@ namespace JetBrains.Rd.Reflection
             if (member is MethodInfo { IsSpecialName: false } method)
               yield return ProxyFieldName(method);
             break;
-          
+
           case MemberTypes.Property:
             yield return MakeBackingFieldName(member.Name);
             break;

--- a/rd-net/RdFramework/Tasks/RdCall.cs
+++ b/rd-net/RdFramework/Tasks/RdCall.cs
@@ -73,7 +73,7 @@ namespace JetBrains.Rd.Tasks
     public override void OnWireReceived(UnsafeReader reader) //endpoint's side
     {
       var taskId = RdId.Read(reader);
-      
+
       var wiredTask = new WiredRdTask<TReq, TRes>.Endpoint(myBindLifetime, this, taskId, myCancellationScheduler ?? SynchronousScheduler.Instance);
       //subscribe for lifetime cancellation
       var externalCancellation = wiredTask.Lifetime;
@@ -90,7 +90,7 @@ namespace JetBrains.Rd.Tasks
           {
             var message = $"Handler is not set for {wiredTask} :: received request: {value.PrintToString()}";
             ourLogReceived.Error(message);
-            rdTask = RdTask<TRes>.Faulted(new Exception(message));
+            rdTask = RdTask.Faulted<TRes>(new Exception(message));
           }
           else
           {
@@ -100,15 +100,15 @@ namespace JetBrains.Rd.Tasks
             }
             catch (Exception ex)
             {
-              rdTask = RdTask<TRes>.Faulted(ex);
+              rdTask = RdTask.Faulted<TRes>(ex);
             }
           }
         }
         catch (Exception e)
         {
-          rdTask = RdTask<TRes>.Faulted(new Exception($"Unexpected exception in {wiredTask}", e));
+          rdTask = RdTask.Faulted<TRes>(new Exception($"Unexpected exception in {wiredTask}", e));
         }
-        
+
         rdTask.Result.Advise(Lifetime.Eternal, result =>
           {
             try
@@ -126,7 +126,7 @@ namespace JetBrains.Rd.Tasks
           });
       }
     }
-    
+
 
     public TRes Sync(TReq request, RpcTimeouts? timeouts = null)
     {
@@ -171,7 +171,7 @@ namespace JetBrains.Rd.Tasks
 
       var taskId = Proto.Identities.Next(RdId.Nil);
       var task = new WiredRdTask<TReq,TRes>.CallSite(Lifetime.Intersect(requestLifetime, myBindLifetime), this, taskId, scheduler);
-      
+
       Wire.Send(RdId, (writer) =>
       {
         SendTrace?.Log($"{task} :: send request: {request.PrintToString()}");

--- a/rd-net/RdFramework/Tasks/RdTask.cs
+++ b/rd-net/RdFramework/Tasks/RdTask.cs
@@ -14,7 +14,7 @@ namespace JetBrains.Rd.Tasks
 {
   public class RdTask<T> : IRdTask<T>
   {
-    
+
     internal readonly WriteOnceProperty<RdTaskResult<T>> ResultInternal = new WriteOnceProperty<RdTaskResult<T>>();
 
     public IReadonlyProperty<RdTaskResult<T>> Result => ResultInternal;
@@ -23,19 +23,31 @@ namespace JetBrains.Rd.Tasks
     public void SetCancelled() => ResultInternal.SetIfEmpty(RdTaskResult<T>.Cancelled());
     public void Set(Exception e) => ResultInternal.SetIfEmpty(RdTaskResult<T>.Faulted(e));
 
-    private static RdTask<T> FromResult(RdTaskResult<T> result)
-    {
-      var res = new RdTask<T>();
-      res.ResultInternal.Value = result;
-      return res;
-    }
-
-    public static RdTask<T> Successful(T result) => FromResult(RdTaskResult<T>.Success(result));
-    public static RdTask<T> Faulted(Exception exception) => FromResult(RdTaskResult<T>.Faulted(exception));
-    public static RdTask<T> Cancelled() => FromResult(RdTaskResult<T>.Cancelled());
+    [Obsolete("Use 'RdTask.Successful<T>(T)' instead")]
+    public static RdTask<T> Successful(T result) => RdTask.Successful(result);
+    [Obsolete("Use 'RdTask.Faulted<T>(Exception)' instead")]
+    public static RdTask<T> Faulted(Exception exception) => RdTask.Faulted<T>(exception);
+    [Obsolete("Use 'RdTask.Cancelled<T>()' instead")]
+    public static RdTask<T> Cancelled() => RdTask.Cancelled<T>();
 
 #if !NET35
     [PublicAPI] public static implicit operator Task<T>(RdTask<T> task) => task.AsTask();
 #endif
+  }
+
+  public static class RdTask
+  {
+    public static RdTask<T> Successful<T>(T result) => FromResult(RdTaskResult<T>.Success(result));
+    public static RdTask<T> Faulted<T>(Exception exception) => FromResult(RdTaskResult<T>.Faulted(exception));
+    public static RdTask<T> Cancelled<T>() => FromResult(RdTaskResult<T>.Cancelled());
+    private static RdTask<T> FromResult<T>(RdTaskResult<T> result)
+    {
+      var res = new RdTask<T>
+      {
+        ResultInternal = { Value = result }
+      };
+
+      return res;
+    }
   }
 }

--- a/rd-net/RdFramework/Tasks/RdTask.cs
+++ b/rd-net/RdFramework/Tasks/RdTask.cs
@@ -37,17 +37,10 @@ namespace JetBrains.Rd.Tasks
 
   public static class RdTask
   {
-    public static RdTask<T> Successful<T>(T result) => FromResult(RdTaskResult<T>.Success(result));
-    public static RdTask<T> Faulted<T>(Exception exception) => FromResult(RdTaskResult<T>.Faulted(exception));
-    public static RdTask<T> Cancelled<T>() => FromResult(RdTaskResult<T>.Cancelled());
-    private static RdTask<T> FromResult<T>(RdTaskResult<T> result)
-    {
-      var res = new RdTask<T>
-      {
-        ResultInternal = { Value = result }
-      };
-
-      return res;
-    }
+    [PublicAPI] public static RdTask<T> Successful<T>(T result) => FromResult(RdTaskResult<T>.Success(result));
+    [PublicAPI] public static RdTask<T> Faulted<T>(Exception exception) => FromResult(RdTaskResult<T>.Faulted(exception));
+    [PublicAPI] public static RdTask<T> Cancelled<T>() => FromResult(RdTaskResult<T>.Cancelled());
+    private static RdTask<T> FromResult<T>(RdTaskResult<T> result) =>
+      new() { ResultInternal = { Value = result } };
   }
 }

--- a/rd-net/RdFramework/Tasks/RdTaskEx.cs
+++ b/rd-net/RdFramework/Tasks/RdTaskEx.cs
@@ -16,7 +16,7 @@ namespace JetBrains.Rd.Tasks
     [PublicAPI] public static bool IsFaulted<T>(this IRdTask<T> task) => task.Result.HasValue() && task.Result.Value.Status == RdTaskStatus.Faulted;
 
     public static bool Wait<T>(this IRdTask<T> task, TimeSpan timeout) => SpinWaitEx.SpinUntil(Lifetime.Eternal, timeout, () => task.Result.HasValue());
-    
+
 
     public static RdTask<T> ToRdTask<T>(this Task<T> task)
     {
@@ -53,17 +53,17 @@ namespace JetBrains.Rd.Tasks
     {
       endpoint.Set((lt, req) => handler(lt, req).ToRdTask(), cancellationScheduler, handlerScheduler);
     }
-    
+
     [PublicAPI] public static void Set<TReq, TRes>(this IRdEndpoint<TReq, TRes> endpoint, Func<Lifetime, TReq, TRes> handler, IScheduler? cancellationScheduler = null, IScheduler? handlerScheduler = null)
     {
-      endpoint.Set((lifetime, req) => RdTask<TRes>.Successful(handler(lifetime, req)), cancellationScheduler, handlerScheduler);
+      endpoint.Set((lifetime, req) => RdTask.Successful(handler(lifetime, req)), cancellationScheduler, handlerScheduler);
     }
-    
+
     [PublicAPI] public static void Set<TReq, TRes>(this IRdEndpoint<TReq, TRes> endpoint, Func<TReq, TRes> handler, IScheduler? cancellationScheduler = null, IScheduler? handlerScheduler = null)
     {
-      endpoint.Set((_, req) => RdTask<TRes>.Successful(handler(req)), cancellationScheduler, handlerScheduler);
+      endpoint.Set((_, req) => RdTask.Successful(handler(req)), cancellationScheduler, handlerScheduler);
     }
-    
+
     [PublicAPI] public static void SetVoid<TReq>(this IRdEndpoint<TReq, Unit> endpoint, Action<TReq> handler, IScheduler? cancellationScheduler = null, IScheduler? handlerScheduler = null)
     {
       endpoint.Set(req =>
@@ -72,7 +72,7 @@ namespace JetBrains.Rd.Tasks
         return Unit.Instance;
       }, cancellationScheduler, handlerScheduler);
     }
-    
+
     [PublicAPI]
     public static Task<T> AsTask<T>(this IRdTask<T> task)
     {
@@ -96,6 +96,6 @@ namespace JetBrains.Rd.Tasks
         }
       });
       return tcs.Task;
-    }   
+    }
   }
 }

--- a/rd-net/Test.Cross/Cases/Client/CrossTest_RdCall_CsClient.cs
+++ b/rd-net/Test.Cross/Cases/Client/CrossTest_RdCall_CsClient.cs
@@ -14,7 +14,7 @@ namespace Test.RdCross.Cases.Client
       {
         var demoModel = new DemoModel(ModelLifetime, Protocol);
 
-        demoModel.Call.Set((lifetime, c) => RdTask<string>.Successful(c.ToString()));
+        demoModel.Call.Set((lifetime, c) => RdTask.Successful(c.ToString()));
 
         demoModel.Callback.Start(ModelLifetime, "Csharp");
       });

--- a/rd-net/Test.RdFramework/RdTaskTest.cs
+++ b/rd-net/Test.RdFramework/RdTaskTest.cs
@@ -30,9 +30,9 @@ namespace Test.RdFramework
       res.Set(handler, cancellationScheduler, handlerScheduler);
       return res;
     }
-    
-    
-    
+
+
+
     [Test]
     public void TestStatic()
     {
@@ -49,7 +49,7 @@ namespace Test.RdFramework
       var task = serverEntity.Start(0);
       Assert.AreEqual(RdTaskStatus.Success, task.Result.Value.Status);
     }
-    
+
 
     [Test]
     public void TestNullability()
@@ -59,7 +59,7 @@ namespace Test.RdFramework
 
       var serverEntity = BindToServer(LifetimeDefinition.Lifetime, NewRdCall<string, string>(), ourKey);
       var clientEntity = BindToClient(LifetimeDefinition.Lifetime, CreateEndpoint<string, string>(x => x.ToString()), ourKey);
-      clientEntity.Set((lf, req) => RdTask<string>.Successful(req == null ? "NULL" : null));
+      clientEntity.Set((lf, req) => RdTask.Successful(req == null ? "NULL" : null));
 
       Assert.Throws<Assertion.AssertionException>(() =>
       {
@@ -82,12 +82,12 @@ namespace Test.RdFramework
     {
       ClientWire.AutoTransmitMode = true;
       ServerWire.AutoTransmitMode = true;
-      
+
       var serverEntity = BindToServer(LifetimeDefinition.Lifetime, NewRdCall<Unit, string>(), ourKey);
       var clientEntity = BindToClient(LifetimeDefinition.Lifetime, CreateEndpoint<Unit, string>(x => x.ToString()), ourKey);
 
-      bool handlerFinished = false; 
-      bool handlerCompletedSuccessfully = false; 
+      bool handlerFinished = false;
+      bool handlerCompletedSuccessfully = false;
       clientEntity.Set(async (lf, req) =>
       {
         try
@@ -111,12 +111,12 @@ namespace Test.RdFramework
 
         SpinWaitEx.SpinUntil(() => task.IsCompleted);
         Assert.True(task.IsOperationCanceled());
-      
+
         SpinWaitEx.SpinUntil(() => handlerFinished);
         Assert.False(handlerCompletedSuccessfully);
       }
-      
-      
+
+
       //2. no cancellation
       {
         handlerFinished = false;
@@ -124,41 +124,41 @@ namespace Test.RdFramework
         var task = serverEntity.Start(new LifetimeDefinition().Lifetime, Unit.Instance).AsTask();
         SpinWaitEx.SpinUntil(() => task.IsCompleted);
         Assert.False(task.IsOperationCanceled());
-      
+
         SpinWaitEx.SpinUntil(() => handlerFinished);
         Assert.True(handlerCompletedSuccessfully);
       }
-      
+
       //3. terminatedLifetime
       {
         var task = serverEntity.Start(Lifetime.Terminated, Unit.Instance).AsTask();
         Assert.IsTrue(task.IsCanceled);
       }
-      
+
       //4. cancellation from parent lifetime
       {
         handlerFinished = false;
         handlerCompletedSuccessfully = false;
         var task = serverEntity.Start(new LifetimeDefinition().Lifetime, Unit.Instance).AsTask();
         LifetimeDefinition.Terminate();
-      
+
         SpinWaitEx.SpinUntil(() => task.IsCompleted);
         Assert.True(task.IsOperationCanceled());
-      
+
         SpinWaitEx.SpinUntil(() => handlerFinished);
         Assert.False(handlerCompletedSuccessfully);
       }
     }
 
-    
-    
+
+
     [Test]
     public void TestBindable()
     {
       ClientWire.AutoTransmitMode = true;
       ServerWire.AutoTransmitMode = true;
-      
-      
+
+
       var call1 = new RdCall<Unit, RdSignal<int>>(Serializers.ReadVoid, Serializers.WriteVoid, RdSignal<int>.Read, RdSignal<int>.Write);
       var call2 = new RdCall<Unit, RdSignal<int>>(Serializers.ReadVoid, Serializers.WriteVoid, RdSignal<int>.Read, RdSignal<int>.Write);
 
@@ -167,9 +167,9 @@ namespace Test.RdFramework
       call2.Set((endpointLf, _) =>
       {
         endpointLf.OnTermination(() => endpointLfTerminated = true);
-        return RdTask<RdSignal<int>>.Successful(respSignal);
+        return RdTask.Successful(respSignal);
       });
-      
+
       var serverEntity = BindToServer(LifetimeDefinition.Lifetime, call1, ourKey);
       var clientEntity = BindToClient(LifetimeDefinition.Lifetime, call2, ourKey);
 
@@ -177,13 +177,13 @@ namespace Test.RdFramework
       var lf = ld.Lifetime;
       var signal = call1.Start(lf, Unit.Instance).AsTask().GetOrWait(lf);
       var log = new List<int>();
-      
+
       signal.Advise(Lifetime.Eternal, v =>
       {
         log.Add(v);
         Console.WriteLine(v);
       });
-      
+
       respSignal.Fire(1);
       respSignal.Fire(2);
       respSignal.Fire(3);
@@ -193,10 +193,10 @@ namespace Test.RdFramework
       SpinWaitEx.SpinUntil(() => log.Count >= 3);
       Thread.Sleep(100);
       Assert.AreEqual(new [] {1, 2, 3}, log.ToArray());
-      
+
       Assert.True(endpointLfTerminated);
     }
-    
+
     [Test]
     public void TestOverriddenHandlerScheduler()
     {
@@ -207,7 +207,7 @@ namespace Test.RdFramework
 
       var callsite = BindToServer(LifetimeDefinition.Lifetime, NewRdCall<int, string>(), ourKey);
       var endpoint = BindToClient(LifetimeDefinition.Lifetime, NewRdCall<int, string>(), ourKey);
-      
+
       Assert.IsFalse(scheduler.IsActive);
 
       var point1 = false;
@@ -217,29 +217,29 @@ namespace Test.RdFramework
       {
         Assert.IsTrue(scheduler.IsActive);
         Assert.AreNotEqual(thread, Thread.CurrentThread);
-        
+
         Volatile.Write(ref point1, true);
-        
+
         SpinWaitEx.SpinUntil(TestLifetime, TimeSpan.FromSeconds(10), () => point2);
         Assert.IsTrue(point2);
-        
+
         return i.ToString();
       }, handlerScheduler: scheduler);
 
       Assert.IsFalse(scheduler.IsActive);
-      
+
       var task = callsite.Start(0);
       var result = task.Result;
-      
+
       Assert.IsFalse(result.Maybe.HasValue);
-      
+
       SpinWaitEx.SpinUntil(TestLifetime, TimeSpan.FromSeconds(10), () => point1);
       Assert.IsTrue(point1);
       Assert.IsFalse(result.Maybe.HasValue);
-      
+
       Volatile.Write(ref point2, true);
       SpinWaitEx.SpinUntil(TestLifetime, () => result.Maybe.HasValue);
-      
+
       Assert.AreEqual("0", result.Value.Result);
     }
   }


### PR DESCRIPTION
Currently, to return the successful result you should provide a full specific type when dealing with `RdTask<T>.Successful`. It could be quite massive:
```csharp
return RdTask<IEnumerable<SomeResultModel>>.Successful(results);
```

This PR introduces a special non-generic `RdTask` class with generic types moved to method signatures. This allows to use the power of the C# compiler to infer the type from a method argument and simplifies usage:
```csharp
return RdTask.Successful(results);
```

`Faulted` and `Cancelled` are also introduced in `RdTask` to remove possible user confusion.