### PR TITLE
Fix unaligned memory access in UnsafeReader.ReadDouble() and UnsafeWriter.Write(double) on Linux ARM32

### DIFF
--- a/rd-net/Lifetimes/Serialization/UnsafeReader.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeReader.cs
@@ -136,7 +136,13 @@ namespace JetBrains.Serialization
 
       var x = (double*)myPtr;
       myPtr = (byte*)(x + 1);
+#if NET35
       return *x;
+#else
+      double d = 0;
+      Buffer.MemoryCopy(x, &d, sizeof(double), sizeof(double));
+      return d;
+#endif
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]

--- a/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
@@ -370,7 +370,11 @@ namespace JetBrains.Serialization
       Prepare(sizeof(double));
       var x = (double*)myPtr;
       myPtr = (byte*)(x + 1);
+#if NET35
       *x = value;
+#else
+      Buffer.MemoryCopy(&value, x, sizeof(double), sizeof(double));
+#endif
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]


### PR DESCRIPTION
Fix unaligned memory access in UnsafeReader.ReadDouble() and UnsafeWriter.Write(double) on Linux ARM32

https://youtrack.jetbrains.com/issue/RSRP-490138