### PR TITLE
Fix findByRName for empty RName

### DIFF
--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdBindableBase.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdBindableBase.kt
@@ -116,6 +116,7 @@ abstract class RdBindableBase : IRdBindable, IPrintable {
     }
 
     open fun findByRName(rName: RName): RdBindableBase? {
+        if (rName == RName.Empty) return this
         val rootName = rName.getNonEmptyRoot()
         val child = bindableChildren
             .asSequence()

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdList.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdList.kt
@@ -72,6 +72,7 @@ class RdList<V : Any> private constructor(val valSzr: ISerializer<V>, private va
     }
 
     override fun findByRName(rName: RName): RdBindableBase? {
+        if (rName == RName.Empty) return this
         val rootName = rName.getNonEmptyRoot()
         val localName = rootName.localName
         if (!localName.startsWith('[') || !localName.endsWith(']'))

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdMap.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdMap.kt
@@ -87,6 +87,7 @@ class RdMap<K : Any, V : Any> private constructor(
     }
 
     override fun findByRName(rName: RName): RdBindableBase? {
+        if (rName == RName.Empty) return this
         val rootName = rName.getNonEmptyRoot()
         val localName = rootName.localName
         if (!localName.startsWith('[') || !localName.endsWith(']'))

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdProperty.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdProperty.kt
@@ -142,6 +142,7 @@ class RdOptionalProperty<T : Any>(valueSerializer: ISerializer<T> = Polymorphic(
     }
 
     override fun findByRName(rName: RName): RdBindableBase? {
+        if (rName == RName.Empty) return this
         val rootName = rName.getNonEmptyRoot()
         val localName = rootName.localName
         if (localName != "$")


### PR DESCRIPTION
In the case of `Model1 : Ext(Model2)` where `Model2 : Ext(SomeOtherModel)` there is a case when `findByRName` fails because the difference between containing ext and an actual parent is `RName.Empty`. `RdBindable.findByRName` should return itself in this case, but it doesn't. This pull request should fix this issue.