### PR TITLE
UnsafeWriter/UnsafeReader rework

### DIFF
--- a/rd-net/Lifetimes/Annotations/CodeAnnotations.cs
+++ b/rd-net/Lifetimes/Annotations/CodeAnnotations.cs
@@ -564,4 +564,202 @@ namespace JetBrains.Annotations
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
     internal sealed class RegexPatternAttribute : Attribute { }
+
+    /// <summary>
+    /// <para>
+    /// Defines the code search template using the Structural Search and Replace syntax.
+    /// It allows you to find and, if necessary, replace blocks of code that match a specific pattern.
+    /// Search and replace patterns consist of a textual part and placeholders.
+    /// Textural part must contain only identifiers allowed in the target language and will be matched exactly (white spaces, tabulation characters, and line breaks are ignored).
+    /// Placeholders allow matching variable parts of the target code blocks.
+    /// A placeholder has the following format: $placeholder_name$- where placeholder_name is an arbitrary identifier.
+    /// </para>
+    /// <para>
+    /// Available placeholders:
+    /// <list type="bullet">
+    /// <item>$this$ - expression of containing type</item>
+    /// <item>$thisType$ - containing type</item>
+    /// <item>$member$ - current member placeholder</item>
+    /// <item>$qualifier$ - this placeholder is available in the replace pattern and can be used to insert a qualifier expression matched by the $member$ placeholder.
+    /// (Note that if $qualifier$ placeholder is used, then $member$ placeholder will match only qualified references)</item>
+    /// <item>$expression$ - expression of any type</item>
+    /// <item>$identifier$ - identifier placeholder</item>
+    /// <item>$args$ - any number of arguments</item>
+    /// <item>$arg$ - single argument</item>
+    /// <item>$arg1$ ... $arg10$ - single argument</item>
+    /// <item>$stmts$ - any number of statements</item>
+    /// <item>$stmt$ - single statement</item>
+    /// <item>$stmt1$ ... $stmt10$ - single statement</item>
+    /// <item>$name{Expression, 'Namespace.FooType'}$ - expression with 'Namespace.FooType' type</item>
+    /// <item>$expression{'Namespace.FooType'}$ - expression with 'Namespace.FooType' type</item>
+    /// <item>$name{Type, 'Namespace.FooType'}$ - 'Namespace.FooType' type</item>
+    /// <item>$type{'Namespace.FooType'}$ - 'Namespace.FooType' type</item>
+    /// <item>$statement{1,2}$ - 1 or 2 statements</item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// Note that you can also define your own placeholders of the supported types and specify arguments for each placeholder type.
+    /// This can be done using the following format: $name{type, arguments}$. Where 'name' - is the name of your placeholder,
+    /// 'type' - is the type of your placeholder (one of the following: Expression, Type, Identifier, Statement, Argument, Member),
+    /// 'arguments' - arguments list for your placeholder. Each placeholder type supports its own arguments, check examples below for more details.
+    /// The placeholder type may be omitted and determined from the placeholder name, if the name has one of the following prefixes:
+    /// <list type="bullet">
+    /// <item>expr, expression - expression placeholder, e.g. $exprPlaceholder{}$, $expressionFoo{}$</item>
+    /// <item>arg, argument - argument placeholder, e.g. $argPlaceholder{}$, $argumentFoo{}$</item>
+    /// <item>ident, identifier - identifier placeholder, e.g. $identPlaceholder{}$, $identifierFoo{}$</item>
+    /// <item>stmt, statement - statement placeholder, e.g. $stmtPlaceholder{}$, $statementFoo{}$</item>
+    /// <item>type - type placeholder, e.g. $typePlaceholder{}$, $typeFoo{}$</item>
+    /// <item>member - member placeholder, e.g. $memberPlaceholder{}$, $memberFoo{}$</item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// Expression placeholder arguments:
+    /// <list type="bullet">
+    /// <item>expressionType - string value in single quotes, specifies full type name to match (empty string by default)</item>
+    /// <item>exactType - boolean value, specifies if expression should have exact type match (false by default)</item>
+    /// </list>
+    /// Examples:
+    /// <list type="bullet">
+    /// <item>$myExpr{Expression, 'Namespace.FooType', true}$ - defines expression placeholder, matching expressions of the 'Namespace.FooType' type with exact matching.</item>
+    /// <item>$myExpr{Expression, 'Namespace.FooType'}$ - defines expression placeholder, matching expressions of the 'Namespace.FooType' type or expressions which can be implicitly converted to 'Namespace.FooType'.</item>
+    /// <item>$myExpr{Expression}$ - defines expression placeholder, matching expressions of any type.</item>
+    /// <item>$exprFoo{'Namespace.FooType', true}$ - defines expression placeholder, matching expressions of the 'Namespace.FooType' type with exact matching.</item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// Type placeholder arguments:
+    /// <list type="bullet">
+    /// <item>type - string value in single quotes, specifies full type name to match (empty string by default)</item>
+    /// <item>exactType - boolean value, specifies if expression should have exact type match (false by default)</item>
+    /// </list>
+    /// Examples:
+    /// <list type="bullet">
+    /// <item>$myType{Type, 'Namespace.FooType', true}$ - defines type placeholder, matching 'Namespace.FooType' types with exact matching.</item>
+    /// <item>$myType{Type, 'Namespace.FooType'}$ - defines type placeholder, matching 'Namespace.FooType' types or types, which can be implicitly converted to 'Namespace.FooType'.</item>
+    /// <item>$myType{Type}$ - defines type placeholder, matching any type.</item>
+    /// <item>$typeFoo{'Namespace.FooType', true}$ - defines types placeholder, matching 'Namespace.FooType' types with exact matching.</item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// Identifier placeholder arguments:
+    /// <list type="bullet">
+    /// <item>nameRegex - string value in single quotes, specifies regex to use for matching (empty string by default)</item>
+    /// <item>nameRegexCaseSensitive - boolean value, specifies if name regex is case sensitive (true by default)</item>
+    /// <item>type - string value in single quotes, specifies full type name to match (empty string by default)</item>
+    /// <item>exactType - boolean value, specifies if expression should have exact type match (false by default)</item>
+    /// </list>
+    /// Examples:
+    /// <list type="bullet">
+    /// <item>$myIdentifier{Identifier, 'my.*', false, 'Namespace.FooType', true}$ - defines identifier placeholder, matching identifiers (ignoring case) starting with 'my' prefix with 'Namespace.FooType' type.</item>
+    /// <item>$myIdentifier{Identifier, 'my.*', true, 'Namespace.FooType', true}$ - defines identifier placeholder, matching identifiers (case sensitively) starting with 'my' prefix with 'Namespace.FooType' type.</item>
+    /// <item>$identFoo{'my.*'}$ - defines identifier placeholder, matching identifiers (case sensitively) starting with 'my' prefix.</item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// Statement placeholder arguments:
+    /// <list type="bullet">
+    /// <item>minimalOccurrences - minimal number of statements to match (-1 by default)</item>
+    /// <item>maximalOccurrences - maximal number of statements to match (-1 by default)</item>
+    /// </list>
+    /// Examples:
+    /// <list type="bullet">
+    /// <item>$myStmt{Statement, 1, 2}$ - defines statement placeholder, matching 1 or 2 statements.</item>
+    /// <item>$myStmt{Statement}$ - defines statement placeholder, matching any number of statements.</item>
+    /// <item>$stmtFoo{1, 2}$ - defines statement placeholder, matching 1 or 2 statements.</item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// Argument placeholder arguments:
+    /// <list type="bullet">
+    /// <item>minimalOccurrences - minimal number of arguments to match (-1 by default)</item>
+    /// <item>maximalOccurrences - maximal number of arguments to match (-1 by default)</item>
+    /// </list>
+    /// Examples:
+    /// <list type="bullet">
+    /// <item>$myArg{Argument, 1, 2}$ - defines argument placeholder, matching 1 or 2 arguments.</item>
+    /// <item>$myArg{Argument}$ - defines argument placeholder, matching any number of arguments.</item>
+    /// <item>$argFoo{1, 2}$ - defines argument placeholder, matching 1 or 2 arguments.</item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// Member placeholder arguments:
+    /// <list type="bullet">
+    /// <item>docId - string value in single quotes, specifies XML documentation id of the member to match (empty by default)</item>
+    /// </list>
+    /// Examples:
+    /// <list type="bullet">
+    /// <item>$myMember{Member, 'M:System.String.IsNullOrEmpty(System.String)'}$ - defines member placeholder, matching 'IsNullOrEmpty' member of the 'System.String' type.</item>
+    /// <item>$memberFoo{'M:System.String.IsNullOrEmpty(System.String)'}$ - defines member placeholder, matching 'IsNullOrEmpty' member of the 'System.String' type.</item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// For more information please refer to the <a href="https://www.jetbrains.com/help/resharper/Navigation_and_Search__Structural_Search_and_Replace.html">Structural Search and Replace</a> article.
+    /// </para>
+    /// </summary>
+    [AttributeUsage(
+        AttributeTargets.Method
+        | AttributeTargets.Constructor
+        | AttributeTargets.Property
+        | AttributeTargets.Field
+        | AttributeTargets.Event
+        | AttributeTargets.Interface
+        | AttributeTargets.Class
+        | AttributeTargets.Struct
+        | AttributeTargets.Enum,
+        AllowMultiple = true,
+        Inherited = false)]
+    public sealed class CodeTemplateAttribute : Attribute
+    {
+        public CodeTemplateAttribute(string searchTemplate)
+        {
+            SearchTemplate = searchTemplate;
+        }
+
+        /// <summary>
+        /// Structural search pattern to use in the code template.
+        /// The pattern includes a textual part, which must contain only identifiers allowed in the target language,
+        /// and placeholders, which allow matching variable parts of the target code blocks.
+        /// </summary>
+        public string SearchTemplate { get; }
+
+        /// <summary>
+        /// Message to show when the search pattern was found.
+        /// You can also prepend the message text with "Error:", "Warning:", "Suggestion:" or "Hint:" prefix to specify the pattern severity.
+        /// Code patterns with replace templates produce suggestions by default.
+        /// However, if a replace template is not provided, then warning severity will be used.
+        /// </summary>
+        public string? Message { get; set; }
+
+        /// <summary>
+        /// Structural search replace pattern to use in code template replacement.
+        /// </summary>
+        public string? ReplaceTemplate { get; set; }
+
+        /// <summary>
+        /// The replace message to show in the light bulb.
+        /// </summary>
+        public string? ReplaceMessage { get; set; }
+
+        /// <summary>
+        /// Apply code formatting after code replacement.
+        /// </summary>
+        public bool FormatAfterReplace { get; set; } = true;
+
+        /// <summary>
+        /// Whether similar code blocks should be matched.
+        /// </summary>
+        public bool MatchSimilarConstructs { get; set; }
+
+        /// <summary>
+        /// Automatically insert namespace import directives or remove qualifiers that become redundant after the template is applied.
+        /// </summary>
+        public bool ShortenReferences { get; set; }
+
+        /// <summary>
+        /// The string to use as a suppression key.
+        /// By default the following suppression key is used 'CodeTemplate_SomeType_SomeMember',
+        /// where 'SomeType' and 'SomeMember' are names of the associated containing type and member to which this attribute is applied.
+        /// </summary>
+        public string? SuppressionKey { get; set; }
+    }
 }

--- a/rd-net/Lifetimes/Serialization/UnsafeReader.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeReader.cs
@@ -105,6 +105,14 @@ namespace JetBrains.Serialization
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public sbyte ReadSByte()
+    {
+      AssertLength(sizeof(sbyte));
+
+      return (sbyte) *(myPtr++);
+    }
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public Guid ReadGuid()
     {
       var array = ReadArray(reader => reader.ReadByte());
@@ -173,12 +181,6 @@ namespace JetBrains.Serialization
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public Int16 ReadShort() //alias
-    {
-      return ReadInt16();
-    }
-
-    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public Int32 ReadInt32()
     {
       AssertLength(sizeof(Int32));
@@ -228,18 +230,6 @@ namespace JetBrains.Serialization
       var x = (Int64*)myPtr;
       myPtr = (byte*)(x + 1);
       return *x;
-    }
-
-    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public int ReadInt()
-    {
-      return ReadInt32();
-    }
-
-    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public long ReadLong()
-    {
-      return ReadInt64();
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
@@ -462,39 +452,30 @@ namespace JetBrains.Serialization
     #endregion
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public bool ReadNullness()
-    {
-      return ReadBoolean();
-    }
+    public bool ReadNullness() => ReadBoolean();
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public bool ReadBool()
-    {
-      return ReadBoolean();
-    }
+    public bool ReadBool() => ReadBoolean();
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public byte ReadUByte()
-    {
-      return ReadByte();
-    }
+    public Int16 ReadShort() => ReadInt16();
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public ushort ReadUShort()
-    {
-      return ReadUInt16();
-    }
+    public int ReadInt() => ReadInt32();
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public uint ReadUInt()
-    {
-      return ReadUInt32();
-    }
+    public long ReadLong() => ReadInt64();
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public ulong ReadULong()
-    {
-      return ReadUInt64();
-    }
+    public byte ReadUByte() => ReadByte();
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public ushort ReadUShort() => ReadUInt16();
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public uint ReadUInt() => ReadUInt32();
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public ulong ReadULong() => ReadUInt64();
   }
 }

--- a/rd-net/Lifetimes/Serialization/UnsafeReader.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeReader.cs
@@ -7,6 +7,7 @@ using JetBrains.Diagnostics;
 using JetBrains.Util;
 using JetBrains.Util.Internal;
 // ReSharper disable BuiltInTypeReferenceStyle
+// ReSharper disable ArrangeRedundantParentheses
 
 namespace JetBrains.Serialization
 {
@@ -190,36 +191,34 @@ namespace JetBrains.Serialization
       return *x;
     }
 
-    public static UInt16 ReadUInt16FromBytes(byte[] bytes)
+    public int Read7BitEncodedInt32()
     {
-      fixed (byte* bb = bytes)
+      // read out an Int32 7 bits at a time
+      var count = 0;
+      var shift = 0;
+      byte b;
+      do
       {
-        return *(UInt16*) bb;
-      }
+        if (shift == 5 * 7)
+          throw new FormatException();
+
+        b = ReadByte();
+        count |= (b & 0b1111111) << shift;
+        shift += 7;
+      } while ((b & 0b10000000) != 0);
+
+      return count;
     }
 
-    public static Int32 ReadInt32FromBytes(byte[] bytes, int offset = 0)
+    public int ReadOftenSmallPositiveInt32()
     {
-      fixed (byte* bb = bytes)
+      var byteValue = ReadByte();
+      if (byteValue == byte.MaxValue)
       {
-        return *(Int32*) (bb + offset);
+        return ReadInt32();
       }
-    }
 
-    public static Int64 ReadInt64FromBytes(byte[] bytes, int offset = 0)
-    {
-      fixed (byte* bb = bytes)
-      {
-        return *(Int64*) (bb + offset);
-      }
-    }
-
-    public static UInt64 ReadUInt64FromBytes(byte[] bytes)
-    {
-      fixed (byte* bb = bytes)
-      {
-        return *(UInt64*) bb;
-      }
+      return byteValue;
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
@@ -477,5 +476,37 @@ namespace JetBrains.Serialization
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public ulong ReadULong() => ReadUInt64();
+
+    public static UInt16 ReadUInt16FromBytes(byte[] bytes)
+    {
+      fixed (byte* bb = bytes)
+      {
+        return *(UInt16*) bb;
+      }
+    }
+
+    public static Int32 ReadInt32FromBytes(byte[] bytes, int offset = 0)
+    {
+      fixed (byte* bb = bytes)
+      {
+        return *(Int32*) (bb + offset);
+      }
+    }
+
+    public static Int64 ReadInt64FromBytes(byte[] bytes, int offset = 0)
+    {
+      fixed (byte* bb = bytes)
+      {
+        return *(Int64*) (bb + offset);
+      }
+    }
+
+    public static UInt64 ReadUInt64FromBytes(byte[] bytes)
+    {
+      fixed (byte* bb = bytes)
+      {
+        return *(UInt64*) bb;
+      }
+    }
   }
 }

--- a/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
@@ -8,6 +8,7 @@ using JetBrains.Diagnostics;
 using JetBrains.Util;
 using JetBrains.Util.Internal;
 // ReSharper disable BuiltInTypeReferenceStyle
+// ReSharper disable ArrangeRedundantParentheses
 
 namespace JetBrains.Serialization
 {
@@ -457,6 +458,33 @@ namespace JetBrains.Serialization
       var x = (Int32*)myPtr;
       myPtr = (byte*)(x + 1);
       *x = value;
+    }
+
+    public void Write7BitEncodedInt32(int value)
+    {
+      // write out an int 7 bits at a time
+      var v = (uint)value;
+
+      while (v >= 0b10000000)
+      {
+        WriteByte((byte)(v | 0b10000000));
+        v >>= 7;
+      }
+
+      WriteByte((byte)v);
+    }
+
+    public void WriteOftenSmallPositiveInt32(int value)
+    {
+      if (value >= 0 & value < byte.MaxValue)
+      {
+        WriteByte((byte) value);
+      }
+      else
+      {
+        WriteByte(byte.MaxValue);
+        WriteInt32(value);
+      }
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]

--- a/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
@@ -119,12 +119,25 @@ namespace JetBrains.Serialization
       /// </summary>
       public void WriteIntLength()
       {
-        *(int*) Data = myWriter.Count - myStart - sizeof(int);
+        *((int*)Data) = myWriter.Count - myStart - sizeof(int);
       }
 
       public void WriteIntLength(int length)
       {
-        *(int*) Data = length;
+        *((int*)Data) = length;
+      }
+
+      public void FinishRawWrite(int bytesWritten)
+      {
+        if (bytesWritten <= 0)
+          throw new ArgumentOutOfRangeException(nameof(bytesWritten));
+
+        var finalPtr = myWriter.myStartPtr + myStart + bytesWritten;
+        if (myWriter.myPtr <= finalPtr)
+          throw new ArgumentOutOfRangeException(nameof(bytesWritten), "Overflow, allocation is smaller then bytes written");
+
+        myWriter.myPtr = finalPtr;
+        myWriter.myCount = myStart + bytesWritten;
       }
     }
 

--- a/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
@@ -332,54 +332,139 @@ namespace JetBrains.Serialization
 
     #region Primitive writers
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteBool() instead",
+      ReplaceTemplate = "$qualifier$.WriteBoolean($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(bool value) => WriteBoolean(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteByte() instead",
+      ReplaceTemplate = "$qualifier$.WriteByte($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(byte value) => WriteByte(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteGuid() instead",
+      ReplaceTemplate = "$qualifier$.WriteGuid($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(Guid value) => WriteGuid(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteChar() instead",
+      ReplaceTemplate = "$qualifier$.WriteChar($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(char value) => WriteChar(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteDecimal() instead",
+      ReplaceTemplate = "$qualifier$.WriteDecimal($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(decimal value) => WriteDecimal(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteDouble() instead",
+      ReplaceTemplate = "$qualifier$.WriteDouble($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(double value) => WriteDouble(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteFloat() instead",
+      ReplaceTemplate = "$qualifier$.WriteFloat($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(float value) => WriteFloat(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteInt16() instead",
+      ReplaceTemplate = "$qualifier$.WriteInt16($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(Int16 value) => WriteInt16(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteInt32() instead",
+      ReplaceTemplate = "$qualifier$.WriteInt32($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(Int32 value) => WriteInt32(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteInt64() instead",
+      ReplaceTemplate = "$qualifier$.WriteInt64($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(Int64 value) => WriteInt64(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteUInt16() instead",
+      ReplaceTemplate = "$qualifier$.WriteUInt16($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(UInt16 value) => WriteUint16(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteUInt32() instead",
+      ReplaceTemplate = "$qualifier$.WriteUInt32($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(UInt32 value) => WriteUInt32(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteUInt64() instead",
+      ReplaceTemplate = "$qualifier$.WriteUInt64($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(UInt64 value) => WriteUint64(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteDateTime() instead",
+      ReplaceTemplate = "$qualifier$.WriteDateTime($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(DateTime value) => WriteDateTime(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteTimeSpan() instead",
+      ReplaceTemplate = "$qualifier$.WriteTimeSpan($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(TimeSpan value) => WriteTimeSpan(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteUri() instead",
+      ReplaceTemplate = "$qualifier$.WriteUri($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(Uri value) => WriteUri(value);
 
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteString() instead",
+      ReplaceTemplate = "$qualifier$.WriteString($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public void Write(string? value) => WriteString(value);
 
@@ -677,7 +762,21 @@ namespace JetBrains.Serialization
     #endregion
     #region Collection writers
 
-    public void Write(int[]? value)
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteArray() instead",
+      ReplaceTemplate = "$qualifier$.WriteArray($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
+    public void Write(int[]? value) => WriteArray(value);
+
+    [CodeTemplate(
+      searchTemplate: "$member$($arg$)",
+      Message = "HINT: Use WriteByteArray() instead",
+      ReplaceTemplate = "$qualifier$.WriteByteArray($arg$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
+    public void Write(byte[]? value) => WriteByteArray(value);
+
+    public void WriteArray(int[]? value)
     {
       if (value == null)
       {
@@ -693,7 +792,7 @@ namespace JetBrains.Serialization
       }
     }
 
-    public void Write(byte[]? value)
+    public void WriteByteArray(byte[]? value)
     {
       if (value == null)
       {
@@ -756,10 +855,19 @@ namespace JetBrains.Serialization
       return result;
     }
 
+    [CodeTemplate(
+      searchTemplate: "$member$($args$)",
+      Message = "HINT: Use WriteCollection() instead",
+      ReplaceTemplate = "$qualifier$.WriteCollection($args$)",
+      SuppressionKey = "UnsafeWriter_ExplicitApi")]
+    public void Write<T, TCollection>(WriteDelegate<T> writeDelegate, TCollection? value)
+      where TCollection : ICollection<T>
+      => WriteCollection(writeDelegate, value);
+
     /// <summary>
     /// Non optimal collection serialization. You can serialize internal structure (eg. array) instead.
     /// </summary>
-    public void Write<T, TCollection>(WriteDelegate<T> writeDelegate, TCollection? value)
+    public void WriteCollection<T, TCollection>(WriteDelegate<T> writeDelegate, TCollection? value)
       where TCollection : ICollection<T>
     {
       if (value == null)

--- a/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
@@ -319,27 +319,85 @@ namespace JetBrains.Serialization
     #region Primitive writers
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(bool value)
+    public void Write(bool value) => WriteBoolean(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(byte value) => WriteByte(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(Guid value) => WriteGuid(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(char value) => WriteChar(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(decimal value) => WriteDecimal(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(double value) => WriteDouble(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(float value) => WriteFloat(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(Int16 value) => WriteInt16(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(Int32 value) => WriteInt32(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(Int64 value) => WriteInt64(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(UInt16 value) => WriteUint16(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(UInt32 value) => WriteUInt32(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(UInt64 value) => WriteUint64(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(DateTime value) => WriteDateTime(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(TimeSpan value) => WriteTimeSpan(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(Uri value) => WriteUri(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void Write(string? value) => WriteString(value);
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void WriteBoolean(bool value)
     {
       Prepare(sizeof(byte));
       *(myPtr++) = (byte)(value ? 1 : 0);
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(byte value)
+    public void WriteByte(byte value)
     {
       Prepare(sizeof(byte));
       *(myPtr++) = value;
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(Guid value)
+    public void WriteSByte(sbyte value)
+    {
+      Prepare(sizeof(sbyte));
+      *(myPtr++) = (byte) value;
+    }
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    public void WriteGuid(Guid value)
     {
       Write<byte, byte[]>((writer, b) => writer.Write(b), value.ToByteArray());
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(char value)
+    public void WriteChar(char value)
     {
       Prepare(sizeof(char));
       var x = (char*)myPtr;
@@ -348,7 +406,7 @@ namespace JetBrains.Serialization
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(decimal value)
+    public void WriteDecimal(decimal value)
     {
       Prepare(sizeof(decimal));
       var x = (decimal*)myPtr;
@@ -357,7 +415,7 @@ namespace JetBrains.Serialization
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(double value)
+    public void WriteDouble(double value)
     {
       Prepare(sizeof(double));
       var x = (double*)myPtr;
@@ -375,7 +433,7 @@ namespace JetBrains.Serialization
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(float value)
+    public void WriteFloat(float value)
     {
       Prepare(sizeof(float));
       var x = (float*)myPtr;
@@ -384,7 +442,7 @@ namespace JetBrains.Serialization
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(Int16 value)
+    public void WriteInt16(Int16 value)
     {
       Prepare(sizeof(Int16));
       var x = (Int16*)myPtr;
@@ -393,7 +451,7 @@ namespace JetBrains.Serialization
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(Int32 value)
+    public void WriteInt32(Int32 value)
     {
       Prepare(sizeof(Int32));
       var x = (Int32*)myPtr;
@@ -409,7 +467,7 @@ namespace JetBrains.Serialization
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(Int64 value)
+    public void WriteInt64(Int64 value)
     {
       Prepare(sizeof(Int64));
       var x = (Int64*)myPtr;
@@ -418,7 +476,7 @@ namespace JetBrains.Serialization
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(UInt16 value)
+    public void WriteUint16(UInt16 value)
     {
       Prepare(sizeof(UInt16));
       var x = (UInt16*)myPtr;
@@ -427,7 +485,7 @@ namespace JetBrains.Serialization
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(UInt32 value)
+    public void WriteUInt32(UInt32 value)
     {
       Prepare(sizeof(UInt32));
       var x = (UInt32*)myPtr;
@@ -436,7 +494,7 @@ namespace JetBrains.Serialization
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(UInt64 value)
+    public void WriteUint64(UInt64 value)
     {
       Prepare(sizeof(UInt64));
       var x = (UInt64*)myPtr;
@@ -445,7 +503,7 @@ namespace JetBrains.Serialization
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(DateTime value)
+    public void WriteDateTime(DateTime value)
     {
       if (Mode.IsAssertion) Assertion.Assert(value.Kind != DateTimeKind.Local, "Use UTC time");
 
@@ -453,19 +511,19 @@ namespace JetBrains.Serialization
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(TimeSpan value)
+    public void WriteTimeSpan(TimeSpan value)
     {
       Write(value.Ticks);
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(Uri value)
+    public void WriteUri(Uri value)
     {
       Write(Uri.EscapeUriString(value.OriginalString));
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
-    public void Write(string? value)
+    public void WriteString(string? value)
     {
       if (value == null) Write(-1);
       else


### PR DESCRIPTION
* UnsafeWriter: introduce `WriteInt32()`-like APIs instead of one highly-overloaded single `Write()` method to avoid bugs annoying in serializers when you accidentally choose wrong overload (for example, expect to serialize some byte-sized value, while `Write(0)` invocation actually writes 4 bytes through `Int32` overload). Those APIs also mirror `UnsafeReader` API surface. I've introduced [CodeTemplate] migrators to simplify the migrations. Binary compatibility is preserved.
* UnsafeWriter: add new API to have the ability to allocate some amount of memory and write less than this amount through raw pointer - useful to allow string serialization with custom encoding (see new test).
* UnsafeWriter/UnsafeReader: two new APIs to read/write compressed Int32 values
* Get rid of unnecessary `AggressiveInlining` usage
* Fix warnings and cleanup the code