### PR TITLE
Pack of RD lifetimes fixes + auto-binding for task results

### DIFF
--- a/rd-cpp/src/rd_core_cpp/src/main/CMakeLists.txt
+++ b/rd-cpp/src/rd_core_cpp/src/main/CMakeLists.txt
@@ -37,6 +37,7 @@ set(RD_CORE_CPP_SOURCES
         #pch
         ${PCH_CPP_OPT}
         util/export_api_helper.h
+        util/lifetime_util.h
 )
 
 if (RD_STATIC)

--- a/rd-cpp/src/rd_core_cpp/src/main/lifetime/Lifetime.cpp
+++ b/rd-cpp/src/rd_core_cpp/src/main/lifetime/Lifetime.cpp
@@ -37,6 +37,19 @@ Lifetime const& Lifetime::Eternal()
 	return ETERNAL;
 }
 
+
+Lifetime const& Lifetime::Terminated()
+{
+	static Lifetime TERMINATED = []
+	{
+		Lifetime lifetime;
+		lifetime->terminate();
+		return lifetime;
+	}();
+
+	return TERMINATED;
+}
+
 bool operator==(Lifetime const& lw1, Lifetime const& lw2)
 {
 	return lw1.ptr == lw2.ptr;

--- a/rd-cpp/src/rd_core_cpp/src/main/lifetime/Lifetime.h
+++ b/rd-cpp/src/rd_core_cpp/src/main/lifetime/Lifetime.h
@@ -35,7 +35,10 @@ private:
 	std::shared_ptr<LifetimeImpl> ptr;
 
 public:
+	typedef LifetimeImpl::counter_t counter_t;
+
 	static Lifetime const& Eternal();
+	static Lifetime const& Terminated();
 
 	// region ctor/dtor
 

--- a/rd-cpp/src/rd_core_cpp/src/main/lifetime/LifetimeDefinition.cpp
+++ b/rd-cpp/src/rd_core_cpp/src/main/lifetime/LifetimeDefinition.cpp
@@ -4,7 +4,7 @@
 
 namespace rd
 {
-LifetimeDefinition::LifetimeDefinition(bool eternaled) : eternaled(eternaled), lifetime(eternaled)
+LifetimeDefinition::LifetimeDefinition(bool eternaled) : lifetime(eternaled)
 {
 }
 
@@ -18,7 +18,7 @@ bool LifetimeDefinition::is_terminated() const
 	return lifetime->is_terminated();
 }
 
-void LifetimeDefinition::terminate()
+void LifetimeDefinition::terminate() const
 {
 	lifetime->terminate();
 }

--- a/rd-cpp/src/rd_core_cpp/src/main/lifetime/LifetimeDefinition.h
+++ b/rd-cpp/src/rd_core_cpp/src/main/lifetime/LifetimeDefinition.h
@@ -19,9 +19,6 @@ class RD_CORE_API LifetimeDefinition
 {
 private:
 	friend class SequentialLifetimes;
-
-	bool eternaled = false;
-
 public:
 	Lifetime lifetime;
 
@@ -39,14 +36,13 @@ public:
 
 	virtual ~LifetimeDefinition();
 
-	//    static std::shared_ptr<LifetimeDefinition> eternal;
 	static std::shared_ptr<LifetimeDefinition> get_shared_eternal();
 
 	bool is_terminated() const;
 
 	bool is_eternal() const;
 
-	void terminate();
+	void terminate() const;
 
 	template <typename F>
 	static auto use(F&& block) -> typename util::result_of_t<F(Lifetime)>

--- a/rd-cpp/src/rd_core_cpp/src/main/lifetime/LifetimeImpl.h
+++ b/rd-cpp/src/rd_core_cpp/src/main/lifetime/LifetimeImpl.h
@@ -22,7 +22,7 @@ class RD_CORE_API LifetimeImpl final
 {
 public:
 	friend class LifetimeDefinition;
-
+	friend class SequentialLifetimes;
 	friend class Lifetime;
 
 	using counter_t = int32_t;

--- a/rd-cpp/src/rd_core_cpp/src/main/lifetime/LifetimeImpl.h
+++ b/rd-cpp/src/rd_core_cpp/src/main/lifetime/LifetimeImpl.h
@@ -75,6 +75,37 @@ public:
 		actions.erase(i);
 	}
 
+
+	// Attach pointer to lifetime. It guarantee that pointer will survive at least lifetime duration.
+	template <typename T, typename ...Args>
+	std::shared_ptr<T> make_attached(Args... args)
+	{
+		auto ptr = std::make_shared<T>(std::forward<Args>(args)...);
+		attach(ptr);
+		return ptr;
+	}
+
+	/// \brief Attach pointer to lifetime. Guarantees that pointer will survive at least lifetime duration.
+	template <typename T>
+	counter_t attach(std::shared_ptr<T> pointer)
+	{
+		// No-op structure wich acts as an action, but preserves pointer until lifetime terminated
+		struct holder
+		{
+			std::shared_ptr<T> pointer;
+
+			explicit holder(const std::shared_ptr<T>& pointer) : pointer(pointer)
+			{
+			}
+
+			void operator()() const
+			{
+			}
+		};
+
+		return add_action(holder(pointer));
+	}
+
 #if __cplusplus >= 201703L
 	static inline counter_t get_id = 0;
 #else

--- a/rd-cpp/src/rd_core_cpp/src/main/lifetime/SequentialLifetimes.h
+++ b/rd-cpp/src/rd_core_cpp/src/main/lifetime/SequentialLifetimes.h
@@ -12,9 +12,9 @@ namespace rd
 {
 class RD_CORE_API SequentialLifetimes
 {
-private:
-	std::shared_ptr<LifetimeDefinition> current_def = LifetimeDefinition::get_shared_eternal();
 	Lifetime parent_lifetime;
+	Lifetime current_lifetime = Lifetime::Terminated();
+	void set_current_lifetime(const Lifetime& lifetime);
 
 public:
 	// region ctor/dtor
@@ -28,7 +28,7 @@ public:
 
 	SequentialLifetimes& operator=(SequentialLifetimes&&) = delete;
 
-	explicit SequentialLifetimes(Lifetime parent_lifetime);
+	explicit SequentialLifetimes(const Lifetime& parent_lifetime);
 	// endregion
 
 	Lifetime next();
@@ -36,8 +36,6 @@ public:
 	void terminate_current();
 
 	bool is_terminated() const;
-
-	void set_current_lifetime(std::shared_ptr<LifetimeDefinition> new_def);
 };
 }	 // namespace rd
 

--- a/rd-cpp/src/rd_core_cpp/src/main/util/lifetime_util.h
+++ b/rd-cpp/src/rd_core_cpp/src/main/util/lifetime_util.h
@@ -1,0 +1,37 @@
+#ifndef LIFETIME_UTIL_H
+#define LIFETIME_UTIL_H
+
+#include <memory>
+#include "../lifetime/LifetimeDefinition.h"
+
+namespace rd
+{
+namespace util
+{
+/// \brief Attaches lifetime to shared_ptr. Lifetime terminates when shared_ptr destructed.
+/// \param original original pointer which will be used to make a new pointer with lifetime.
+/// \param lifetime_definition Lifetime definition associated with returned shared_ptr.
+/// \return New shared_ptr which owns lifetime_definition and terminates that lifetime when destroyed.
+template <typename T>
+static std::shared_ptr<T> attach_lifetime(std::shared_ptr<T> original, LifetimeDefinition lifetime_definition)
+{
+	struct Deleter
+	{
+		std::shared_ptr<T> ptr;
+		LifetimeDefinition lifetime_definition;
+
+		explicit Deleter(LifetimeDefinition&& lifetime_definition, std::shared_ptr<T> ptr) : ptr(std::move(ptr)), lifetime_definition(std::move(lifetime_definition)) { }
+
+		void operator()(T*) const
+		{
+		}
+	};
+
+	auto raw_ptr = original.get();
+	auto deleter = Deleter(std::move(lifetime_definition), std::move(original));
+	return std::shared_ptr<T>(raw_ptr, std::move(deleter));
+}
+}
+}
+
+#endif //LIFETIME_UTIL_H

--- a/rd-cpp/src/rd_framework_cpp/src/main/protocol/MessageBroker.cpp
+++ b/rd-cpp/src/rd_framework_cpp/src/main/protocol/MessageBroker.cpp
@@ -143,4 +143,9 @@ void MessageBroker::advise_on(Lifetime lifetime, RdReactiveBase const* entity) c
 		lifetime->add_action([this, key]() { subscriptions.erase(key); });
 	}
 }
+
+bool MessageBroker::is_subscribed(const RdId id) const
+{
+	return subscriptions.find(id) != subscriptions.end();
+}
 }	 // namespace rd

--- a/rd-cpp/src/rd_framework_cpp/src/main/protocol/MessageBroker.h
+++ b/rd-cpp/src/rd_framework_cpp/src/main/protocol/MessageBroker.h
@@ -59,6 +59,8 @@ public:
 	void dispatch(RdId id, Buffer message) const;
 
 	void advise_on(Lifetime lifetime, RdReactiveBase const* entity) const;
+
+	bool is_subscribed(const RdId id) const;
 };
 }	 // namespace rd
 

--- a/rd-cpp/src/rd_framework_cpp/src/main/task/RdEndpoint.h
+++ b/rd-cpp/src/rd_framework_cpp/src/main/task/RdEndpoint.h
@@ -3,9 +3,92 @@
 
 #include "serialization/Polymorphic.h"
 #include "RdTask.h"
+#include "framework_traits.h"
 
 namespace rd
 {
+namespace detail
+{
+/// \brief For bindable result
+template <typename>
+class RdEndpointWiredResult;
+
+template <typename T>
+class RdEndpointWiredResult<Wrapper<T>> final : public RdReactiveBase
+{
+	friend class EndpointWiredRdTask;
+
+	LifetimeDefinition result_lifetime_def;
+	Wrapper<T> value;
+public:
+	explicit RdEndpointWiredResult(LifetimeDefinition result_lifetime_def, const Wrapper<T>& value) : result_lifetime_def(std::move(result_lifetime_def)), value(value)
+	{
+	}
+
+	RdEndpointWiredResult(const RdEndpointWiredResult&) = delete;				// non construction-copyable
+	RdEndpointWiredResult& operator=(const RdEndpointWiredResult&) = delete;	// non copyable
+
+	void init(const Lifetime lifetime) const override
+	{
+		RdReactiveBase::init(lifetime);
+		get_wire()->advise(lifetime, this);
+	}
+
+	void bind(const Lifetime lf, IRdDynamic const* parent, string_view name) const override
+	{
+		RdReactiveBase::bind(lf, parent, name);
+		value->bind(lf, this, "Value");
+	}
+
+	void identify(Identities const& identities, RdId const& id) const override
+	{
+		RdReactiveBase::identify(identities, id);
+		value->identify(identities, id.mix("Value"));
+	}
+
+	void on_wire_received(Buffer buffer) const override
+	{
+		spdlog::get("logReceived")->trace("received cancellation");
+
+		//nothing just a void value
+
+		get_wire_scheduler()->invoke_or_queue([this] { result_lifetime_def.terminate(); });
+	}
+};
+
+template <typename T, typename S>
+class RdEndpointTaskCancellation : public RdReactiveBase
+{
+	using Task = RdTask<T, S>;
+
+	Task task;
+
+public:
+	explicit RdEndpointTaskCancellation(Task task) : task(task)
+	{
+	}
+
+	RdEndpointTaskCancellation(const RdEndpointTaskCancellation&) = delete;				// non construction-copyable
+	RdEndpointTaskCancellation& operator=(const RdEndpointTaskCancellation&) = delete;	// non copyable
+
+	void init(const Lifetime lifetime) const override
+	{
+		RdReactiveBase::init(lifetime);
+		get_wire()->advise(lifetime, this);
+	}
+
+	void on_wire_received(Buffer buffer) const override
+	{
+		spdlog::get("logReceived")->trace("received cancellation");
+
+		//nothing just a void value
+
+		get_wire_scheduler()->invoke_or_queue([this] { task.set_result_if_empty(typename Task::result_type::Cancelled()); });
+	}
+};
+
+}
+
 /**
  * \brief An API that is exposed to the remote process and can be invoked over the protocol.
  *
@@ -19,11 +102,88 @@ class RdEndpoint : public virtual RdReactiveBase, public ISerializable
 {
 	using WTReq = value_or_wrapper<TReq>;
 	using WTRes = value_or_wrapper<TRes>;
+	using Task = RdTask<TRes, ResSer>;
+	using TaskResult = typename Task::result_type;
 
-	using handler_t = std::function<RdTask<TRes, ResSer>(Lifetime, TReq const&)>;
+	using handler_t = std::function<RdTask<TRes, ResSer>(Lifetime result_lifetime, TReq const&)>;
 	mutable handler_t local_handler;
 
-	mutable tsl::ordered_map<RdId, RdTask<TRes, ResSer>, rd::hash<RdId>> awaiting_tasks;	// TO-DO get rid of it
+	void send_result(const RdId task_id, const TaskResult& result) const
+	{
+		auto logger = spdlog::get("logSend");
+		if (logger->should_log(spdlog::level::trace))
+			logger->trace("endpoint {}::{} response = {}", to_string(get_location()), to_string(get_id()), to_string(result));
+		get_wire()->send(task_id, [this, &result](Buffer& inner_buffer) { result.write(get_serialization_context(), inner_buffer); });
+	}
+
+	template <class Bindable = TRes, std::enable_if_t<util::is_bindable_v<Bindable>, bool> = true>
+	void handle_result(LifetimeDefinition result_lifetime_def, const RdId task_id, const TaskResult& result) const
+	{
+		try
+		{
+			if (result.is_succeeded())
+			{
+				auto result_lifetime = result_lifetime_def.lifetime;
+				auto wired_result = result_lifetime->make_attached<detail::RdEndpointWiredResult<WTRes>>(std::move(result_lifetime_def), result.get_value());
+				wired_result->identify(*get_protocol()->get_identity(), task_id);
+				wired_result->bind(result_lifetime, this, "EndpointWiredResult");
+				send_result(task_id, result);
+			}
+			else
+			{
+				send_result(task_id, result);
+				result_lifetime_def.terminate();
+			}
+		}
+		catch (std::exception ex)
+		{
+			spdlog::get("logSend")->error(ex.what());
+			result_lifetime_def.terminate();
+		}
+	}
+
+	template <class NonBindable = TRes, std::enable_if_t<!util::is_bindable_v<NonBindable>, bool> = true>
+	void handle_result(LifetimeDefinition result_lifetime_def, const RdId task_id, TaskResult result) const
+	{
+		try
+		{
+			send_result(task_id, result);
+			result_lifetime_def.terminate();
+		}
+		catch (std::exception ex)
+		{
+			spdlog::get("logSend")->error(ex.what());
+			result_lifetime_def.terminate();
+		}
+	}
+
+	void handle_result_async(LifetimeDefinition result_lifetime_def, const RdId task_id, Task task) const
+	{
+		struct AsyncCallData
+		{
+			const RdEndpoint* endpoint;
+			LifetimeDefinition call_lifetime_def;
+			LifetimeDefinition result_lifetime_def;
+			RdId task_id;
+
+			AsyncCallData(const RdEndpoint* endpoint, LifetimeDefinition call_lifetime_def, LifetimeDefinition result_lifetime_def, const RdId task_id) :
+				endpoint(endpoint), call_lifetime_def(std::move(call_lifetime_def)), result_lifetime_def(std::move(result_lifetime_def)), task_id(task_id)
+			{
+			}
+		};
+
+		auto call_lifetime_def = LifetimeDefinition(*bind_lifetime);
+		auto call_lifetime = call_lifetime_def.lifetime;
+		auto cancellation = call_lifetime->make_attached<detail::RdEndpointTaskCancellation<TRes, ResSer>>(task);
+		cancellation->set_id(task_id);
+		cancellation->bind(call_lifetime, this, "EndpointTaskCancellation");
+
+		task.advise(call_lifetime, [data = std::make_shared<AsyncCallData>(this, std::move(call_lifetime_def), std::move(result_lifetime_def), task_id)](const auto& result)
+		{
+			data->call_lifetime_def.terminate();
+			data->endpoint->handle_result(std::move(data->result_lifetime_def), data->task_id, result);
+		});
+	}
 public:
 	// region ctor/dtor
 
@@ -74,8 +234,21 @@ public:
 	 */
 	void set(std::function<WTRes(TReq const&)> functor) const
 	{
-		local_handler = [handler = std::move(functor)](Lifetime _, TReq const& req) -> RdTask<TRes, ResSer>
-		{ return RdTask<TRes, ResSer>::from_result(handler(req)); };
+		local_handler = [handler = std::move(functor)](Lifetime _, TReq const& req)
+		{
+			return Task::from_result(handler(req));
+		};
+	}
+
+	/**
+	 * \brief @see set above
+	 */
+	void set(std::function<WTRes(const Lifetime& lifetime, TReq const&)> functor) const
+	{
+		local_handler = [handler = std::move(functor)](const Lifetime& lifetime, TReq const& req)
+		{
+			return Task::from_result(handler(lifetime, req));
+		};
 	}
 
 	void init(Lifetime lifetime) const override
@@ -95,27 +268,18 @@ public:
 			throw std::invalid_argument("handler is empty for RdEndPoint");
 		}
 
-		using TaskResult = RdTaskResult<TRes, ResSer>;
-
-		auto lifetime = *bind_lifetime;
-		auto send_result = [this, task_id](TaskResult const& task_result)
-		{
-			auto logger = spdlog::get("logSend");
-			if (logger->should_log(spdlog::level::trace))
-				logger->trace("endpoint {}::{} response = {}", to_string(location), to_string(rdid), to_string(task_result));
-			get_wire()->send(task_id, [&](Buffer& inner_buffer) { task_result.write(get_serialization_context(), inner_buffer); });
-		};
-
+		auto result_lifetime_def = LifetimeDefinition(*bind_lifetime);
 		try
 		{
-			auto task = local_handler(lifetime, wrapper::get<TReq>(value));
-			awaiting_tasks[task_id] = task;
-			lifetime->add_action([this, task_id] { awaiting_tasks.erase(task_id); });
-			task.advise(lifetime, send_result);
+			auto task = local_handler(result_lifetime_def.lifetime, wrapper::get<TReq>(value));
+			if (!task.has_value())
+				handle_result_async(std::move(result_lifetime_def), task_id, task);
+			else
+				handle_result(std::move(result_lifetime_def), task_id, task.value_or_throw());
 		}
 		catch (std::exception const& e)
 		{
-			send_result(typename TaskResult::Fault(e));
+			send_result(task_id, typename TaskResult::Fault(e));
 		}
 	}
 

--- a/rd-cpp/src/rd_framework_cpp/src/main/task/RdTaskResult.h
+++ b/rd-cpp/src/rd_framework_cpp/src/main/task/RdTaskResult.h
@@ -119,12 +119,44 @@ public:
 			v);
 	}
 
+	/// \brief Attaches lifetime to result value. Lifetime terminates when result value destructed.
+	/// \param parent Parent lifetime.
+	/// \throw mpark::bad_variant_access if result isn't available or not Success
+	template <class Wrapped = WT, std::enable_if_t<is_wrapper_v<Wrapped>, bool> = true>
+	Lifetime attach_nested_lifetime_to_value(const Lifetime& parent)
+	{
+		auto&& wrapper = get<Success>(v).value;
+
+		struct Deleter
+		{
+			std::shared_ptr<T> ptr;
+			LifetimeDefinition lifetime_definition;
+
+			explicit Deleter(LifetimeDefinition&& lifetime_definition, std::shared_ptr<T> ptr) : ptr(std::move(ptr)), lifetime_definition(std::move(lifetime_definition)) { }
+
+			void operator()(T*) const
+			{
+			}
+		};
+
+		auto deleter = Deleter(LifetimeDefinition(parent), std::move(wrapper));
+		auto ptr = deleter.ptr.get();
+		auto lifetime = deleter.lifetime_definition.lifetime;
+		wrapper = std::shared_ptr<T>(ptr, std::move(deleter));
+		return lifetime;
+	}
+
+	WT const& get_value() const
+	{
+		return visit(util::make_visitor([](Success const& value) -> WT const& { return value.value; },
+						 [](Cancelled const&) -> WT const& { throw std::invalid_argument("Task finished in Cancelled state"); },
+						 [](Fault const& value) -> WT const& { throw std::runtime_error(to_string(value.reason_message)); }),
+			v);
+	}
+
 	T const& unwrap() const
 	{
-		return visit(util::make_visitor([](Success const& value) -> T const& { return wrapper::get<T>(value.value); },
-						 [](Cancelled const&) -> T const& { throw std::invalid_argument("Task finished in Cancelled state"); },
-						 [](Fault const& value) -> T const& { throw std::runtime_error(to_string(value.reason_message)); }),
-			v);
+		return wrapper::get<T>(get_value());
 	}
 
 	bool is_succeeded() const

--- a/rd-cpp/src/rd_framework_cpp/src/main/task/RdTaskResult.h
+++ b/rd-cpp/src/rd_framework_cpp/src/main/task/RdTaskResult.h
@@ -119,33 +119,6 @@ public:
 			v);
 	}
 
-	/// \brief Attaches lifetime to result value. Lifetime terminates when result value destructed.
-	/// \param parent Parent lifetime.
-	/// \throw mpark::bad_variant_access if result isn't available or not Success
-	template <class Wrapped = WT, std::enable_if_t<is_wrapper_v<Wrapped>, bool> = true>
-	Lifetime attach_nested_lifetime_to_value(const Lifetime& parent)
-	{
-		auto&& wrapper = get<Success>(v).value;
-
-		struct Deleter
-		{
-			std::shared_ptr<T> ptr;
-			LifetimeDefinition lifetime_definition;
-
-			explicit Deleter(LifetimeDefinition&& lifetime_definition, std::shared_ptr<T> ptr) : ptr(std::move(ptr)), lifetime_definition(std::move(lifetime_definition)) { }
-
-			void operator()(T*) const
-			{
-			}
-		};
-
-		auto deleter = Deleter(LifetimeDefinition(parent), std::move(wrapper));
-		auto ptr = deleter.ptr.get();
-		auto lifetime = deleter.lifetime_definition.lifetime;
-		wrapper = std::shared_ptr<T>(ptr, std::move(deleter));
-		return lifetime;
-	}
-
 	WT const& get_value() const
 	{
 		return visit(util::make_visitor([](Success const& value) -> WT const& { return value.value; },

--- a/rd-cpp/src/rd_framework_cpp/src/main/util/framework_traits.h
+++ b/rd-cpp/src/rd_framework_cpp/src/main/util/framework_traits.h
@@ -14,6 +14,13 @@ template <typename S, typename T = decltype((S::read(std::declval<rd::Serializat
 using read_t = T;
 
 static_assert(util::is_same_v<std::wstring, read_t<Polymorphic<std::wstring>>>, " ");
+
+template <class T>
+using is_bindable = std::is_base_of<IRdBindable, T>;
+
+template <class T>
+constexpr bool is_bindable_v = is_bindable<T>::value;
+
 }	 // namespace util
 }	 // namespace rd
 

--- a/rd-cpp/src/rd_framework_cpp/src/test/util/SimpleWire.h
+++ b/rd-cpp/src/rd_framework_cpp/src/test/util/SimpleWire.h
@@ -45,6 +45,8 @@ public:
 	void process_one_message() const;
 
 	void set_auto_flush(bool value);
+
+	bool is_subscribed(const RdId id) { return message_broker.is_subscribed(id); }
 };
 }	 // namespace test
 }	 // namespace rd


### PR DESCRIPTION
Fixes https://github.com/JetBrains/rd/issues/463 and https://github.com/JetBrains/rd/issues/460.

List of fixes and improvements:
1. Added shared Terminated lifetime.
2. Fixed SequentialLifetimes to not keep on terminate action in parent Lifetime when destroyed.
3. Fixed Signal to release lambda closure resources on Lifetime termination. It was possible to make cyclic-reference which never releases resources (it only released resources on fire event which may never happen).
4. Allow attaching shared_ptr to lifetime to prevent issues which callbacks to already destroyed objects because there no explicit references (i.e. from subscriptions in MessageBroker which bounded by lifetime, but only have a raw pointer instead of shared_ptr).
5. Support auto-binding for call results both client and server-side.
6. Support call result lifetimes allowing to keep result alive on server as long as it required on client.