### PR TITLE
(RSRP-489331) Build: remove workaround for a fixed issue in the inspection

### DIFF
--- a/rd-net/Directory.Build.props
+++ b/rd-net/Directory.Build.props
@@ -20,8 +20,7 @@
     <Nullable Condition="'$(Nullable)' == ''">enable</Nullable>
 
     <DefineConstants>JET_MODE_ASSERT</DefineConstants>
-    <!-- TODO: CS8632 is redundant here but added to suppress inspections in ReSharper/Rider, see RSRP-489331 -->
-    <NoWarn Condition="'$(TargetFramework)' == 'net35'">nullable;CS8632</NoWarn>
+    <NoWarn Condition="'$(TargetFramework)' == 'net35'">nullable</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Condition="'$(TargetFramework)' == 'net472'" Version="1.0.3">


### PR DESCRIPTION
Since [RSRP-489331](https://youtrack.jetbrains.com/issue/RSRP-489331) is fixed in the latest builds of ReSharper/Rider, we no longer need this workaround.