### PR TITLE
Leave advise priority section to submit ext created signal

### DIFF
--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/reactive/Signal.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/reactive/Signal.kt
@@ -5,6 +5,7 @@ import com.jetbrains.rd.util.*
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.lifetime.isAlive
 import com.jetbrains.rd.util.reflection.incrementCookie
+import com.jetbrains.rd.util.reflection.usingValue
 
 open class Signal<T> : ISignal<T> {
     companion object {
@@ -12,6 +13,7 @@ open class Signal<T> : ISignal<T> {
 
         private val isPriorityAdvise: Boolean get() = cookie.value > 0
         fun priorityAdviseSection(block:() -> Unit) = incrementCookie(cookie, TlsBoxed<Int>::value) { block() }
+        fun nonPriorityAdviseSection(block: () -> Unit) = cookie::value.usingValue(0) { block() }
 
         fun Void() = Signal<Unit>()
     }

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
@@ -8,10 +8,7 @@ import com.jetbrains.rd.util.Queue
 import com.jetbrains.rd.util.Sync
 import com.jetbrains.rd.util.collections.QueueImpl
 import com.jetbrains.rd.util.lifetime.Lifetime
-import com.jetbrains.rd.util.reactive.IScheduler
-import com.jetbrains.rd.util.reactive.Property
-import com.jetbrains.rd.util.reactive.flowInto
-import com.jetbrains.rd.util.reactive.whenTrue
+import com.jetbrains.rd.util.reactive.*
 import com.jetbrains.rd.util.string.printToString
 import com.jetbrains.rd.util.threading.SynchronousScheduler
 import com.jetbrains.rd.util.trace
@@ -55,7 +52,9 @@ abstract class RdExtBase : RdReactiveBase() {
                 }
 
                 val info = ExtCreationInfo(location, (parent as? RdBindableBase)?.containingExt?.rdid, serializationHash, this)
-                (parentProtocol as Protocol).submitExtCreated(info)
+                Signal.nonPriorityAdviseSection {
+                    (parentProtocol as Protocol).submitExtCreated(info)
+                }
             },
             {
                 extProtocol = null


### PR DESCRIPTION
`RdExtBase.init` is called under `Signal.priorityAdviseSection` cookie. This leads to calling `Protocol.submitExtCreated` and calling all extension listeners under this cookie. Thus any advise from an extension listener will be prioritized and called even before binding advise will trigger. As a result, all models will come to this advise yet unbound.
To fix this, we leave this priority section only to call `sumbitExtCreated`.