### PR TITLE
Replace BitHacks.Log2 with implementation based on de Bruijn sequence

### DIFF
--- a/rd-net/Lifetimes/Util/BitHacks.cs
+++ b/rd-net/Lifetimes/Util/BitHacks.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace JetBrains.Util
 {
@@ -8,18 +9,27 @@ namespace JetBrains.Util
   
   public static class BitHacks
   {
-    private static readonly int[] ourLogFloor2Lookup = new int[256];
+    // de Bruijn multiplication, see http://supertech.csail.mit.edu/papers/debruijn.pdf
+    private const uint DeBruijnSequence32 = 0x07C4ACDD;
+    private const ulong DeBruijnSequence64 = 0x03F79D71B4CB0A89;
 
-    static BitHacks()
-    {
-      ourLogFloor2Lookup[0] = 0;
+    private static readonly byte[] ourDeBruijnBitTable32 = {
+      0, 9, 1, 10, 13, 21, 2, 29,
+      11, 14, 16, 18, 22, 25, 3, 30,
+      8, 12, 20, 28, 15, 17, 24, 7,
+      19, 27, 23, 6, 26, 5, 4, 31
+    };
 
-      for (int i = 0; i < 8; i++)
-      {
-        for (int j = 1 << i; j < 1 << (i + 1); j++)
-          ourLogFloor2Lookup[j] = i;
-      }
-    }
+    private static readonly byte[] ourDeBruijnBitTable64 = {
+      0, 47, 1, 56, 48, 27, 2, 60,
+      57, 49, 41, 37, 28, 16, 3, 61,
+      54, 58, 35, 52, 50, 42, 21, 44,
+      38, 32, 29, 23, 17, 11, 4, 62,
+      46, 55, 26, 59, 40, 36, 15, 53,
+      34, 51, 20, 43, 31, 22, 10, 45,
+      25, 39, 14, 33, 19, 30, 9, 24,
+      13, 18, 8, 12, 7, 6, 5, 63
+    };
 
     /// <summary>
     /// Returns largest non-negative integer <c>y</c> such that <c>2^y&lt;=x</c> if <c>x&gt;0</c>, <c>0</c> if <c>x=0</c>, or throw ArgumentException if <c>x&lt;0</c> 
@@ -29,21 +39,33 @@ namespace JetBrains.Util
     public static int Log2Floor(int x)
     {
       if (x < 0) throw new ArgumentException("x must be greater than 0");
-      
-      if (x >= 1 << 16)
-      {
-        if (x >= 1 << 24) 
-          return 24 + ourLogFloor2Lookup[x >> 24];
-        else 
-          return 16 + ourLogFloor2Lookup[x >> 16];
-      }
-      else
-      {
-        if (x >= 1 << 8) 
-          return 8 + ourLogFloor2Lookup[x >> 8];
-        else 
-          return ourLogFloor2Lookup[x];
-      }
+      return ReverseBitScan((uint)x);
+    }
+
+    /// <summary>
+    /// Returns largest non-negative integer <c>y</c> such that <c>2^y&lt;=x</c> if <c>x&gt;0</c>, <c>0</c> if <c>x=0</c>, or throw ArgumentException if <c>x&lt;0</c> 
+    /// </summary>
+    /// <param name="x">Must be greater than or equal to zero.</param>
+    /// <returns><c>y : 2^y&lt;=x</c></returns>
+    public static int Log2Floor(long x)
+    {
+      if (x < 0) throw new ArgumentException("x must be greater than 0");
+      return ReverseBitScan((ulong)x);
+    }
+
+    
+    /// <summary>
+    /// Returns lowest non-negative integer <c>y</c> such that <c>2^y&gt;=x</c> if <c>x&gt;=0</c> or throw ArgumentException if <c>x&lt;0</c> 
+    /// </summary>
+    /// <param name="x">Must be greater than or equal to zero.</param>    
+    /// <returns><c>y : 2^y&gt;=x</c></returns>    
+    public static int Log2Ceil(int x)
+    {      
+      if (x < 0) throw new ArgumentException("x must be greater than 0");
+      if (x == 0) return 0;
+      var log2Floor = ReverseBitScan((uint)x);
+      if (1U << log2Floor == (uint)x) return log2Floor;
+      return log2Floor + 1;
     }
 
     /// <summary>
@@ -54,13 +76,10 @@ namespace JetBrains.Util
     public static int Log2Ceil(long x)
     {      
       if (x < 0) throw new ArgumentException("x must be greater than 0");
-      
-      //Current implementation is suboptimal. Make it faster if you need more performance.
-      for (int i=0; i<62; i++)
-        if (1 << i >= x)
-          return i;
-      
-      return 63;
+      if (x == 0) return 0;
+      var log2Floor = ReverseBitScan((ulong)x);
+      if (1UL << log2Floor == (ulong)x) return log2Floor;
+      return log2Floor + 1;
     }
 
     /// <summary>
@@ -76,6 +95,29 @@ namespace JetBrains.Util
         x = (x & 0x33333333) + ((x >> 2) & 0x33333333); 
         return ((x + (x >> 4) & 0xF0F0F0F) * 0x1010101) >> 24;
       }
+    }
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    private static int ReverseBitScan(uint value)
+    {
+      value |= value >> 1;
+      value |= value >> 2;
+      value |= value >> 4;
+      value |= value >> 8;
+      value |= value >> 16;
+      return ourDeBruijnBitTable32[(int) ((value * DeBruijnSequence32) >> 27)];
+    }
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    private static int ReverseBitScan(ulong value)
+    {
+      value |= value >> 1;
+      value |= value >> 2;
+      value |= value >> 4;
+      value |= value >> 8;
+      value |= value >> 16;
+      value |= value >> 32;
+      return ourDeBruijnBitTable64[(int) ((value * DeBruijnSequence64) >> 58)];
     }
   }
 }

--- a/rd-net/Lifetimes/Util/BitHacks.cs
+++ b/rd-net/Lifetimes/Util/BitHacks.cs
@@ -100,24 +100,30 @@ namespace JetBrains.Util
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     private static int ReverseBitScan(uint value)
     {
-      value |= value >> 1;
-      value |= value >> 2;
-      value |= value >> 4;
-      value |= value >> 8;
-      value |= value >> 16;
-      return ourDeBruijnBitTable32[(int) ((value * DeBruijnSequence32) >> 27)];
+      unchecked
+      {
+        value |= value >> 1;
+        value |= value >> 2;
+        value |= value >> 4;
+        value |= value >> 8;
+        value |= value >> 16;
+        return ourDeBruijnBitTable32[(int) ((value * DeBruijnSequence32) >> 27)];
+      }
     }
 
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     private static int ReverseBitScan(ulong value)
     {
-      value |= value >> 1;
-      value |= value >> 2;
-      value |= value >> 4;
-      value |= value >> 8;
-      value |= value >> 16;
-      value |= value >> 32;
-      return ourDeBruijnBitTable64[(int) ((value * DeBruijnSequence64) >> 58)];
+      unchecked
+      {
+        value |= value >> 1;
+        value |= value >> 2;
+        value |= value >> 4;
+        value |= value >> 8;
+        value |= value >> 16;
+        value |= value >> 32;
+        return ourDeBruijnBitTable64[(int) ((value * DeBruijnSequence64) >> 58)];
+      }
     }
   }
 }

--- a/rd-net/Test.Lifetimes/Utils/BitHacksTest.cs
+++ b/rd-net/Test.Lifetimes/Utils/BitHacksTest.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using JetBrains.Util;
+using NUnit.Framework;
+
+namespace Test.Lifetimes.Utils
+{
+  public class BitHacksTest
+  {
+    [TestCase(0, 0)]
+    [TestCase(1, 0)]
+    [TestCase(2, 1)]
+    [TestCase(3, 1)]
+    [TestCase(4, 2)]
+    [TestCase(5, 2)]
+    [TestCase(7, 2)]
+    [TestCase(8, 3)]
+    [TestCase(9, 3)]
+    [TestCase(15, 3)]
+    [TestCase(16, 4)]
+    [TestCase(byte.MaxValue, 7)]
+    [TestCase(ushort.MaxValue, 15)]
+    public static void Log2FloorInt32(int n, int expected)
+    {
+      int actual = BitHacks.Log2Floor(n);
+      Assert.AreEqual(expected, actual);
+    }
+
+    [TestCase(0, 0)]
+    [TestCase(1, 0)]
+    [TestCase(2, 1)]
+    [TestCase(3, 1)]
+    [TestCase(4, 2)]
+    [TestCase(5, 2)]
+    [TestCase(7, 2)]
+    [TestCase(8, 3)]
+    [TestCase(9, 3)]
+    [TestCase(15, 3)]
+    [TestCase(16, 4)]
+    [TestCase(byte.MaxValue, 7)]
+    [TestCase(ushort.MaxValue, 15)]
+    [TestCase(uint.MaxValue, 31)]
+    public static void Log2FloorInt64(long n, int expected)
+    {
+      int actual = BitHacks.Log2Floor(n);
+      Assert.AreEqual(expected, actual);
+    }
+
+    [TestCase(0, 0)]
+    [TestCase(1, 0)]
+    [TestCase(2, 1)]
+    [TestCase(3, 2)]
+    [TestCase(4, 2)]
+    [TestCase(5, 3)]
+    [TestCase(7, 3)]
+    [TestCase(8, 3)]
+    [TestCase(9, 4)]
+    [TestCase(15, 4)]
+    [TestCase(16, 4)]
+    [TestCase(byte.MaxValue, 8)]
+    [TestCase(ushort.MaxValue, 16)]
+    public static void Log2CeilInt32(int n, int expected)
+    {
+      int actual = BitHacks.Log2Ceil(n);
+      Assert.AreEqual(expected, actual);
+    }
+
+    [TestCase(0, 0)]
+    [TestCase(1, 0)]
+    [TestCase(2, 1)]
+    [TestCase(3, 2)]
+    [TestCase(4, 2)]
+    [TestCase(5, 3)]
+    [TestCase(7, 3)]
+    [TestCase(8, 3)]
+    [TestCase(9, 4)]
+    [TestCase(15, 4)]
+    [TestCase(16, 4)]
+    [TestCase(byte.MaxValue, 8)]
+    [TestCase(ushort.MaxValue, 16)]
+    [TestCase(uint.MaxValue, 32)]
+    public static void Log2CeilInt64(long n, int expected)
+    {
+      int actual = BitHacks.Log2Ceil(n);
+      Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public static void ThrowsOnNegativeArgument()
+    {
+      Assert.Throws<ArgumentException>(() => BitHacks.Log2Floor(-1));
+      Assert.Throws<ArgumentException>(() => BitHacks.Log2Floor(-1L));
+      Assert.Throws<ArgumentException>(() => BitHacks.Log2Ceil(-1));
+      Assert.Throws<ArgumentException>(() => BitHacks.Log2Ceil(-1L));
+    }
+  }
+}


### PR DESCRIPTION
Replace implementation of `BitHacks.Log2Floor` and `BitHacks.Log2Ceil` with more bit-hacky *de Bruijn multiplication*.
- smaller precomputed tables
- less instruction branching
- some test coverage

Further optimizations are possible:
- read precomputed table directly from assembly data without allocations (Requires `ReadOnlySpan<byte>` support, see https://github.com/dotnet/roslyn/pull/24621)
- use platform intrinsics (Requires runtime support), so software implementation can be replaced with hardware instruction (e.g. `Log2`, `LeadingZeroCount`, `BitScanReverse`, `MostSignificantBit`...)
 