### PR TITLE
RdReflection updates

### DIFF
--- a/rd-net/RdFramework.Reflection/ProxyGenerator.cs
+++ b/rd-net/RdFramework.Reflection/ProxyGenerator.cs
@@ -122,18 +122,14 @@ namespace JetBrains.Rd.Reflection
       var rdExtConstructor = Members.RdExtConstructor;
       typebuilder.SetCustomAttribute(new CustomAttributeBuilder(rdExtConstructor, new object[]{ interfaceType }));
 
-      var memberNames = new HashSet<string>(StringComparer.Ordinal);
-      ImplementInterface(interfaceType, memberNames, typebuilder);
+      ImplementInterface(interfaceType, typebuilder);
       foreach (var baseInterface in interfaceType.GetInterfaces())
-        ImplementInterface(baseInterface, memberNames, typebuilder);
+        ImplementInterface(baseInterface, typebuilder);
 
-      void ImplementInterface(Type baseInterface, HashSet<string> hashSet, TypeBuilder typeBuilder)
+      void ImplementInterface(Type baseInterface, TypeBuilder typeBuilder)
       {
         foreach (var member in baseInterface.GetMembers(BindingFlags.Instance | BindingFlags.Public))
         {
-          if (!hashSet.Add(member.Name))
-            throw new ArgumentException($"Duplicate member name: {member.Name}. Method overloads are not supported.");
-
           ImplementMember(typeBuilder, member);
         }
       }
@@ -496,10 +492,7 @@ namespace JetBrains.Rd.Reflection
     }
 
 
-    public static string ProxyFieldName(MethodInfo method)
-    {
-      return method.Name + "_proxy";
-    }
+    public static string ProxyFieldName(MethodInfo method) => $"{method}_proxy";
 
     /// <summary>
     /// Return the expected list of names in BindableChildren collection for <see cref="RdRpcAttribute"/> interfaces

--- a/rd-net/RdFramework.Reflection/ProxyGeneratorCache.cs
+++ b/rd-net/RdFramework.Reflection/ProxyGeneratorCache.cs
@@ -12,10 +12,10 @@ namespace JetBrains.Rd.Reflection
     private readonly ConcurrentDictionary<Type, Type> myTypesCache = new ConcurrentDictionary<Type, Type>();
     private readonly ConcurrentDictionary<Type, SortedList<MethodInfo, DynamicMethod>> myAdaptersCache = new ConcurrentDictionary<Type, SortedList<MethodInfo, DynamicMethod>>();
 
-    private sealed class MethodNameComparer : IComparer<MethodInfo>
+    private sealed class TokenComparer : IComparer<MethodInfo>
     {
-      public static IComparer<MethodInfo> Instance { get; } = new MethodNameComparer();
-      public int Compare(MethodInfo x, MethodInfo y) => StringComparer.Ordinal.Compare(x?.Name, y?.Name);
+      public static IComparer<MethodInfo> Instance { get; } = new TokenComparer();
+      public int Compare(MethodInfo x, MethodInfo y) => (x?.MetadataToken ?? -1).CompareTo(y?.MetadataToken ?? -1);
     }
 
     public ProxyGeneratorCache(ProxyGenerator generator)
@@ -30,7 +30,7 @@ namespace JetBrains.Rd.Reflection
 
     public DynamicMethod CreateAdapter(Type selfType, MethodInfo method)
     {
-      var methods = myAdaptersCache.GetOrAdd(selfType, type => new SortedList<MethodInfo, DynamicMethod>(MethodNameComparer.Instance));
+      var methods = myAdaptersCache.GetOrAdd(selfType, type => new SortedList<MethodInfo, DynamicMethod>(TokenComparer.Instance));
       lock (methods)
       {
         if (methods.TryGetValue(method, out var adapter))

--- a/rd-net/RdFramework.Reflection/ReflectionSerializerVerifier.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionSerializerVerifier.cs
@@ -172,7 +172,7 @@ namespace JetBrains.Rd.Reflection
       return IsMemberType(typeInfo);
     }
 
-    private static bool IsMemberType(TypeInfo typeInfo)
+    public static bool IsMemberType(TypeInfo typeInfo)
     {
       if (typeInfo.IsGenericType)
       {

--- a/rd-net/RdFramework.Reflection/ReflectionSerializers.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionSerializers.cs
@@ -95,6 +95,8 @@ public class ReflectionSerializers : ISerializers, ISerializersSource
 
       if (!myStaticSerializers.TryGetValue(type, out var serializerPair))
       {
+        using var info = new FirstChanceExceptionInterceptor.ThreadLocalDebugInfo(type);
+
         myCatalog.AddType(type);
         
         BeforeCreation.Fire(type);
@@ -102,7 +104,6 @@ public class ReflectionSerializers : ISerializers, ISerializersSource
         if (myStaticSerializers.TryGetValue(type, out serializerPair))
           return serializerPair;
 
-        using var info = new FirstChanceExceptionInterceptor.ThreadLocalDebugInfo(type);
         if (Mode.IsAssertion) myCurrentSerializersChain.Enqueue(type);
         try
         {

--- a/rd-net/RdFramework.Reflection/ScalarSerializer.cs
+++ b/rd-net/RdFramework.Reflection/ScalarSerializer.cs
@@ -51,7 +51,12 @@ namespace JetBrains.Rd.Reflection
     {
       if (type == typeof(IntPtr))
       {
-        throw new ArgumentException("Platform-specific types cannot be serialized.");
+        throw new ArgumentException($"Unable to serialize {type.ToString(true)}. Platform-specific types cannot be serialized.");
+      }
+
+      if (typeof(Delegate).IsAssignableFrom(type))
+      {
+        throw new ArgumentException($"Unable to serialize {type.ToString(true)}. Delegates cannot be serialized.");
       }
 
       if (myBlackListChecker(type))

--- a/rd-net/RdFramework.Reflection/SerializerPair.cs
+++ b/rd-net/RdFramework.Reflection/SerializerPair.cs
@@ -2,26 +2,28 @@ using System;
 using System.Diagnostics;
 using System.Reflection;
 using JetBrains.Diagnostics;
-using JetBrains.Rd.Impl;
 using JetBrains.Serialization;
 using JetBrains.Util;
 using JetBrains.Util.Util;
 
 namespace JetBrains.Rd.Reflection;
 
-[DebuggerDisplay("T: {ElementType}, Polymorphic: {IsPolymorphic}")]
-public class SerializerPair
+[DebuggerDisplay("TR: {ReaderTypeString}, TW: {WriterTypeString}, Polymorphic: {IsPolymorphic}")]
+public sealed class SerializerPair
 {
   private readonly object myReader;
   private readonly object myWriter;
 
   public object Reader => myReader;
-
   public object Writer => myWriter;
 
   public bool IsPolymorphic { get; }
 
-  private string ElementType => ((Delegate)myReader).Method.ReturnParameter.ParameterType.ToString(false);
+  public Type ReaderType => myReader.GetType().GetGenericArguments()[0];
+  public Type WriterType => myWriter.GetType().GetGenericArguments()[0];
+
+  private string WriterTypeString => WriterType.ToString(false);
+  private string ReaderTypeString => ReaderType.ToString(false);
 
   public SerializerPair(object reader, object writer, bool isPolymorphic = false)
   {

--- a/rd-net/Test.RdFramework/Reflection/ProxyGeneratorAsyncCallsTest.cs
+++ b/rd-net/Test.RdFramework/Reflection/ProxyGeneratorAsyncCallsTest.cs
@@ -26,6 +26,8 @@ namespace Test.RdFramework.Reflection
     [RdExt]
     internal class AsyncCallsTest : RdExtReflectionBindableBase, IAsyncCallsTest
     {
+      public IViewableMap<short, IViewableSet<short>> SyncMoments { get; }
+
       public Task<string> GetStringAsync()
       {
         return Task.FromResult("result");
@@ -60,6 +62,8 @@ namespace Test.RdFramework.Reflection
     [RdRpc]
     public interface IAsyncCallsTest
     {
+      IViewableMap<short, IViewableSet<short>> SyncMoments { get; }
+
       Task<string> GetStringAsync();
       Task RunSomething();
 
@@ -204,6 +208,24 @@ namespace Test.RdFramework.Reflection
         await Wait();
         CollectionAssert.AreEqual(new[] {"123"}, m.History);
       });
+    }
+
+    [Test]
+    public async Task TestPrimitiveComposition()
+    {
+      await TestAsyncCalls(model =>
+      {
+        var vs = CFacade.Activator.Activate<IViewableSet<short>>();
+        vs.Add(123);
+        model.SyncMoments.Add(123, vs);
+        return Task.CompletedTask;
+      });
+
+/*#if NET35
+      // it seems like ExecuteSynchronously does not work in NET35
+      SpinWaitEx.SpinUntil(TimeSpan.FromSeconds(1), () => result != null);
+#endif*/
+      Assert.AreEqual(true, ((IAsyncCallsTest)myClient).SyncMoments.First().Value.Contains(123));
     }
 
     private async Task TestAsyncCalls(Func<IAsyncCallsTest, Task> run) => await TestTemplate<AsyncCallsTest, IAsyncCallsTest>(run);

--- a/rd-net/Test.RdFramework/Reflection/ProxyGeneratorComplexScalarsTest.cs
+++ b/rd-net/Test.RdFramework/Reflection/ProxyGeneratorComplexScalarsTest.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using JetBrains.Rd.Reflection;
+using NUnit.Framework;
+
+namespace Test.RdFramework.Reflection;
+
+[TestFixture]
+public class ProxyGeneratorComplexScalarsTest : RdReflectionTestBase
+{
+  [Test]
+  public void RunTest()
+  {
+    var proxy = SFacade.ActivateProxy<IArgsCalls>(TestLifetime, ServerProtocol);
+    var client = CFacade.Activator.ActivateBind<ArgsCalls>(TestLifetime, ClientProtocol);
+    CollectionAssert.AreEqual(client.Test(null), proxy.Test(null));
+  }
+
+  [RdRpc] public interface IArgsCalls
+  {
+    Guid[] Test(Guid[] input);
+  }
+
+  [RdExt] public class ArgsCalls : RdExtReflectionBindableBase, IArgsCalls
+  {
+    public Guid[] Test(Guid[] input) { return new Guid[1]; }
+  }
+}

--- a/rd-net/Test.RdFramework/Reflection/ProxyGeneratorOverloadsTest.cs
+++ b/rd-net/Test.RdFramework/Reflection/ProxyGeneratorOverloadsTest.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using JetBrains.Rd.Reflection;
+using NUnit.Framework;
+
+namespace Test.RdFramework.Reflection;
+
+[TestFixture]
+public class ProxyGeneratorOverloadsTest : RdReflectionTestBase
+{
+  [Test]
+  public void RunTest()
+  {
+    var client = CFacade.Activator.ActivateBind<Calls>(TestLifetime, ClientProtocol);
+    var proxy = SFacade.ActivateProxy<ICalls>(TestLifetime, ServerProtocol);
+    var g = Guid.NewGuid();
+    Assert.AreEqual(client.GetLangPreferences(g), proxy.GetLangPreferences(g));
+    CollectionAssert.AreEqual(client.GetLangPreferences(new Guid[10]), proxy.GetLangPreferences(new Guid[10]));
+  }
+
+  [RdRpc] public interface ICalls
+  {
+    Guid GetLangPreferences(Guid langServiceGuid);
+    Guid[] GetLangPreferences(Guid[] langServiceGuids);
+  }
+
+  [RdExt] public class Calls : RdExtReflectionBindableBase, ICalls
+  {
+    public Guid GetLangPreferences(Guid langServiceGuid) => Guid.Parse("3FB51DAC-EFAB-48D0-9535-D96B79E928B8");
+    public Guid[] GetLangPreferences(Guid[] langServiceGuids) => new[] {Guid.Parse("156F86F9-C90D-4D84-B3BB-4568BE3644D4")};
+  }
+}

--- a/rd-net/Test.RdFramework/Reflection/ProxyGeneratorPrimitiveCompositionTest.cs
+++ b/rd-net/Test.RdFramework/Reflection/ProxyGeneratorPrimitiveCompositionTest.cs
@@ -1,0 +1,51 @@
+﻿using System.Threading.Tasks;
+using JetBrains.Collections.Viewable;
+using JetBrains.Lifetimes;
+using JetBrains.Rd.Reflection;
+using NUnit.Framework;
+
+namespace Test.RdFramework.Reflection;
+
+/// <summary>
+/// Live models can be returned from calls. Provided lifetime in method's parameters should define the lifetime of
+/// "connection" of two sides.
+/// </summary>
+[TestFixture]
+public class ProxyGeneratorPrimitiveCompositionTest : ProxyGeneratorTestBase
+{
+  protected override bool IsAsync => true;
+
+  [RdRpc]
+  public interface ITest
+  {
+    IViewableList<IViewableList<string>> Multilist { get; }
+
+    // IViewableMap<short, IViewableSet<short>> SyncMoments { get; }
+  }
+
+  [RdExt]
+  public class Test : RdExtReflectionBindableBase, ITest
+  {
+    // public IViewableMap<short, IViewableSet<short>> SyncMoments { get; }
+    public IViewableList<IViewableList<string>> Multilist { get; }
+  }
+
+  [Test]
+  public async Task TestAsync()
+  {
+    await YieldToClient();
+    var client = CFacade.ActivateProxy<ITest>(TestLifetime, ClientProtocol);
+
+    await YieldToServer();
+    var server = SFacade.InitBind(new Test(), TestLifetime, ServerProtocol);
+    await Wait();
+
+    await YieldToClient();
+    var vs = CFacade.Activator.Activate<IViewableList<string>>();
+    vs.Add("123");
+    client.Multilist.Add(vs);
+    
+    await Wait();
+    //Assert.IsTrue(server.SyncMoments[123].Contains(123));
+  }
+}

--- a/rd-net/Test.RdFramework/Reflection/ReflectionSerializersPrimitivesTest.cs
+++ b/rd-net/Test.RdFramework/Reflection/ReflectionSerializersPrimitivesTest.cs
@@ -1,0 +1,18 @@
+﻿using JetBrains.Collections.Viewable;
+using JetBrains.Rd.Reflection;
+using NUnit.Framework;
+
+namespace Test.RdFramework.Reflection;
+
+[TestFixture]
+public class ReflectionSerializersPrimitivesTest
+{
+  [Test]
+  public void TestNonPolymorphicForPrimitive()
+  {
+    var s = new ReflectionSerializers(new SimpleTypesCatalog()).WithBasicCollectionSerializers();
+    var pair = s.GetOrRegisterSerializerPair(typeof(IViewableList<string>), true);
+
+    Assert.False(pair.IsPolymorphic);
+  }
+}


### PR DESCRIPTION
Changes in RdReflection, mainly related to R# OOP
  * RdReflection: support overloads
  * ReflectionSerializers: simplify member serializers, fix casting, tests
  * RdReflection: better tracing of serializers
  * Better asserts in ScalarSerializers
