### PR TITLE
rd-reflection: a feature to override RpcTimeouts in SyncCalls

### DIFF
--- a/rd-net/RdFramework.Reflection/Attributes.cs
+++ b/rd-net/RdFramework.Reflection/Attributes.cs
@@ -63,9 +63,6 @@ namespace JetBrains.Rd.Reflection
     }
   }
 
-  [Obsolete("RdAsync enabled by default for everything")]
-  [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method)]
-  public class RdAsyncAttribute : Attribute { }
   /// <summary>
   /// Override default <see cref="RpcTimeouts"/> in proxy instances in RdReflection. Should be used either on the method of
   /// interface marked by <see cref="RdRpcAttribute"/> or on the interface itself.

--- a/rd-net/RdFramework.Reflection/Attributes.cs
+++ b/rd-net/RdFramework.Reflection/Attributes.cs
@@ -1,5 +1,6 @@
 using System;
 using JetBrains.Annotations;
+using JetBrains.Rd.Tasks;
 
 namespace JetBrains.Rd.Reflection
 {
@@ -65,6 +66,32 @@ namespace JetBrains.Rd.Reflection
   [Obsolete("RdAsync enabled by default for everything")]
   [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method)]
   public class RdAsyncAttribute : Attribute { }
+  /// <summary>
+  /// Override default <see cref="RpcTimeouts"/> in proxy instances in RdReflection. Should be used either on the method of
+  /// interface marked by <see cref="RdRpcAttribute"/> or on the interface itself.
+  ///
+  /// Default value means no timeout.
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Method | AttributeTargets.Interface)]
+  public class RpcTimeoutAttribute : Attribute
+  {
+    [UsedImplicitly/*used in ProxyGenerator*/]
+    public readonly RpcTimeouts myTimeout;
+
+    public RpcTimeouts Timeout => myTimeout;
+
+    public RpcTimeoutAttribute(double errorMilliseconds = -1, double warnMilliseconds = -1)
+    {
+      var errorTimespan = errorMilliseconds == -1 ? TimeSpan.MaxValue : TimeSpan.FromMilliseconds(errorMilliseconds);
+      var warnTimespan = warnMilliseconds < 0 ? errorTimespan : TimeSpan.FromMilliseconds(warnMilliseconds);
+      myTimeout = new RpcTimeouts(warnTimespan, errorTimespan);
+    }
+
+    public RpcTimeoutAttribute(bool rawValues, long errorTicks, long warnTicks = -1)
+    {
+      myTimeout = new RpcTimeouts(new TimeSpan(warnTicks), new TimeSpan(errorTicks));
+    }
+  }
 
   /// <summary>
   /// Marker interface for proxy types.

--- a/rd-net/RdFramework.Reflection/ProxyGeneratorUtil.cs
+++ b/rd-net/RdFramework.Reflection/ProxyGeneratorUtil.cs
@@ -92,5 +92,10 @@ namespace JetBrains.Rd.Reflection
         return task.Result.Value.Unwrap();
       }
     }
+
+    public static RpcTimeouts CreateRpcTimeouts(long ticksWarning, long ticksError)
+    {
+      return new RpcTimeouts(new TimeSpan(ticksWarning), new TimeSpan(ticksError));
+    }
   }
 }

--- a/rd-net/RdFramework/Impl/RdSimpleDispatcher.cs
+++ b/rd-net/RdFramework/Impl/RdSimpleDispatcher.cs
@@ -61,7 +61,7 @@ namespace JetBrains.Rd.Impl
             return;
           }
 
-          var timeout = MessageTimeout != null ? (int)MessageTimeout.Value.TotalMilliseconds : -1;
+          var timeout = MessageTimeout == null || MessageTimeout == TimeSpan.MaxValue ? -1 : (int)MessageTimeout.Value.TotalMilliseconds;
           if (!myEvent.WaitOne(timeout))
           {
             throw new Exception($"Cannot receive a message in {timeout} ms");

--- a/rd-net/Test.RdFramework/Reflection/ProxyGeneratorRpcTimeoutOverrideTest.cs
+++ b/rd-net/Test.RdFramework/Reflection/ProxyGeneratorRpcTimeoutOverrideTest.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Rd.Reflection;
+using NUnit.Framework;
+
+namespace Test.RdFramework.Reflection;
+
+[TestFixture]
+public class ProxyGeneratorRpcTimeoutOverrideTest : ProxyGeneratorTestBase
+{
+  protected override bool IsAsync => true;
+  protected override bool RespectRpcTimeouts => true;
+
+  ////////////////////////
+
+  [RdRpc]
+  public interface ICallTest
+  {
+    [RpcTimeout(1)]
+    void MTimeout();
+
+    [RpcTimeout]
+    void MQuick();
+  }
+
+  [RdExt]
+  internal class CallTest : RdExtReflectionBindableBase, ICallTest
+  {
+    public void MTimeout() => Thread.Sleep(50);
+    public void MQuick() { }
+  }
+
+  [Test]
+  public async Task TestRpcTimeouts()
+  {
+    ThrowLoggedExceptions();
+
+    await TestTemplate<CallTest, ICallTest>(model =>
+    {
+      model.MQuick(); // should not throw, timeouts are satisfied
+      ThrowLoggedExceptions(); 
+
+      // should produce log message with level=Error, timeout 1ms is violated
+      model.MTimeout();
+      Assert.Throws<Exception>(ThrowLoggedExceptions);
+
+      return Task.CompletedTask;
+    });
+  }
+
+  ////////////////////////
+
+  [RdRpc, RpcTimeout(1)]
+  public interface ICall2Test
+  {
+    void MTimeout();
+  }
+  [RdExt]
+  internal class Call2Test : RdExtReflectionBindableBase, ICall2Test
+  {
+    public void MTimeout() => Thread.Sleep(50);
+  }
+
+  [Test]
+  public async Task TestRpcTimeouts2()
+  {
+    await TestTemplate<Call2Test, ICall2Test>(model =>
+    {
+      // should produce log message with level=Error, timeout 1ms is violated
+      model.MTimeout();
+      Assert.Throws<Exception>(ThrowLoggedExceptions);
+      return Task.CompletedTask;
+    });
+  }
+}

--- a/rd-net/Test.RdFramework/Reflection/RdReflectionTestBase.cs
+++ b/rd-net/Test.RdFramework/Reflection/RdReflectionTestBase.cs
@@ -24,7 +24,7 @@ namespace Test.RdFramework.Reflection
     {
       // increase timeouts to balance unpredictable agent performance
       myRespectRpcTimeouts = RpcTimeouts.RespectRpcTimeouts;
-      RpcTimeouts.RespectRpcTimeouts = false;
+      RpcTimeouts.RespectRpcTimeouts = RespectRpcTimeouts;
       CFacade = new ReflectionSerializersFacade(allowSave: true);
       SFacade = new ReflectionSerializersFacade(allowSave: true);
 
@@ -32,6 +32,8 @@ namespace Test.RdFramework.Reflection
       ServerWire.AutoTransmitMode = true;
       ClientWire.AutoTransmitMode = true;
     }
+
+    protected virtual bool RespectRpcTimeouts => false;
 
     public override void TearDown()
     {

--- a/rd-net/Test.RdFramework/Test.RdFramework.csproj
+++ b/rd-net/Test.RdFramework/Test.RdFramework.csproj
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
-        <Compile Remove="Reflection" />
+        <Compile Remove="Reflection/**" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
    [RdRpc]
    public interface ICallTest
    {
      [RpcTimeout(errorMilliseconds: 1)]
      void MTimeout();
    
      [RpcTimeout(errorMilliseconds: 2000, warnMilliseconds: 10)]
      void MQuick();
    }
    
    [RdRpc, RpcTimeout(1)]
    public interface ICall2Test
    {
      void MTimeout();
    }
