### PR TITLE
Fix already bound assert for extensions

### DIFF
--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
@@ -74,6 +74,11 @@ abstract class RdExtBase : RdReactiveBase() {
 
         //todo make it smarter
         for ((name, child) in bindableChildren) {
+            if (child is RdExtBase && child.parent == this) {
+                // Extensions can be created from extension listener above, in submitExtCreated,
+                // and they will be already bound at this point, so we should skip them
+                continue
+            }
             if (child is RdPropertyBase<*> && child.defaultValueChanged) {
                 child.localChange {
                     child.bind(lifetime, this, name)


### PR DESCRIPTION
There is a following scenario:
1. `SomeModel: RdExtBase` is created on one side of a protocol
2. On the other side 1ProtocolExtListenerManager1 creates and binds this extension
3. In `RdExtBase.init > Protocol.submitExtCreated` all listeners are invoked
4. One of the listeners invokes `SomeModel.getOrCreateExtension("mySubModel")`
5. This sub-extension is created and bound
6. When all listeners are invoked, `RdExtBase.init` continues and tries to bind all its `bindableChildren`
7. Sub-extension is already there and is already bound => we get a failed assert about binding already bound model

To fix this case, we can check that an extension is already bound and bound to us as a parent. Then we have no need to bind it again.