### PR TITLE
Short circuit RdCall on stub wires

### DIFF
--- a/rd-net/RdFramework/Base/RdExtBase.cs
+++ b/rd-net/RdFramework/Base/RdExtBase.cs
@@ -189,7 +189,7 @@ namespace JetBrains.Rd.Base
     
     private readonly Queue<QueueItem> mySendQ = new Queue<QueueItem>();
 
-    public bool IsStub => false;
+    public bool IsStub => RealWire.IsStub;
 
     public ProtocolContexts Contexts
     {


### PR DESCRIPTION
For local protocol it would be convenient if RdCall worked like other primitives, e.g. synchronously call all classes which have been subscribed to events.