### PR TITLE
Assertion review

### DIFF
--- a/rd-net/Lifetimes/Collections/CompactList.cs
+++ b/rd-net/Lifetimes/Collections/CompactList.cs
@@ -76,7 +76,7 @@ namespace JetBrains.Collections
         case 0: return -1;
         case 1: return comparer.Equals(mySingleValue, item) ? 0 : -1;          
         default:
-          Assertion.Assert(myMultipleValues != null);
+          Assertion.AssertNotNull(myMultipleValues);
           for (var i = myMultipleValues.Count - 1; i >= 0; i--)
           {
             if (comparer.Equals(myMultipleValues[i], item)) return i;
@@ -99,13 +99,13 @@ namespace JetBrains.Collections
           return true;
           
         case 2:
-          Assertion.Assert(myMultipleValues != null);
+          Assertion.AssertNotNull(myMultipleValues);
           mySingleValue = myMultipleValues[1-index];
           myMultipleValues = SingleMarker;
           return true;
             
         default:
-          Assertion.Assert(myMultipleValues != null);
+          Assertion.AssertNotNull(myMultipleValues);
           myMultipleValues.RemoveAt(index);
           return true;
       }      

--- a/rd-net/Lifetimes/Collections/CompactList.cs
+++ b/rd-net/Lifetimes/Collections/CompactList.cs
@@ -58,8 +58,7 @@ namespace JetBrains.Collections
           mySingleValue = default(T);
           break;
         default:
-          Assertion.Assert(myMultipleValues != null, "myMultipleValues != null");
-          myMultipleValues.Add(item);
+          myMultipleValues.NotNull().Add(item);
           break;
       }
     }
@@ -77,7 +76,7 @@ namespace JetBrains.Collections
         case 0: return -1;
         case 1: return comparer.Equals(mySingleValue, item) ? 0 : -1;          
         default:
-          Assertion.Assert(myMultipleValues != null, "myMultipleValues != null");
+          Assertion.Assert(myMultipleValues != null);
           for (var i = myMultipleValues.Count - 1; i >= 0; i--)
           {
             if (comparer.Equals(myMultipleValues[i], item)) return i;
@@ -88,7 +87,8 @@ namespace JetBrains.Collections
 
     public bool RemoveAt(int index)
     {
-      Assertion.Assert(index >= 0, "{0} >= 0", index);
+      if (Mode.IsAssertion)
+        Assertion.Assert(index >= 0, "{0} >= 0", index);
       if (index >= Count) return false;
       
       switch (Count)
@@ -99,13 +99,13 @@ namespace JetBrains.Collections
           return true;
           
         case 2:
-          Assertion.Assert(myMultipleValues != null, "myMultipleValues != null");
+          Assertion.Assert(myMultipleValues != null);
           mySingleValue = myMultipleValues[1-index];
           myMultipleValues = SingleMarker;
           return true;
             
         default:
-          Assertion.Assert(myMultipleValues != null, "myMultipleValues != null");
+          Assertion.Assert(myMultipleValues != null);
           myMultipleValues.RemoveAt(index);
           return true;
       }      
@@ -120,8 +120,7 @@ namespace JetBrains.Collections
         case 1:
           return new [] {mySingleValue};
         default:
-          Assertion.Assert(myMultipleValues != null, "myMultipleValues != null");
-          return myMultipleValues.ToArray();
+          return myMultipleValues.NotNull().ToArray();
       }
     }
     

--- a/rd-net/Lifetimes/Collections/JetPriorityQueue.cs
+++ b/rd-net/Lifetimes/Collections/JetPriorityQueue.cs
@@ -153,13 +153,13 @@ namespace JetBrains.Collections
       if (cmp1 != 0) return cmp1;
 
       var cmp2 = myVersions[left] - myVersions[right];
-      Assertion.Assert(cmp2 != 0, "Equal versions for indices {0}, {1}, version = {2}", left, right, myVersions[left]);
+      if (Mode.IsAssertion) Assertion.Assert(cmp2 != 0, "Equal versions for indices {0}, {1}, version = {2}", left, right, myVersions[left]);
       return cmp2 > 0 ? 1 : -1;
     }
     
     private void HeapDown(int idx)
     {
-      Assertion.Assert(idx >= 1 && idx < myStorage.Count, "Index {0} is not in range [1, {1})", idx, myStorage.Count);
+      if (Mode.IsAssertion) Assertion.Assert(idx >= 1 && idx < myStorage.Count, "Index {0} is not in range [1, {1})", idx, myStorage.Count);
 
       int n = myStorage.Count;
       int left = (idx << 1) | 0;
@@ -181,7 +181,7 @@ namespace JetBrains.Collections
 
     private void HeapUp(int idx)
     {      
-      Assertion.Assert(idx >= 1 && idx < myStorage.Count, "Index {0} is not in range [1, {1})", idx, myStorage.Count);
+      if (Mode.IsAssertion) Assertion.Assert(idx >= 1 && idx < myStorage.Count, "Index {0} is not in range [1, {1})", idx, myStorage.Count);
       
       while (idx > 1 && Compare(idx, idx >> 1) < 0)
       {

--- a/rd-net/Lifetimes/Diagnostics/Log.cs
+++ b/rd-net/Lifetimes/Diagnostics/Log.cs
@@ -250,7 +250,7 @@ namespace JetBrains.Diagnostics
     /// <exception cref="IOException"></exception>
     public static TextWriterLogFactory CreateFileLogFactory(Lifetime lifetime, string path, bool append = false, LoggingLevel enabledLevel = LoggingLevel.VERBOSE)
     {      
-      Assertion.Assert(lifetime.IsAlive, "lifetime.IsTerminated");
+      Assertion.Require(lifetime.IsAlive, "lifetime.IsTerminated");
       
       var directory = Path.GetDirectoryName(path);
       if (directory == null)

--- a/rd-net/Lifetimes/Diagnostics/StringInterpolation/JetConditionalInterpolatedStringHandler.cs
+++ b/rd-net/Lifetimes/Diagnostics/StringInterpolation/JetConditionalInterpolatedStringHandler.cs
@@ -24,71 +24,71 @@ public ref struct JetConditionalInterpolatedStringHandler
   
   public string ToStringAndClear()
   {
-    Assertion.Assert(IsEnabled);
+    if (Mode.IsAssertion) Assertion.Assert(IsEnabled);
     return myHandler.ToStringAndClear();
   }
 
   [MethodImpl(MethodImplOptions.AggressiveInlining)]
   public void AppendLiteral(string value)
   {
-    Assertion.Assert(IsEnabled);
+    if (Mode.IsAssertion) Assertion.Assert(IsEnabled);
     myHandler.AppendLiteral(value);
   }
 
   public void AppendFormatted<T>(T value)
   {
-    Assertion.Assert(IsEnabled);
+    if (Mode.IsAssertion) Assertion.Assert(IsEnabled);
     myHandler.AppendFormatted(value);
   }
 
   public void AppendFormatted<T>(T value, string? format)
   {
-    Assertion.Assert(IsEnabled);
+    if (Mode.IsAssertion) Assertion.Assert(IsEnabled);
     myHandler.AppendFormatted(value, format);
   }
 
   public void AppendFormatted<T>(T value, int alignment)
   {
-    Assertion.Assert(IsEnabled);
+    if (Mode.IsAssertion) Assertion.Assert(IsEnabled);
     myHandler.AppendFormatted(value, alignment);
   }
 
   public void AppendFormatted<T>(T value, int alignment, string? format)
   {
-    Assertion.Assert(IsEnabled);
+    if (Mode.IsAssertion) Assertion.Assert(IsEnabled);
     myHandler.AppendFormatted(value, alignment, format);
   }
 
   // Commented out, because the compiler will require System.Memory for a project that uses string interpolation 
   // public void AppendFormatted(ReadOnlySpan<char> value)
   // {
-  //   Assertion.Assert(IsEnabled);
+  //   if (Mode.IsAssertion) Assertion.Assert(IsEnabled);
   //   myHandler.AppendFormatted(value);
   // }
   //
   // public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null)
   // {
-  //   Assertion.Assert(IsEnabled);
+  //   if (Mode.IsAssertion) Assertion.Assert(IsEnabled);
   //   myHandler.AppendFormatted(value, alignment, format);
   // }
 
   public void AppendFormatted(string? value)
   {
-    Assertion.Assert(IsEnabled);
+    if (Mode.IsAssertion) Assertion.Assert(IsEnabled);
     myHandler.AppendFormatted(value);
   }
 
   // ReSharper disable once MethodOverloadWithOptionalParameter
   public void AppendFormatted(string? value, int alignment = 0, string? format = null)
   {
-    Assertion.Assert(IsEnabled);
+    if (Mode.IsAssertion) Assertion.Assert(IsEnabled);
     myHandler.AppendFormatted(value, alignment, format);
   }
 
   [MethodImpl(MethodImplOptions.AggressiveInlining)]
   public void AppendFormatted(object? value, int alignment = 0, string? format = null)
   {
-    Assertion.Assert(IsEnabled);
+    if (Mode.IsAssertion) Assertion.Assert(IsEnabled);
     myHandler.AppendFormatted(value, alignment, format);
   }
 }

--- a/rd-net/Lifetimes/Lifetimes/Lifetime.cs
+++ b/rd-net/Lifetimes/Lifetimes/Lifetime.cs
@@ -734,7 +734,7 @@ namespace JetBrains.Lifetimes
     public static LifetimeDefinition DefineIntersection(params Lifetime[] lifetimes)
     {
       if (lifetimes == null) throw new ArgumentNullException(nameof(lifetimes));
-      Assertion.Assert(lifetimes.Length > 0, "One or more parameters must be passed");
+      if (Mode.IsAssertion) Assertion.Assert(lifetimes.Length > 0, "One or more parameters must be passed");
 
       var res = new LifetimeDefinition();
       var minTimeoutKind = (LifetimeTerminationTimeoutKind)int.MaxValue;

--- a/rd-net/Lifetimes/Lifetimes/LifetimeDefinition.cs
+++ b/rd-net/Lifetimes/Lifetimes/LifetimeDefinition.cs
@@ -503,8 +503,8 @@ namespace JetBrains.Lifetimes
       if (Mode.IsAssertion) Assertion.Assert(ourMutexSlice[myState] == false, "{0}: mutex must be released in this point", this);
       //no one can take mutex after this point
 
-      var resources = myResources;
-      if (Mode.IsAssertion) Assertion.Assert(resources != null, "{0}: `resources` can't be null on destructuring stage", this);
+      var resources = myResources!;
+      if (Mode.IsAssertion) Assertion.AssertNotNull(resources, "{0}: `resources` can't be null on destructuring stage", this);
       
       for (var i = myResCount - 1; i >= 0; i--)
       {

--- a/rd-net/Lifetimes/Lifetimes/LifetimeDefinition.cs
+++ b/rd-net/Lifetimes/Lifetimes/LifetimeDefinition.cs
@@ -588,7 +588,7 @@ namespace JetBrains.Lifetimes
           return false;
 
         var resources = myResources;
-        if (Mode.IsAssertion) Assertion.Assert(resources != null, "{0}: `resources` can't be null under mutex while status < Terminating", this);
+        if (Mode.IsAssertion) Assertion.AssertNotNull(resources, "{0}: `resources` can't be null under mutex while status < Terminating", this);
         
         if (myResCount == resources!.Length)
         {

--- a/rd-net/Lifetimes/Lifetimes/LifetimedList.cs
+++ b/rd-net/Lifetimes/Lifetimes/LifetimedList.cs
@@ -252,7 +252,7 @@ namespace JetBrains.Lifetimes
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     private void ReleaseLock(BoolBitSlice slice)
     {
-      Assertion.Assert(slice[myState], "Must be under mutex");
+      if (Mode.IsAssertion) Assertion.Assert(slice[myState], "Must be under mutex");
       slice.InterlockedUpdate(ref myState, false);
     }
 

--- a/rd-net/Lifetimes/Lifetimes/OuterLifetime.cs
+++ b/rd-net/Lifetimes/Lifetimes/OuterLifetime.cs
@@ -132,7 +132,7 @@ namespace JetBrains.Lifetimes
     [PublicAPI]
     public static LifetimeDefinition DefineIntersection(params OuterLifetime[] lifetimes)
     {
-      Assertion.Assert(lifetimes.Length > 0, "One or more parameters must be passed");
+      if (Mode.IsAssertion) Assertion.Assert(lifetimes.Length > 0, "One or more parameters must be passed");
       var res = new LifetimeDefinition();
       var minTimeoutKind = (LifetimeTerminationTimeoutKind)int.MaxValue;
       foreach (var lf in lifetimes)

--- a/rd-net/Lifetimes/Serialization/NativeMemoryPool.cs
+++ b/rd-net/Lifetimes/Serialization/NativeMemoryPool.cs
@@ -233,7 +233,7 @@ namespace JetBrains.Serialization
 
       public ThreadMemoryHolder()
       {
-        Assertion.Assert(myPtr == IntPtr.Zero, "myPtr == IntPtr.Zero");
+        if (Mode.IsAssertion) Assertion.Assert(myPtr == IntPtr.Zero);
         myPtr = AllocateMemory(AllocSize);
         Length = AllocSize;
       }

--- a/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
@@ -208,7 +208,7 @@ namespace JetBrains.Serialization
         else
         {
           var cookie = NativeMemoryPool.ReserveMiss();
-          Assertion.Assert(cookie.IsValid, "memoryCookie.IsValid");
+          if (Mode.IsAssertion) Assertion.Assert(cookie.IsValid, "memoryCookie.IsValid");
           myMemory = cookie.myHolder;
           if (cookie.CausedAllocation)
           {
@@ -309,8 +309,8 @@ namespace JetBrains.Serialization
         LogLog.Verbose(LogCategory, "Realloc UnsafeWriter, current: {0:N0} bytes, new: {1:N0}", myCurrentAllocSize, reallocSize);
         if (myStartPtr != null) //already terminated
         {
-          Assertion.Assert(myMemory != null, "myMemory != null");
-          myStartPtr = (byte*) myMemory.Realloc(reallocSize);
+          if (Mode.IsAssertion) Assertion.Assert(myMemory != null);
+          myStartPtr = (byte*) myMemory!.Realloc(reallocSize);
           myPtr = myStartPtr + myCount;
           myCurrentAllocSize = reallocSize;
           myCount = newCount;
@@ -453,7 +453,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(DateTime value)
     {
-      Assertion.Assert(value.Kind != DateTimeKind.Local, "Use UTC time");
+      if (Mode.IsAssertion) Assertion.Assert(value.Kind != DateTimeKind.Local, "Use UTC time");
       Write(value.Ticks);
     }
     

--- a/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
@@ -309,8 +309,8 @@ namespace JetBrains.Serialization
         LogLog.Verbose(LogCategory, "Realloc UnsafeWriter, current: {0:N0} bytes, new: {1:N0}", myCurrentAllocSize, reallocSize);
         if (myStartPtr != null) //already terminated
         {
-          if (Mode.IsAssertion) Assertion.Assert(myMemory != null);
-          myStartPtr = (byte*) myMemory!.Realloc(reallocSize);
+          Assertion.AssertNotNull(myMemory);
+          myStartPtr = (byte*) myMemory.Realloc(reallocSize);
           myPtr = myStartPtr + myCount;
           myCurrentAllocSize = reallocSize;
           myCount = newCount;

--- a/rd-net/Lifetimes/Threading/Actor.cs
+++ b/rd-net/Lifetimes/Threading/Actor.cs
@@ -99,7 +99,7 @@ namespace JetBrains.Threading
           }
           finally
           {
-            Assertion.Assert(IsEmpty, "Not empty: sent items: {0}, processed items: {1}", myChannel.TotalMessagesSent, myTotalMessagesProcessed);
+            Assertion.Require(IsEmpty, "Not empty: sent items: {0}, processed items: {1}", myChannel.TotalMessagesSent, myTotalMessagesProcessed);
           }
         }, lifetime, TaskCreationOptions.None, scheduler ?? TaskScheduler.Default);
     }

--- a/rd-net/Lifetimes/Threading/ByteBufferAsyncProcessor.cs
+++ b/rd-net/Lifetimes/Threading/ByteBufferAsyncProcessor.cs
@@ -49,7 +49,7 @@ namespace JetBrains.Threading
       {
         if (Ptr == 0)
         {
-          Assertion.Assert(SeqN == long.MaxValue, "SeqN == long.MaxValue, but: {0}", SeqN);
+          if (Mode.IsAssertion) Assertion.Assert(SeqN == long.MaxValue, "SeqN == long.MaxValue, but: {0}", SeqN);
           return true;
         }
         
@@ -238,7 +238,7 @@ namespace JetBrains.Threading
 
     public void ReprocessUnacknowledged()
     {
-      Assertion.Require(Thread.CurrentThread != myAsyncProcessingThread, "Thread.CurrentThread != myAsyncProcessingThread");
+      Assertion.Require(Thread.CurrentThread != myAsyncProcessingThread);
       lock (myLock)
       {
         while (myProcessing) 
@@ -293,8 +293,8 @@ namespace JetBrains.Threading
 
           ShrinkConditionally(myChunkToProcess);
 
-          Assertion.Assert(myChunkToProcess.Ptr > 0, "chunkToProcess.Ptr > 0");
-          Assertion.Assert(myChunkToFill != myChunkToProcess && myChunkToFill.IsNotProcessed, "myChunkToFill != chunkToProcess && myChunkToFill.IsNotProcessed");
+          if (Mode.IsAssertion) Assertion.Assert(myChunkToProcess.Ptr > 0, "chunkToProcess.Ptr > 0");
+          if (Mode.IsAssertion) Assertion.Assert(myChunkToFill != myChunkToProcess && myChunkToFill.IsNotProcessed, "myChunkToFill != chunkToProcess && myChunkToFill.IsNotProcessed");
 
           myProcessing = true;
         }
@@ -368,7 +368,7 @@ namespace JetBrains.Threading
     
     public void Clear()
     {
-      Assertion.Require(Thread.CurrentThread != myAsyncProcessingThread, "Thread.CurrentThread != myAsyncProcessingThread");
+      Assertion.Require(Thread.CurrentThread != myAsyncProcessingThread);
 
       lock (myLock)
       {
@@ -487,7 +487,7 @@ namespace JetBrains.Threading
         var ptr = 0;
         while (ptr < count)
         {
-          Assertion.Assert(myChunkToFill.IsNotProcessed, "myChunkToFill.IsNotProcessed");
+          if (Mode.IsAssertion) Assertion.Assert(myChunkToFill.IsNotProcessed);
           var rest = count - ptr;
           var available = ChunkSize - myChunkToFill.Ptr;
           if (available > 0)
@@ -523,7 +523,7 @@ namespace JetBrains.Threading
 
     private void ShrinkConditionally(Chunk upTo) //under lock
     {
-      Assertion.Assert(myChunkToFill != upTo, "myFreeChunk != upTo");
+      if (Mode.IsAssertion) Assertion.Assert(myChunkToFill != upTo, "myFreeChunk != upTo");
       
       var now = Environment.TickCount;
       if (now - myLastShrinkOrGrowTimeMs <= ShrinkIntervalMs && /*overflow*/now - myLastShrinkOrGrowTimeMs >= 0 ) return;

--- a/rd-net/Lifetimes/Util/BitSlice.cs
+++ b/rd-net/Lifetimes/Util/BitSlice.cs
@@ -41,8 +41,8 @@ namespace JetBrains.Util.Util
         : type == typeof(long) ? 64
         : 0;
       
-      Assertion.Assert(maxBit > 0, "Unsupported host type: {0}", type);      
-      Assertion.Assert(HiBit <= maxBit, "{0} doesn't fit into host type {1}; must be inside [0, {2}]", this, type, maxBit);
+      if (Mode.IsAssertion) Assertion.Assert(maxBit > 0, "Unsupported host type: {0}", type);      
+      if (Mode.IsAssertion) Assertion.Assert(HiBit <= maxBit, "{0} doesn't fit into host type {1}; must be inside [0, {2}]", this, type, maxBit);
     }
 
     [AssertionMethod]
@@ -50,8 +50,8 @@ namespace JetBrains.Util.Util
     {
       if (!Mode.IsAssertion) return;
 
-      Assertion.Assert(value >= 0, "[{0}] must be >= 0; actual: {1}", nameof(value), value);
-      Assertion.Assert(value <= Mask, "[{0}] must be <= {1} to fit {2}; actual: {3}", nameof(value), Mask, this, value);
+      if (Mode.IsAssertion) Assertion.Assert(value >= 0, "[{0}] must be >= 0; actual: {1}", nameof(value), value);
+      if (Mode.IsAssertion) Assertion.Assert(value <= Mask, "[{0}] must be <= {1} to fit {2}; actual: {3}", nameof(value), Mask, this, value);
     }
     
     #endregion

--- a/rd-net/Lifetimes/Util/LocalStopwatch.cs
+++ b/rd-net/Lifetimes/Util/LocalStopwatch.cs
@@ -53,8 +53,7 @@ namespace JetBrains.Util
 
     private void AssertTimeStamp()
     {
-      if (!Mode.IsAssertion) return;
-      Assertion.Assert(myStartTimeStamp != 0, $"{nameof(LocalStopwatch)} must be created using `{nameof(StartNew)}` method");
+      if (Mode.IsAssertion) Assertion.Assert(myStartTimeStamp != 0, $"{nameof(LocalStopwatch)} must be created using `{nameof(StartNew)}` method");
     }
   }
 }

--- a/rd-net/RdFramework.Reflection/ProxyGenerator.cs
+++ b/rd-net/RdFramework.Reflection/ProxyGenerator.cs
@@ -153,8 +153,8 @@ namespace JetBrains.Rd.Reflection
     /// <returns></returns>
     public DynamicMethod CreateAdapter(Type selfType, MethodInfo method)
     {
-      Assertion.Assert(!method.IsGenericMethod, "generics are not supported");
-      Assertion.Assert(!method.IsStatic, "only instance methods are supported");
+      Assertion.Require(!method.IsGenericMethod, "generics are not supported");
+      Assertion.Require(!method.IsStatic, "only instance methods are supported");
 
       // var type = ModuleBuilder.DefineType(selfType.FullName + "_adapter",
       //   TypeAttributes.Public & TypeAttributes.Sealed & TypeAttributes.Abstract & TypeAttributes.BeforeFieldInit);
@@ -373,8 +373,8 @@ namespace JetBrains.Rd.Reflection
       var requestType = GetRequstType(method)[0];
       var responseType = GetResponseType(method, true);
 
-      Assertion.Assert(!requestType.IsByRef, "ByRef is not supported. ({0}.{1})", typebuilder, requestType);
-      Assertion.Assert(!responseType.IsByRef, "ByRef is not supported. ({0}.{1})", typebuilder, responseType);
+      Assertion.Require(!requestType.IsByRef, "ByRef is not supported. ({0}.{1})", typebuilder, requestType);
+      Assertion.Require(!responseType.IsByRef, "ByRef is not supported. ({0}.{1})", typebuilder, responseType);
 
       var fieldType = typeof(IRdCall<,>).MakeGenericType(requestType, responseType);
       var field = typebuilder.DefineField(ProxyFieldName(method), fieldType , FieldAttributes.Public);
@@ -403,7 +403,7 @@ namespace JetBrains.Rd.Reflection
       {
         if (parameters[i].ParameterType == typeof(Lifetime))
         {
-          Assertion.Assert(lifetimeArgument == -1, "Only one lifetime parameter is allowed");
+          Assertion.Require(lifetimeArgument == -1, "Only one lifetime parameter is allowed");
           lifetimeArgument = i;
         }
       }
@@ -503,7 +503,7 @@ namespace JetBrains.Rd.Reflection
       foreach (var fieldName in GetBindableFieldsNames(i))
         yield return fieldName;
 
-      Assertion.Assert(rpcInterface.IsInterface, "Interface is expected");
+      Assertion.Require(rpcInterface.IsInterface, "Interface is expected");
       foreach (var member in rpcInterface.GetMembers(BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.Public))
       {
         switch (member.MemberType)

--- a/rd-net/RdFramework.Reflection/ReflectionRdActivator.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionRdActivator.cs
@@ -133,7 +133,7 @@ namespace JetBrains.Rd.Reflection
     {
       if (Mode.IsAssertion)
       {
-        Assertion.Assert(myCurrentActivationChain != null);
+        Assertion.AssertNotNull(myCurrentActivationChain);
         Assertion.Assert(!myCurrentActivationChain.Contains(type),
             $"Unable to activate {type.FullName}: circular dependency detected: {string.Join(" -> ", myCurrentActivationChain.Select(t => t.FullName).ToArray())}");
         myCurrentActivationChain.Enqueue(type);
@@ -280,7 +280,7 @@ namespace JetBrains.Rd.Reflection
 
     private void EnsureFakeTupleRegistered(Type type)
     {
-      Assertion.Assert(myTypesCatalog != null, "myPolymorphicTypesCatalog required to be NotNull when RPC is used");
+      Assertion.AssertNotNull(myTypesCatalog, "myPolymorphicTypesCatalog required to be NotNull when RPC is used");
       myTypesCatalog.AddType(type);
     }
 

--- a/rd-net/RdFramework.Reflection/ReflectionRdActivator.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionRdActivator.cs
@@ -133,7 +133,7 @@ namespace JetBrains.Rd.Reflection
     {
       if (Mode.IsAssertion)
       {
-        Assertion.Assert(myCurrentActivationChain != null, "myCurrentActivationChain != null");
+        Assertion.Assert(myCurrentActivationChain != null);
         Assertion.Assert(!myCurrentActivationChain.Contains(type),
             $"Unable to activate {type.FullName}: circular dependency detected: {string.Join(" -> ", myCurrentActivationChain.Select(t => t.FullName).ToArray())}");
         myCurrentActivationChain.Enqueue(type);
@@ -142,7 +142,7 @@ namespace JetBrains.Rd.Reflection
       var typeInfo = type.GetTypeInfo();
       ReflectionSerializerVerifier.AssertEitherExtModelAttribute(typeInfo);
       var implementingType = ReflectionSerializerVerifier.GetImplementingType(typeInfo);
-      Assertion.Assert(typeof(RdBindableBase).GetTypeInfo().IsAssignableFrom(implementingType),
+      if (Mode.IsAssertion) Assertion.Assert(typeof(RdBindableBase).GetTypeInfo().IsAssignableFrom(implementingType),
         $"Unable to activate {type.FullName}: type should be {nameof(RdBindableBase)}");
 
       object instance;
@@ -194,7 +194,7 @@ namespace JetBrains.Rd.Reflection
         else
         {
           var implementingType = ReflectionSerializerVerifier.GetImplementingType(ReflectionUtil.GetReturnType(mi).GetTypeInfo());
-          Assertion.Assert(currentValue.GetType() == implementingType, 
+          if (Mode.IsAssertion) Assertion.Assert(currentValue.GetType() == implementingType, 
             "Bindable field {0} was initialized with incompatible type. Expected type {1}, actual {2}", 
             mi, 
             implementingType.ToString(true), 
@@ -222,8 +222,7 @@ namespace JetBrains.Rd.Reflection
           var responseNonTaskType = ProxyGenerator.GetResponseType(interfaceMethod, unwrapTask: true);
           var responseType = ProxyGenerator.GetResponseType(interfaceMethod, unwrapTask: false);
           var endPointType = typeof(RdCall<,>).MakeGenericType(requestType, responseNonTaskType);
-          var endpoint = ActivateGenericMember(name, endPointType.GetTypeInfo());
-          Assertion.Assert(endpoint != null, "endpoint != null");
+          var endpoint = ActivateGenericMember(name, endPointType.GetTypeInfo()).NotNull();
           SetAsync(endpoint);
           if (endpoint is RdReactiveBase reactiveBase)
             reactiveBase.ValueCanBeNull = true;

--- a/rd-net/RdFramework.Reflection/ReflectionSerializerVerifier.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionSerializerVerifier.cs
@@ -211,12 +211,17 @@ namespace JetBrains.Rd.Reflection
 
     public static void AssertEitherExtModelAttribute(TypeInfo type)
     {
-      /*Assertion.Assert((HasRdExtAttribute(type) || HasRdModelAttribute(type)), $"Invalid RdModel: expected to have either {nameof(RdModelAttribute)} or {nameof(RdExtAttribute)} ({type.ToString(true)}).");*/
-      Assertion.Assert(HasRdExtAttribute(type) ^ HasRdModelAttribute(type), $"Invalid RdModel {type.ToString(true)}: expected to have only one of {nameof(RdModelAttribute)} or {nameof(RdExtAttribute)}.");
+      if (Mode.IsAssertion)
+      {
+        Assertion.Assert(HasRdExtAttribute(type) ^ HasRdModelAttribute(type), $"Invalid RdModel {type.ToString(true)}: expected to have only one of {nameof(RdModelAttribute)} or {nameof(RdExtAttribute)}.");
+      }
     }
 
     public static void AssertRoot(TypeInfo type)
     {
+      if (!Mode.IsAssertion)
+        return;
+
       if (HasRdExtAttribute(type))
       {
         AssertEitherExtModelAttribute(type);
@@ -263,6 +268,9 @@ namespace JetBrains.Rd.Reflection
 
     public static void AssertValidRdExt(TypeInfo type)
     {
+      if (!Mode.IsAssertion)
+        return;
+
       var isRdModel = HasRdExtAttribute(type);
       Assertion.Assert(isRdModel, $"Error in {type.ToString(true)} model: no {nameof(RdExtAttribute)} attribute specified");
       Assertion.Assert(!type.IsValueType, $"Error in {type.ToString(true)} model: can't be ValueType");
@@ -305,6 +313,9 @@ namespace JetBrains.Rd.Reflection
 
     public static void AssertMemberDeclaration(MemberInfo member)
     {
+      if (!Mode.IsAssertion)
+        return;
+
       var isMember = IsMemberDeclaration(member);
       Assertion.Assert(isMember,
         $"Error in {member.DeclaringType?.ToString(true)}: model: member {member.Name} " +
@@ -314,6 +325,9 @@ namespace JetBrains.Rd.Reflection
 
     public static void AssertValidRdModel(TypeInfo type)
     {
+      if (!Mode.IsAssertion)
+        return;
+
       var isDataModel = HasRdModelAttribute(type);
       Assertion.Assert(isDataModel, $"Error in {type.ToString(true)} model: no {nameof(RdModelAttribute)} attribute specified");
       Assertion.Assert(typeof(RdReflectionBindableBase).GetTypeInfo().IsAssignableFrom(type.AsType()), $"Error in {type.ToString(true)} model: should be inherited from {nameof(RdReflectionBindableBase)}");
@@ -337,6 +351,9 @@ namespace JetBrains.Rd.Reflection
 
     private static void AssertValidScalar(TypeInfo type)
     {
+      if (!Mode.IsAssertion)
+        return;
+
       if (HasRdModelAttribute(type) || HasRdExtAttribute(type))
       {
         Assertion.Fail($"Scalar type {type.ToString(true)} is invalid. {nameof(RdExtAttribute)} and {nameof(RdModelAttribute)} are not applicable to scalars since they can't be bound to the protocol.");
@@ -354,6 +371,9 @@ namespace JetBrains.Rd.Reflection
 
     public static void AssertDataMemberDeclaration(MemberInfo member)
     {
+      if (!Mode.IsAssertion)
+        return;
+
       var isMember = IsModelMemberDeclaration(member);
       Assertion.Assert(isMember,
         $"Error in {member.DeclaringType?.ToString(true)}: data model: member {member.Name} " +

--- a/rd-net/RdFramework.Reflection/ReflectionSerializers.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionSerializers.cs
@@ -120,7 +120,7 @@ public class ReflectionSerializers : ISerializers, ISerializersSource
           if (isRdType)
           {
             var intrinsic = Intrinsic.TryGetIntrinsicSerializer(implementingType, t => GetOrRegisterSerializerPair(t, true));
-            Assertion.Assert(intrinsic != null, "Unable to get intrinsic serializer for type {0}, thought it should be implemented for Rd-types.", type);
+            Assertion.AssertNotNull(intrinsic, "Unable to get intrinsic serializer for type {0}, thought it should be implemented for Rd-types.", type);
             var pair = SerializerReflectionUtil.ConvertPair(intrinsic, type);
 
             myStaticSerializers[type] = pair;
@@ -134,8 +134,7 @@ public class ReflectionSerializers : ISerializers, ISerializersSource
             var intrinsic = Intrinsic.TryGetIntrinsicSerializer(
               type.GetTypeInfo(),
               t => GetOrRegisterSerializerPair(t, true));
-            Assertion.Assert(intrinsic != null,
-              "Unable to get intrinsic serializer for type {0}, thought API detect the presense of it. Probably it was only partially implemented",
+            Assertion.AssertNotNull(intrinsic, "Unable to get intrinsic serializer for type {0}, thought API detect the presense of it. Probably it was only partially implemented",
               type);
             myStaticSerializers[type] = intrinsic;
           }
@@ -176,7 +175,7 @@ public class ReflectionSerializers : ISerializers, ISerializersSource
     var pair = myScalars.CreateSerializer(serializerType, this);
     if (pair == null)
       Assertion.Fail($"Unable to Create serializer for scalar type {serializerType.ToString(true)}");
-    else
+    else if (Mode.IsAssertion)
       Assertion.Assert(!pair.IsPolymorphic, "Polymorphic serializer can't be stored in staticSerializers");
 
     return pair;
@@ -187,7 +186,7 @@ public class ReflectionSerializers : ISerializers, ISerializersSource
   /// </summary>
   private void RegisterModelSerializer<T>()
   {
-    Assertion.Assert(!ReflectionSerializerVerifier.IsScalar(typeof(T)), "Type {0} should be either RdModel or RdExt.", typeof(T));
+    if (Mode.IsAssertion) Assertion.Assert(!ReflectionSerializerVerifier.IsScalar(typeof(T)), "Type {0} should be either RdModel or RdExt.", typeof(T));
 
     var typeInfo = typeof(T).GetTypeInfo();
     ReflectionSerializerVerifier.AssertRoot(typeInfo);
@@ -310,9 +309,9 @@ public class ReflectionSerializers : ISerializers, ISerializersSource
     {
       if (SerializerReflectionUtil.CanBePolymorphic(type))
       {
-        Assertion.Assert(!myStaticSerializers.ContainsKey(type),
+        if (Mode.IsAssertion) Assertion.Assert(!myStaticSerializers.ContainsKey(type),
           $"Unable to register serializers serializer: a static serializer for type {type.ToString(true)} already exists");
-        Assertion.Assert(!myPolySerializersSealed,
+        Assertion.Require(!myPolySerializersSealed,
           $"Unable to register serializers serializer for type {type.ToString(true)}. It is too late to register a serializers serializer as one or more models were already activated.");
 
         myInstanceSerializers.Add(type, pair);

--- a/rd-net/RdFramework.Reflection/ReflectionSerializers.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionSerializers.cs
@@ -68,11 +68,16 @@ public class ReflectionSerializers : ISerializers, ISerializersSource
   /// </summary>
   public ISignal<Type> BeforeCreation { get; } = new Signal<Type>();
 
-  public ReflectionSerializers(ITypesCatalog typeCatalog, IScalarSerializers? scalars = null, Predicate<Type>? blackListChecker = null)
+  public ReflectionSerializers(ITypesCatalog typeCatalog, IScalarSerializers? scalars = null, Predicate<Type>? blackListChecker = null, bool withExtensions = true)
   {
     myCatalog = typeCatalog;
     myScalars = scalars ?? new ScalarSerializer(typeCatalog, blackListChecker);
     Serializers.RegisterFrameworkMarshallers(this);
+    
+    if (withExtensions)
+    {
+      ScalarCollectionExtension.AttachCollectionSerializers(this);
+    }
   }
 
   public SerializerPair GetOrRegisterSerializerPair(Type type, bool instance = false)

--- a/rd-net/RdFramework.Reflection/ReflectionSerializersFacade.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionSerializersFacade.cs
@@ -27,7 +27,7 @@ namespace JetBrains.Rd.Reflection
     {
       TypesCatalog = typesCatalog ?? new SimpleTypesCatalog();
       ScalarSerializers = scalarSerializers ?? new ScalarSerializer(TypesCatalog, blackListChecker);
-      Serializers = reflectionSerializers ?? new ReflectionSerializers(TypesCatalog, ScalarSerializers).WithBasicCollectionSerializers();
+      Serializers = reflectionSerializers ?? new ReflectionSerializers(TypesCatalog, ScalarSerializers);
 
       ProxyGenerator = proxyGenerator ?? new ProxyGeneratorCache(new ProxyGenerator(allowSave));
       Activator = activator ?? new ReflectionRdActivator(Serializers, ProxyGenerator, TypesCatalog);

--- a/rd-net/RdFramework.Reflection/ReflectionSerializersFacade.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionSerializersFacade.cs
@@ -37,7 +37,7 @@ namespace JetBrains.Rd.Reflection
     {
       var type = ProxyGenerator.CreateType<TInterface>();
       var proxyInstance = Activator.ActivateBind(type, lifetime, protocol) as TInterface;
-      Assertion.Assert(proxyInstance != null, "Unable to cast proxy to desired interface ({0})", typeof(TInterface));
+      Assertion.AssertNotNull(proxyInstance, "Unable to cast proxy to desired interface ({0})", typeof(TInterface));
       return proxyInstance;
     }
 

--- a/rd-net/RdFramework.Reflection/ScalarCollectionExtension.cs
+++ b/rd-net/RdFramework.Reflection/ScalarCollectionExtension.cs
@@ -11,7 +11,13 @@ namespace JetBrains.Rd.Reflection;
 /// </summary>
 public static class ScalarCollectionExtension
 {
+  [Obsolete("NOP method. Basic collection serializers are enabled by default")]
   public static ReflectionSerializers WithBasicCollectionSerializers(this ReflectionSerializers self)
+  {
+    return self;
+  }
+
+  public static void AttachCollectionSerializers(ReflectionSerializers self)
   {
     self.BeforeCreation.Advise(Lifetime.Eternal, type =>
     {
@@ -42,7 +48,6 @@ public static class ScalarCollectionExtension
         self.Register(type, result);
       }
     });
-    return self;
   }
 
   private static SerializerPair CreateArraySerializer<T>(ISerializersSource serializersSource)

--- a/rd-net/RdFramework.Reflection/ScalarSerializer.cs
+++ b/rd-net/RdFramework.Reflection/ScalarSerializer.cs
@@ -206,7 +206,7 @@ namespace JetBrains.Rd.Reflection
       var writerConvert = Expression.ConvertChecked(writerParameter, typeof(int));
       var writerCaster = Expression.Lambda<Func<T, int>>(writerConvert, writerParameter).Compile();
 
-      Assertion.Assert(typeof(T).IsSubclassOf(typeof(Enum)), "{0}", typeof(T));
+      if (Mode.IsAssertion) Assertion.Require(typeof(T).IsSubclassOf(typeof(Enum)), "{0}", typeof(T));
       var result = new SerializerPair(
         (CtxReadDelegate<T>) ((ctx, reader) => readerCaster(reader.ReadInt())),
         (CtxWriteDelegate<T>) ((ctx, w, o) => w.Write(writerCaster(o))));

--- a/rd-net/RdFramework.Reflection/SerializerPair.cs
+++ b/rd-net/RdFramework.Reflection/SerializerPair.cs
@@ -30,10 +30,13 @@ public sealed class SerializerPair
     if (reader == null) throw new ArgumentNullException(nameof(reader));
     if (writer == null) throw new ArgumentNullException(nameof(writer));
 
-    Assertion.Assert(reader.GetType().GetGenericTypeDefinition() == typeof(CtxReadDelegate<>),
-      $"Invalid type: expected CtxReaderDelegate, but was {reader.GetType().ToString(true)}");
-    Assertion.Assert(writer.GetType().GetGenericTypeDefinition() == typeof(CtxWriteDelegate<>),
-      $"Invalid type: expected CtxWriteDelegate, but was {writer.GetType().ToString(true)}");
+    if (Mode.IsAssertion)
+    {
+      Assertion.Assert(reader.GetType().GetGenericTypeDefinition() == typeof(CtxReadDelegate<>),
+        $"Invalid type: expected CtxReaderDelegate, but was {reader.GetType().ToString(true)}");
+      Assertion.Assert(writer.GetType().GetGenericTypeDefinition() == typeof(CtxWriteDelegate<>),
+        $"Invalid type: expected CtxWriteDelegate, but was {writer.GetType().ToString(true)}");
+    }
 
     myReader = reader;
     myWriter = writer;
@@ -147,7 +150,7 @@ public sealed class SerializerPair
 
   private static SerializerPair CreateFromNonProtocolMethodsT<T>(MethodInfo readMethod, MethodInfo writeMethod)
   {
-    Assertion.Assert(readMethod.IsStatic, $"Read method should be static ({readMethod.DeclaringType.ToString(true)})");
+    Assertion.Require(readMethod.IsStatic, $"Read method should be static ({readMethod.DeclaringType.ToString(true)})");
 
     void WriterDelegate(SerializationCtx ctx, UnsafeWriter writer, T value)
     {

--- a/rd-net/RdFramework/Base/RdReactiveBase.cs
+++ b/rd-net/RdFramework/Base/RdReactiveBase.cs
@@ -93,7 +93,7 @@ namespace JetBrains.Rd.Base
     
     protected internal LocalChangeCookie UsingLocalChange()
     {
-      Assertion.Assert(!IsLocalChange, "!IsLocalChange: {0}", this);
+      if (Mode.IsAssertion) Assertion.Assert(!IsLocalChange, "!IsLocalChange: {0}", this);
       if (IsBound && !Async) AssertThreading();
       return new LocalChangeCookie(this);
     }

--- a/rd-net/RdFramework/IWire.cs
+++ b/rd-net/RdFramework/IWire.cs
@@ -97,8 +97,8 @@ namespace JetBrains.Rd
 
     public void Send<TParam>(RdId id, TParam param, Action<TParam, UnsafeWriter> writer)
     {
-      Assertion.Require(!id.IsNil, "!id.IsNil");
-      Assertion.AssertNotNull(writer, "writer != null");
+      Assertion.Require(!id.IsNil);
+      Assertion.AssertNotNull(writer);
 
       using (var cookie = UnsafeWriter.NewThreadLocalWriter())
       {

--- a/rd-net/RdFramework/Impl/BufferWindow.cs
+++ b/rd-net/RdFramework/Impl/BufferWindow.cs
@@ -35,11 +35,11 @@ namespace JetBrains.Rd.Impl
     public bool Read(ref BufferWindow helper, Receiver receiver, int size)
     {
       var hi = Hi + size;
-      Assertion.Assert(hi <= Data.Length, "hi <= Data.Length");
+      if (Mode.IsAssertion) Assertion.Assert(hi <= Data.Length, "hi <= Data.Length");
       
       while (Hi < hi)
       {
-        Assertion.Assert(helper.Hi >= helper.Lo, "helper.Hi >= helper.Lo");
+        if (Mode.IsAssertion) Assertion.Assert(helper.Hi >= helper.Lo, "helper.Hi >= helper.Lo");
 
         if (helper.Available > 0)
         {
@@ -61,7 +61,7 @@ namespace JetBrains.Rd.Impl
           helper.Hi += receiverAvailable;
         }
       }
-      Assertion.Assert(Hi == hi, "lo == hi");
+      if (Mode.IsAssertion) Assertion.Assert(Hi == hi, "lo == hi");
       return true;
     }
   }

--- a/rd-net/RdFramework/Impl/MessageBroker.cs
+++ b/rd-net/RdFramework/Impl/MessageBroker.cs
@@ -76,7 +76,7 @@ namespace JetBrains.Rd.Impl
       {
         var reader = UnsafeReader.CreateReader(p, msg.Length);
         var rdid0 = RdId.Read(reader);
-        Assertion.Assert(reactive.RdId.Equals(rdid0), "Not equals: {0}, {1}", reactive.RdId, rdid0);
+        if (Mode.IsAssertion) Assertion.Assert(reactive.RdId.Equals(rdid0), "Not equals: {0}, {1}", reactive.RdId, rdid0);
 
         if (BackwardsCompatibleWireFormat)
           reactive.OnWireReceived(reader);
@@ -99,7 +99,7 @@ namespace JetBrains.Rd.Impl
         
         foreach (var keyValuePair in entries)
         {
-          Assertion.Assert(keyValuePair.Value.CustomSchedulerMessages.Count == 0, "Unexpected custom scheduler messages");
+          if (Mode.IsAssertion) Assertion.Assert(keyValuePair.Value.CustomSchedulerMessages.Count == 0, "Unexpected custom scheduler messages");
           
           foreach (var messageBytes in keyValuePair.Value.DefaultSchedulerMessages)
             Dispatch(keyValuePair.Key, messageBytes);
@@ -110,7 +110,7 @@ namespace JetBrains.Rd.Impl
     //on poller thread
     public void Dispatch(RdId id, byte[] msg)
     {
-      Assertion.Require(!id.IsNil, "!id.IsNil");
+      Assertion.Require(!id.IsNil);
 
       lock (myLock)
       {
@@ -161,7 +161,7 @@ namespace JetBrains.Rd.Impl
                   {
                     foreach (var m in currentBroker.CustomSchedulerMessages)
                     {
-                      Assertion.Assert(subscription.WireScheduler != myScheduler,
+                      if (Mode.IsAssertion) Assertion.Assert(subscription.WireScheduler != myScheduler,
                         "subscription.Scheduler != myScheduler for {0}", subscription);
                       Invoke(subscription, m);
                     }

--- a/rd-net/RdFramework/Impl/ProtocolContexts.cs
+++ b/rd-net/RdFramework/Impl/ProtocolContexts.cs
@@ -104,14 +104,14 @@ namespace JetBrains.Rd.Impl
     
     private void EnsureHeavyHandlerExists<T>(RdContext<T> context)
     {
-      Assertion.Assert(context.IsHeavy, "key.IsHeavy");
+      if (Mode.IsAssertion) Assertion.Assert(context.IsHeavy, "key.IsHeavy");
       if (!myHandlersMap.ContainsKey(context)) 
         DoAddHandler(context, new HeavySingleContextHandler<T>(context, this));
     }
     
     private void EnsureLightHandlerExists<T>(RdContext<T> context)
     {
-      Assertion.Assert(!context.IsHeavy, "!key.IsHeavy");
+      if (Mode.IsAssertion) Assertion.Assert(!context.IsHeavy, "!key.IsHeavy");
       if (!myHandlersMap.ContainsKey(context)) 
         DoAddHandler(context, new LightSingleContextHandler<T>(context));
     }
@@ -121,7 +121,7 @@ namespace JetBrains.Rd.Impl
     /// </summary>
     public IViewableSet<T> GetValueSet<T>(RdContext<T> context) where T : notnull
     {
-      Assertion.Assert(context.IsHeavy, "Only heavy keys have value sets, key {0} is light", context.Key);
+      if (Mode.IsAssertion) Assertion.Assert(context.IsHeavy, "Only heavy keys have value sets, key {0} is light", context.Key);
       return ((HeavySingleContextHandler<T>) GetHandlerForContext(context)).LocalValueSet;
     }
 
@@ -163,7 +163,7 @@ namespace JetBrains.Rd.Impl
     public MessageContextCookie ReadContextsIntoCookie(UnsafeReader reader)
     {
       var numContextValues = reader.ReadShort();
-      Assertion.Assert(numContextValues <= myCounterpartHandlers.Count, "We know of {0} other side keys, received {1} instead", myCounterpartHandlers.Count, numContextValues);
+      if (Mode.IsAssertion) Assertion.Assert(numContextValues <= myCounterpartHandlers.Count, "We know of {0} other side keys, received {1} instead", myCounterpartHandlers.Count, numContextValues);
       
       var pool = ourListsPool ??= new SingleThreadListPool<IDisposable>(2);
       var contextValueRestorersCookie = pool.RentCookie();

--- a/rd-net/RdFramework/Impl/RdList.cs
+++ b/rd-net/RdFramework/Impl/RdList.cs
@@ -78,7 +78,7 @@ namespace JetBrains.Rd.Impl
     [PublicAPI]
     public static void Write(SerializationCtx ctx, UnsafeWriter writer, RdList<V> value)
     {
-      Assertion.Assert(!value.RdId.IsNil, "!value.Id.IsNil");
+      Assertion.Assert(!value.RdId.IsNil);
       writer.Write(value.myNextVersion);
       writer.Write(value.RdId);
     }

--- a/rd-net/RdFramework/Impl/RdMap.cs
+++ b/rd-net/RdFramework/Impl/RdMap.cs
@@ -59,7 +59,7 @@ namespace JetBrains.Rd.Impl
     [PublicAPI]
     public static void Write(SerializationCtx ctx, UnsafeWriter writer, RdMap<K, V> value)
     {
-      Assertion.Assert(!value.RdId.IsNil, "!value.RdId.IsNil");
+      Assertion.Assert(!value.RdId.IsNil);
       writer.Write(value.RdId);
     }
     #endregion

--- a/rd-net/RdFramework/Impl/RdPerContextMap.cs
+++ b/rd-net/RdFramework/Impl/RdPerContextMap.cs
@@ -52,7 +52,7 @@ namespace JetBrains.Rd.Impl
         public V GetForCurrentContext()
         {
           var currentId = Context.ValueForPerContextEntity;
-          Assertion.Assert(currentId != null, "No value set for key {0}", Context.Key);
+          if (Mode.IsAssertion) Assertion.Assert(currentId != null, "No value set for key {0}", Context.Key);
           if (TryGetValue(currentId, out var value))
             return value;
           Assertion.Fail("{0} has no value for Context {1} = {2}", Location, Context.Key, currentId);

--- a/rd-net/RdFramework/Impl/RdPerContextMap.cs
+++ b/rd-net/RdFramework/Impl/RdPerContextMap.cs
@@ -52,7 +52,7 @@ namespace JetBrains.Rd.Impl
         public V GetForCurrentContext()
         {
           var currentId = Context.ValueForPerContextEntity;
-          if (Mode.IsAssertion) Assertion.Assert(currentId != null, "No value set for key {0}", Context.Key);
+          if (Mode.IsAssertion) Assertion.AssertNotNull(currentId, "No value set for key {0}", Context.Key);
           if (TryGetValue(currentId, out var value))
             return value;
           Assertion.Fail("{0} has no value for Context {1} = {2}", Location, Context.Key, currentId);

--- a/rd-net/RdFramework/Impl/RdProperty.cs
+++ b/rd-net/RdFramework/Impl/RdProperty.cs
@@ -61,7 +61,7 @@ namespace JetBrains.Rd.Impl
 
     public static void Write(SerializationCtx ctx, UnsafeWriter writer, RdProperty<T> value)
     {
-      Assertion.Assert(!value.RdId.IsNil, "!value.RdId.IsNil");
+      Assertion.Assert(!value.RdId.IsNil);
       writer.Write(value.RdId);
       if (value.HasValue())
       {

--- a/rd-net/RdFramework/Impl/RdSet.cs
+++ b/rd-net/RdFramework/Impl/RdSet.cs
@@ -45,7 +45,7 @@ namespace JetBrains.Rd.Impl
 
     public static void Write(SerializationCtx ctx, UnsafeWriter writer, RdSet<T> value)
     {
-      Assertion.Assert(!value.RdId.IsNil, "!value.RdId.IsNil");
+      Assertion.Assert(!value.RdId.IsNil);
       writer.Write(value.RdId);
     }
     #endregion

--- a/rd-net/RdFramework/Impl/Serializers.cs
+++ b/rd-net/RdFramework/Impl/Serializers.cs
@@ -202,7 +202,7 @@ namespace JetBrains.Rd.Impl
 #endif
      Enum
     {
-      Assertion.Assert(typeof(T).IsSubclassOf(typeof(Enum)), "{0}", typeof(T));
+      if (Mode.IsAssertion) Assertion.Assert(typeof(T).IsSubclassOf(typeof(Enum)), "{0}", typeof(T));
       return Cast32BitEnum<T>.FromInt(reader.ReadInt());
     }
 
@@ -291,7 +291,7 @@ namespace JetBrains.Rd.Impl
       }
 
       var uncasted = ctxReadDelegate(ctx, reader);
-      Assertion.Assert(uncasted is T, "Bad cast for id {0}. Expected: {1}, actual: {2}", typeId, typeof(T).Name, uncasted.GetType().Name);
+      if (Mode.IsAssertion) Assertion.Assert(uncasted is T, "Bad cast for id {0}. Expected: {1}, actual: {2}", typeId, typeof(T).Name, uncasted.GetType().Name);
       return (T)uncasted;
     }
 

--- a/rd-net/RdFramework/Impl/SocketWire.cs
+++ b/rd-net/RdFramework/Impl/SocketWire.cs
@@ -292,7 +292,7 @@ namespace JetBrains.Rd.Impl
               if (seqN > myMaxReceivedSeqn || seqN == 1 /*TODO new client, possible duplicate problem if ack for seqN=1 from previous client's connection hasn't passed*/)
               {
                 myMaxReceivedSeqn = seqN; //will be acknowledged when we read whole message
-                Assertion.Assert(myPkg.Available > 0, "myPkgBuffer.Available > 0");
+                Assertion.Assert(myPkg.Available > 0);
 
                 var sizeToCopy = Math.Min(size, myPkg.Available);
                 myPkg.MoveTo(buffer, offset, sizeToCopy);

--- a/rd-net/RdFramework/Text/Impl/RdTextBuffer.cs
+++ b/rd-net/RdFramework/Text/Impl/RdTextBuffer.cs
@@ -78,7 +78,7 @@ namespace JetBrains.Rd.Text.Impl
       var newVersion = rdTextBufferChange.Version;
       var change = rdTextBufferChange.Change;
       var side = rdTextBufferChange.Origin;
-      Assertion.Assert(side != myLocalOrigin, "side != mySide");
+      if (Mode.IsAssertion) Assertion.Assert(side != myLocalOrigin, "side != mySide");
 
       var masterVersionRemote = newVersion.Master;
       var slaveVersionRemote = newVersion.Slave;
@@ -89,7 +89,7 @@ namespace JetBrains.Rd.Text.Impl
       }
       else if (change.Kind == RdTextChangeKind.PromoteVersion)
       {
-        Assertion.Assert(!IsMaster, "!IsMaster");
+        if (Mode.IsAssertion) Assertion.Assert(!IsMaster);
         BufferVersion = newVersion;
         return;
       }
@@ -97,7 +97,7 @@ namespace JetBrains.Rd.Text.Impl
       {
         if (IsMaster)
         {
-          Assertion.Assert(myChangesToConfirmOrRollback.Count == 0, "changesToConfirmOrRollback.IsEmpty()");
+          if (Mode.IsAssertion) Assertion.Assert(myChangesToConfirmOrRollback.Count == 0);
           if (masterVersionRemote != BufferVersion.Master)
           {
             // reject the change. we've already sent overriding change.
@@ -143,8 +143,7 @@ namespace JetBrains.Rd.Text.Impl
 
     public void Fire(RdTextChange change)
     {
-      Assertion.Assert(Delegate.IsBound || BufferVersion == TextBufferVersion.InitVersion,
-        "Delegate.IsBound || BufferVersion == TextBufferVersion.InitVersion");
+      if (Mode.IsAssertion) Assertion.Assert(Delegate.IsBound || BufferVersion == TextBufferVersion.InitVersion);
       if (Delegate.IsBound) Proto.Scheduler.AssertThread();
 
       if (IsMaster && myActiveSession != null && myActiveSession.IsCommitting)
@@ -175,7 +174,7 @@ namespace JetBrains.Rd.Text.Impl
 
     public void Advise(Lifetime lifetime, Action<RdTextChange> change)
     {
-      Assertion.Assert(Delegate.IsBound, "Delegate.IsBound");
+      Assertion.Assert(Delegate.IsBound);
       Proto.Scheduler.AssertThread();
       
       myTextChanged.Advise(lifetime, change);
@@ -197,8 +196,8 @@ namespace JetBrains.Rd.Text.Impl
 
     public ITypingSession StartTypingSession(Lifetime lifetime)
     {
-      Assertion.Assert(myActiveSession == null, "myActiveSession == null");
-      Assertion.Assert(lifetime.IsAlive, "lifetime.IsAlive");
+      Assertion.Assert(myActiveSession == null);
+      Assertion.Assert(lifetime.IsAlive);
 
       myActiveSession = new TextBufferTypingSession(this);
       lifetime.OnTermination(() => myActiveSession = null);
@@ -295,7 +294,7 @@ namespace JetBrains.Rd.Text.Impl
 
       public void StartCommitRemoteVersion()
       {
-        Assertion.Assert(myState == State.Opened, "myState == State.Opened");
+        Assertion.Assert(myState == State.Opened);
         myState = State.Committing;
       }
     }

--- a/rd-net/Test.RdFramework/Reflection/ReflectionSerializersPrimitivesTest.cs
+++ b/rd-net/Test.RdFramework/Reflection/ReflectionSerializersPrimitivesTest.cs
@@ -10,7 +10,7 @@ public class ReflectionSerializersPrimitivesTest
   [Test]
   public void TestNonPolymorphicForPrimitive()
   {
-    var s = new ReflectionSerializers(new SimpleTypesCatalog()).WithBasicCollectionSerializers();
+    var s = new ReflectionSerializers(new SimpleTypesCatalog());
     var pair = s.GetOrRegisterSerializerPair(typeof(IViewableList<string>), true);
 
     Assert.False(pair.IsPolymorphic);

--- a/rd-net/Test.RdFramework/Reflection/ScalarTests.cs
+++ b/rd-net/Test.RdFramework/Reflection/ScalarTests.cs
@@ -257,7 +257,7 @@ namespace Test.RdFramework.Reflection
     
     public void RunScalarTest<T>(T instance, Action<T, T> checkEqual)
     {
-      var scalar = new ReflectionSerializers(CFacade.TypesCatalog).WithBasicCollectionSerializers();
+      var scalar = new ReflectionSerializers(CFacade.TypesCatalog);
       var serializerPair = scalar.GetOrRegisterSerializerPair(typeof(T), true);
       var reader = serializerPair.GetReader<T>();
       var writer = serializerPair.GetWriter<T>();


### PR DESCRIPTION
    The most of the assertions were disabled in release build previously
    using JET_MODE_ASSERT define. The code was written with the assumption
    that Assertion.Assert methods invocations are removed in release mode.

    This is no longer truth. The NuGet packages builds with the
    JET_MODE_ASSERT enabled. To reduce performance impact of the Assertion
    I added additional checks for Mode.Assertion to help JIT to remove
    the branch with the check (in perf-critical code)

    Additionally, in non-performance critical places, I converted
    Assertions.Assert to Assertion.Require method, which is not marked by
    ConditionalCompilation.
