### PR TITLE
Add RuntimeInfo.IsUnalignedAccessAllowed to use unaligned memory access on non-ARM32 platforms in UnsafeReader.ReadDouble() and UnsafeWriter.Write(double)

### DIFF
--- a/rd-net/Lifetimes/Serialization/UnsafeReader.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeReader.cs
@@ -139,13 +139,18 @@ namespace JetBrains.Serialization
 
       var x = (double*)myPtr;
       myPtr = (byte*)(x + 1);
-#if NET35
-      return *x;
-#else
-      double d = 0;
-      Buffer.MemoryCopy(x, &d, sizeof(double), sizeof(double));
-      return d;
+#if !NET35
+      if (!RuntimeInfo.IsUnalignedAccessAllowed)
+      {
+        double d = 0;
+        Buffer.MemoryCopy(x, &d, sizeof(double), sizeof(double));
+        return d;
+      }
+      else
 #endif
+      {
+        return *x;
+      }
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]

--- a/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
@@ -370,11 +370,14 @@ namespace JetBrains.Serialization
       Prepare(sizeof(double));
       var x = (double*)myPtr;
       myPtr = (byte*)(x + 1);
-#if NET35
-      *x = value;
-#else
-      Buffer.MemoryCopy(&value, x, sizeof(double), sizeof(double));
+#if !NET35
+      if (!RuntimeInfo.IsUnalignedAccessAllowed)
+        Buffer.MemoryCopy(&value, x, sizeof(double), sizeof(double));
+      else
 #endif
+      {
+        *x = value;
+      }
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]

--- a/rd-net/Lifetimes/Util/RuntimeInfo.cs
+++ b/rd-net/Lifetimes/Util/RuntimeInfo.cs
@@ -3,6 +3,10 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JetBrains.Annotations;
 
+#if !NET35
+using System.Runtime.InteropServices;
+#endif
+
 namespace JetBrains.Util
 {
   public static class RuntimeInfo
@@ -11,6 +15,7 @@ namespace JetBrains.Util
     public static readonly bool IsRunningOnMono; 
     public static readonly bool IsRunningUnderWindows;
     public static readonly bool IsRunningOnCore;
+    public static readonly bool IsUnalignedAccessAllowed;
 
     static RuntimeInfo()
     {
@@ -47,6 +52,14 @@ namespace JetBrains.Util
       {
         IsRunningOnMono = false;
       }
+
+      IsUnalignedAccessAllowed =
+#if NET35
+        true
+#else
+        RuntimeInformation.ProcessArchitecture != Architecture.Arm
+#endif
+        ;
     }
 
 #if NET35


### PR DESCRIPTION
Add RuntimeInfo.IsUnalignedAccessAllowed to use unaligned memory access on non-ARM32 platforms in UnsafeReader.ReadDouble() and UnsafeWriter.Write(double)

https://youtrack.jetbrains.com/issue/RSRP-490138

Relates to https://github.com/JetBrains/rd/pull/360
Depends on https://github.com/JetBrains/rd/pull/361