### PR TITLE
CI: enable Gradle Wrapper validation

### DIFF
--- a/.github/workflows/build-rd-kt.yml
+++ b/.github/workflows/build-rd-kt.yml
@@ -41,3 +41,9 @@ jobs:
       with:
         name: tests-log.${{ runner.os }}
         path: "**/reports/*"
+  validation:
+    runs-on: ubuntu-22.04
+    name: "Validate Gradle wrapper"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
Read more [here](https://github.com/gradle/wrapper-validation-action): this will prevent pull requests from tampering with Gradle wrapper.