### PR TITLE
Build: exclude rd-cross for everyone

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,9 +28,6 @@ if (System.getenv(TEAMCITY_VERSION) == null) {
 //    include(":rd-cpp")
 //    project(":rd-cpp").projectDir = File("rd-cpp")
 
-    include(":rd-cross")
-    project(":rd-cross").projectDir = File("rd-kt/rd-cross")
+//    include(":rd-cross")
+//    project(":rd-cross").projectDir = File("rd-kt/rd-cross")
 }
-
-
-


### PR DESCRIPTION
rd-cross' fate is still under consideration (I'm not giving up that easily, yet), but for now it's absolutely useless and let's remove it from build.