### PR TITLE
rd-gen: fix assorted warnings

### DIFF
--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/Members.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/Members.kt
@@ -1,7 +1,7 @@
 package com.jetbrains.rd.generator.nova
 
-import com.jetbrains.rd.generator.nova.util.decapitalizeInvariant
 import com.jetbrains.rd.generator.nova.util.capitalizeInvariant
+import com.jetbrains.rd.generator.nova.util.decapitalizeInvariant
 import com.jetbrains.rd.util.hash.IncrementalHash64
 import kotlin.reflect.KClass
 import kotlin.reflect.full.safeCast
@@ -142,8 +142,10 @@ sealed class Member(name: String, referencedTypes: List<IType>) : SettingsHolder
 
 }
 
+@Suppress("unused")
 fun Member.Field.notUsedInEquals() = apply { usedInEquals = false }
 
+@Suppress("unused")
 val Member.Field.suppressEmptyCtor get() = apply { emptyCtorSuppressed = true }
 val Member.Field.optional get() = apply {
     if (type is INonNullable) throw GeneratorException("Field '$name' can't be optional because it's not nullable, actual type: ${type.name}")

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/Members.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/Members.kt
@@ -1,5 +1,7 @@
 package com.jetbrains.rd.generator.nova
 
+import com.jetbrains.rd.generator.nova.util.decapitalizeInvariant
+import com.jetbrains.rd.generator.nova.util.capitalizeInvariant
 import com.jetbrains.rd.util.hash.IncrementalHash64
 import kotlin.reflect.KClass
 import kotlin.reflect.full.safeCast
@@ -12,7 +14,7 @@ enum class FlowKind {
 
 
 sealed class Member(name: String, referencedTypes: List<IType>) : SettingsHolder() {
-    open val name: String = name.decapitalize()
+    open val name: String = name.decapitalizeInvariant()
     var documentation: String? = null
     lateinit var owner: Declaration
     val referencedTypes : List<IType> = referencedTypes.flatMap { expandItemTypes(it) }.distinct()
@@ -125,7 +127,7 @@ sealed class Member(name: String, referencedTypes: List<IType>) : SettingsHolder
             errors.add("Member $m is invalid: empty name")
         else if (!name[0].isLetter() || !name.all { it.isLetterOrDigit() || it == '_'})
             errors.add("Member $m is invalid: must be [A-Za-z][A-Za-z0-9_]*")
-        else if (name.capitalize() == owner.name)
+        else if (name.capitalizeInvariant() == owner.name)
             errors.add("Member $m is invalid: name cannot be the same as its enclosing declaration")
         else if (owner.ownMembers.any { it != this && it.name == name })
             errors.add("Member $m is duplicated")

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/Types.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/Types.kt
@@ -4,8 +4,8 @@ package com.jetbrains.rd.generator.nova
 
 import com.jetbrains.rd.generator.nova.cpp.Cpp17Generator
 import com.jetbrains.rd.generator.nova.util.booleanSystemProperty
-import com.jetbrains.rd.generator.nova.util.decapitalizeInvariant
 import com.jetbrains.rd.generator.nova.util.capitalizeInvariant
+import com.jetbrains.rd.generator.nova.util.decapitalizeInvariant
 import com.jetbrains.rd.generator.nova.util.getSourceFileAndLine
 import com.jetbrains.rd.util.hash.IncrementalHash64
 import com.jetbrains.rd.util.string.condstr
@@ -183,6 +183,7 @@ sealed class PredefinedType : INonNullableScalar {
     object ulong: UnsignedIntegral(long)
 
     //aliases
+    @Suppress("unused")
     companion object {
         val int8 : NativeIntegral get() = byte
         val uint8 : UnsignedIntegral get() = ubyte
@@ -336,7 +337,7 @@ abstract class Toplevel(pointcut: BindableDeclaration?) : BindableDeclaration(po
     }
 
 
-    class Part<T>(val name: String)
+    class Part<@Suppress("unused") T>(val name: String)
 
     //classes
     private fun baseclass0(name: String, base: Class.Abstract?, body: Class.() -> Unit) = append(Class.Abstract(name, this, base), body)

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/Types.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/Types.kt
@@ -4,6 +4,8 @@ package com.jetbrains.rd.generator.nova
 
 import com.jetbrains.rd.generator.nova.cpp.Cpp17Generator
 import com.jetbrains.rd.generator.nova.util.booleanSystemProperty
+import com.jetbrains.rd.generator.nova.util.decapitalizeInvariant
+import com.jetbrains.rd.generator.nova.util.capitalizeInvariant
 import com.jetbrains.rd.generator.nova.util.getSourceFileAndLine
 import com.jetbrains.rd.util.hash.IncrementalHash64
 import com.jetbrains.rd.util.string.condstr
@@ -120,7 +122,7 @@ sealed class Context(pointcut: Toplevel, val type: INonNullableScalar): Declarat
 
 
 sealed class PredefinedType : INonNullableScalar {
-    override val name : String get() = javaClass.simpleName.capitalize()
+    override val name : String get() = javaClass.simpleName.capitalizeInvariant()
 
     //special type to denote no parameter or return values
     object void : PredefinedType()
@@ -210,7 +212,7 @@ abstract class Declaration(open val pointcut: BindableDeclaration?) : SettingsHo
     var sourceFileAndLine: String? = null
 
     override val name: String by lazy {
-        if (_name.isNotEmpty()) return@lazy _name.capitalize()
+        if (_name.isNotEmpty()) return@lazy _name.capitalizeInvariant()
 
         val parent = pointcut as? Toplevel ?: return@lazy ""
 
@@ -232,7 +234,7 @@ abstract class Declaration(open val pointcut: BindableDeclaration?) : SettingsHo
         //default: error will arise at validation
         ?: ""
 
-        return@lazy  res.capitalize()
+        return@lazy  res.capitalizeInvariant()
     }
 
     val root : Root get () = pointcut?.root ?: this as Root
@@ -479,7 +481,7 @@ abstract class Toplevel(pointcut: BindableDeclaration?) : BindableDeclaration(po
 }
 
 class Interface(override val _name: String, pointcut: Toplevel, val baseInterfaces: List<Interface>) : Declaration(pointcut){
-    override val cl_name = "${javaClass.simpleName.decapitalize()}_interface"
+    override val cl_name = "${javaClass.simpleName.decapitalizeInvariant()}_interface"
     operator fun invoke(body: Interface.() -> Unit) = this to body //for extends
 
     operator fun plus(inter: Interface) = mutableListOf(this, inter)
@@ -487,7 +489,7 @@ class Interface(override val _name: String, pointcut: Toplevel, val baseInterfac
 }
 
 sealed class Struct(override val _name: String, override val pointcut : Toplevel, override val base: Struct?, val isUnknown: Boolean = false) : Declaration(pointcut), INonNullableScalar, ITypeDeclaration {
-    override val cl_name = "${javaClass.simpleName.decapitalize()}_struct"
+    override val cl_name = "${javaClass.simpleName.decapitalizeInvariant()}_struct"
 
     class Abstract(name: String, pointcut: Toplevel, base: Abstract?) : Struct(name, pointcut, base) {
         override val modifier: Modifier = Modifier.Abstract
@@ -505,7 +507,7 @@ operator fun <T : Struct> T.getValue(thisRef: Any?, property: KProperty<*>): T =
 
 sealed class Class(override val _name: String, override val pointcut : Toplevel, override val base: Class?, val isUnknown: Boolean = false) :
         BindableDeclaration(pointcut), INonNullableBindable, Extensible, ITypeDeclaration {
-    override val cl_name = "${javaClass.simpleName.decapitalize()}_class"
+    override val cl_name = "${javaClass.simpleName.decapitalizeInvariant()}_class"
 
     internal val internRootForScopes = mutableListOf<String>()
     override val extensions = mutableListOf<Ext>()

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/cpp/Cpp17Generator.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/cpp/Cpp17Generator.kt
@@ -6,6 +6,8 @@ import com.jetbrains.rd.generator.nova.FlowKind.*
 import com.jetbrains.rd.generator.nova.cpp.CppSanitizer.sanitize
 import com.jetbrains.rd.generator.nova.cpp.Signature.Constructor
 import com.jetbrains.rd.generator.nova.cpp.Signature.MemberFunction
+import com.jetbrains.rd.generator.nova.util.decapitalizeInvariant
+import com.jetbrains.rd.generator.nova.util.capitalizeInvariant
 import com.jetbrains.rd.generator.nova.util.joinToOptString
 import com.jetbrains.rd.util.Logger
 import com.jetbrains.rd.util.eol
@@ -412,7 +414,7 @@ open class Cpp17Generator(
         is PredefinedType.uri -> "URI"
         is PredefinedType.secureString -> "RdSecureString"
         is PredefinedType.void -> "rd::Void"
-        is PredefinedType -> name.decapitalize()
+        is PredefinedType -> name.decapitalizeInvariant()
         is RdCppLibraryType -> name
 
         else -> fail("Unsupported type ${javaClass.simpleName}")
@@ -1882,7 +1884,7 @@ open class Cpp17Generator(
             is PredefinedType.dateTime -> "buffer.read_date_time()"
             is PredefinedType.NativeIntegral, is PredefinedType.UnsignedIntegral -> "buffer.read_integral<${templateName(decl)}>()"
             is PredefinedType.NativeFloatingPointType -> "buffer.read_floating_point<${templateName(decl)}>()"
-            is PredefinedType -> "buffer.read${name.capitalize()}()"
+            is PredefinedType -> "buffer.read${name.capitalizeInvariant()}()"
             is Declaration -> {
                 if (isIntrinsic) {
                     polymorphicReader()
@@ -2330,7 +2332,7 @@ open class Cpp17Generator(
 
     protected fun PrettyPrinter.extensionTraitDef(decl: Ext) {//todo
         define(extensionTraitDecl(decl)) {
-            val lowerName = decl.name.decapitalize()
+            val lowerName = decl.name.decapitalizeInvariant()
             +"""return pointcut.getOrCreateExtension<${decl.name}>("$lowerName");"""
             println()
         }

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/cpp/CppIntrinsicType.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/cpp/CppIntrinsicType.kt
@@ -1,12 +1,12 @@
 package com.jetbrains.rd.generator.nova.cpp
 
 import com.jetbrains.rd.generator.nova.Declaration
-import com.jetbrains.rd.generator.nova.IType
 import com.jetbrains.rd.generator.nova.ITypeDeclaration
+import com.jetbrains.rd.generator.nova.util.decapitalizeInvariant
 
 data class CppIntrinsicType(val namespace: String?, override val name: String, val header: String?) : Declaration(null), ITypeDeclaration {
     override val _name: String
-        get() = "${javaClass.simpleName.decapitalize()}_cpp_intrinsic"
+        get() = "${javaClass.simpleName.decapitalizeInvariant()}_cpp_intrinsic"
     override val cl_name: String
-        get() = "${javaClass.simpleName.decapitalize()}_class"
+        get() = "${javaClass.simpleName.decapitalizeInvariant()}_class"
 }

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/csharp/CSharp50Generator.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/csharp/CSharp50Generator.kt
@@ -4,6 +4,8 @@ import com.jetbrains.rd.generator.nova.*
 import com.jetbrains.rd.generator.nova.Enum
 import com.jetbrains.rd.generator.nova.FlowKind.*
 import com.jetbrains.rd.generator.nova.csharp.CSharpSanitizer.sanitize
+import com.jetbrains.rd.generator.nova.util.decapitalizeInvariant
+import com.jetbrains.rd.generator.nova.util.capitalizeInvariant
 import com.jetbrains.rd.generator.nova.util.joinToOptString
 import com.jetbrains.rd.util.hash.IncrementalHash64
 import com.jetbrains.rd.util.string.Eol
@@ -137,7 +139,7 @@ open class CSharp50Generator(
                             PredefinedType.double,
                             PredefinedType.char,
                             PredefinedType.string
-                    ).contains(this) -> name.decapitalize()
+                    ).contains(this) -> name.decapitalizeInvariant()
                     this is PredefinedType.UnsignedIntegral -> {
                         if (itemType is PredefinedType.byte) {
                             "byte"
@@ -309,7 +311,7 @@ open class CSharp50Generator(
     }
 
 
-    protected open val Member.publicName: String get() = name.capitalize()
+    protected open val Member.publicName: String get() = name.capitalizeInvariant()
     protected open val Member.encapsulatedName: String get() = isEncapsulated.condstr { "_" } + publicName
     protected open val Member.isEncapsulated: Boolean get() = when (this) {
         is Member.Reactive.Stateful.Extension -> when {
@@ -1289,7 +1291,7 @@ open class CSharp50Generator(
     }
 
     protected open fun PrettyPrinter.interfaceDef(decl: Interface) {
-        +"public interface ${decl.name.capitalize()}"
+        +"public interface ${decl.name.capitalizeInvariant()}"
         indent {baseInterfacesTrait(decl) }
         p("{")
         println()
@@ -1305,7 +1307,7 @@ open class CSharp50Generator(
 
     protected open fun PrettyPrinter.methodsTrait(decl: Interface) {
         decl.ownMembers.filterIsInstance<Member.Method>().forEach { method ->
-            +"${if(method.resultType == PredefinedType.void) "void" else method.resultType.substitutedName(decl)} ${method.name.capitalize()}(${method.args.joinToString { t -> "${t.second.substitutedName(decl)} ${t.first}"}});"
+            +"${if(method.resultType == PredefinedType.void) "void" else method.resultType.substitutedName(decl)} ${method.name.capitalizeInvariant()}(${method.args.joinToString { t -> "${t.second.substitutedName(decl)} ${t.first}"}});"
         }
     }
 
@@ -1342,7 +1344,7 @@ open class CSharp50Generator(
         ?: this.javaClass.simpleName
 
     protected open fun PrettyPrinter.methodTrait(method: Member.Method, decl: Declaration ,isAbstract: Boolean) {
-        println("public ${isAbstract.condstr { "abstract " }}${isUnknown(decl).condstr { "override " }}${if (method.resultType == PredefinedType.void) "void" else method.resultType.substitutedName(decl)} ${method.name.capitalize()}(${method.args.joinToString { t -> "${t.second.substitutedName(decl)} ${t.first}" }})${isAbstract.condstr { ";" }}")
+        println("public ${isAbstract.condstr { "abstract " }}${isUnknown(decl).condstr { "override " }}${if (method.resultType == PredefinedType.void) "void" else method.resultType.substitutedName(decl)} ${method.name.capitalizeInvariant()}(${method.args.joinToString { t -> "${t.second.substitutedName(decl)} ${t.first}" }})${isAbstract.condstr { ";" }}")
 
         if (isAbstract) return
         println("{")
@@ -1357,13 +1359,13 @@ open class CSharp50Generator(
 
     private fun PrettyPrinter.extensionTrait(decl: Ext) {
         val pointcut = decl.pointcut ?: return
-        val ownerLowerName = pointcut.name.decapitalize()
+        val ownerLowerName = pointcut.name.decapitalizeInvariant()
 
         +"public static class ${pointcut.name}${decl.name}Ex"
         +" {"
         indent {
-            val lowerName = decl.name.decapitalize()
-            val extName = decl.extName?.capitalize() ?: decl.name
+            val lowerName = decl.name.decapitalizeInvariant()
+            val extName = decl.extName?.capitalizeInvariant() ?: decl.name
             +"public static ${decl.name} Get$extName(this ${pointcut.sanitizedName(decl)} $ownerLowerName)"
             +"{"
             indent {

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/csharp/CSharp50Generator.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/csharp/CSharp50Generator.kt
@@ -4,8 +4,8 @@ import com.jetbrains.rd.generator.nova.*
 import com.jetbrains.rd.generator.nova.Enum
 import com.jetbrains.rd.generator.nova.FlowKind.*
 import com.jetbrains.rd.generator.nova.csharp.CSharpSanitizer.sanitize
-import com.jetbrains.rd.generator.nova.util.decapitalizeInvariant
 import com.jetbrains.rd.generator.nova.util.capitalizeInvariant
+import com.jetbrains.rd.generator.nova.util.decapitalizeInvariant
 import com.jetbrains.rd.generator.nova.util.joinToOptString
 import com.jetbrains.rd.util.hash.IncrementalHash64
 import com.jetbrains.rd.util.string.Eol

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/kotlin/Kotlin11Generator.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/kotlin/Kotlin11Generator.kt
@@ -4,6 +4,8 @@ import com.jetbrains.rd.generator.nova.*
 import com.jetbrains.rd.generator.nova.Enum
 import com.jetbrains.rd.generator.nova.FlowKind.*
 import com.jetbrains.rd.generator.nova.kotlin.KotlinSanitizer.sanitize
+import com.jetbrains.rd.generator.nova.util.decapitalizeInvariant
+import com.jetbrains.rd.generator.nova.util.capitalizeInvariant
 import com.jetbrains.rd.generator.nova.util.joinToOptString
 import com.jetbrains.rd.util.eol
 import com.jetbrains.rd.util.hash.IncrementalHash64
@@ -80,7 +82,7 @@ open class Kotlin11Generator(
         is PredefinedType.secureString -> "RdSecureString"
         is PredefinedType.void -> "Unit"
         is PredefinedType.UnsignedIntegral -> "U${itemType.substitutedName(scope)}"
-        is PredefinedType -> name.capitalize()
+        is PredefinedType -> name.capitalizeInvariant()
 
         else -> fail("Unsupported type ${javaClass.simpleName}")
     }
@@ -620,7 +622,7 @@ open class Kotlin11Generator(
     private fun PrettyPrinter.createMethodTrait(decl: Toplevel) {
         if (!decl.isToplevelExtension) return
         
-        val extName = (decl as? Ext)?.extName ?: decl.name.decapitalize()
+        val extName = (decl as? Ext)?.extName ?: decl.name.decapitalizeInvariant()
         + "@JvmStatic"
         + "@Deprecated(\"Use protocol.$extName or revise the extension scope instead\", ReplaceWith(\"protocol.$extName\"))"
         block("fun create(lifetime: Lifetime, protocol: IProtocol): ${decl.name} ") {
@@ -680,7 +682,7 @@ open class Kotlin11Generator(
         fun IType.reader(): String = when (this) {
             is Enum -> "buffer.readEnum$setOrEmpty<${sanitizedName(decl)}>()"
             is InternedScalar -> "ctx.readInterned(buffer, \"${internKey.keyName}\") { _, _ -> ${itemType.reader()} }"
-            is PredefinedType -> "buffer.read${name.capitalize()}()"
+            is PredefinedType -> "buffer.read${name.capitalizeInvariant()}()"
             is Declaration ->
                 this.getSetting(Intrinsic)?.marshallerObjectFqn?.let {"$it.read(ctx, buffer)"}
                         ?: if (isSealed)
@@ -747,7 +749,7 @@ open class Kotlin11Generator(
         fun IType.writer(field: String) : String  = when (this) {
             is Enum -> "buffer.writeEnum$setOrEmpty($field)"
             is InternedScalar -> "ctx.writeInterned(buffer, $field, \"${internKey.keyName}\") { _, _, internedValue -> ${itemType.writer("internedValue")} }"
-            is PredefinedType -> "buffer.write${name.capitalize()}($field)"
+            is PredefinedType -> "buffer.write${name.capitalizeInvariant()}($field)"
             is Declaration ->
                 this.getSetting(Intrinsic)?.marshallerObjectFqn?.let {"$it.write(ctx,buffer, $field)"} ?:
                     if (isSealed) "${substitutedName(decl)}.write(ctx, buffer, $field)"
@@ -1129,14 +1131,14 @@ open class Kotlin11Generator(
 
     private fun PrettyPrinter.extensionTrait(decl: Ext) {
         val pointcut = decl.pointcut ?: return
-        val lowerName = decl.name.decapitalize()
+        val lowerName = decl.name.decapitalizeInvariant()
         val extName = decl.extName ?: lowerName
         + """val ${pointcut.sanitizedName(decl)}.$extName get() = getOrCreateExtension("$lowerName", ::${decl.name})"""
         println()
     }
 
     private fun PrettyPrinter.toplevelExtensionTrait(decl: Ext) {
-        val extName = decl.extName ?: decl.name.decapitalize()
+        val extName = decl.extName ?: decl.name.decapitalizeInvariant()
         + """val IProtocol.$extName get() = getOrCreateExtension(${decl.name}::class) { @Suppress("DEPRECATION") ${decl.name}.create(lifetime, this) }"""
         println()
     }

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/util/StringEx.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/util/StringEx.kt
@@ -1,0 +1,4 @@
+package com.jetbrains.rd.generator.nova.util
+
+fun String.decapitalizeInvariant() = replaceFirstChar { it.lowercase() }
+fun String.capitalizeInvariant() = replaceFirstChar { it.uppercase() }


### PR DESCRIPTION
`capitalize` and `decapitalize` were deprecated in Kotlin stdlib, probably because they are dependent on the current locale. Let's implement and use better invariant functions.

Aside from that, I found and decided to fix several random compiler warnings across rd-gen.