### PR TITLE
Improve 'toString' representation of protocol entities

### DIFF
--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/string/PrettyPrinter.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/string/PrettyPrinter.kt
@@ -8,7 +8,7 @@ enum class Eol(val value: String) {
     linux ("\n"),
     windows ("\r\n"),
     osSpecified (eol),
-    none("")
+    none(" ")
 }
 
 inline fun printer(content: PrettyPrinter.() -> Unit) = PrettyPrinter().apply(content)


### PR DESCRIPTION
Updates single-line PrettyPrinter logic to insert a space between joined lines.

'toString' samples
Before the fix: `LxMouseEvent (type = EnteredxAbs = 640yAbs = 512clickCount = 0causedByTouchEvent = falsebutton = 0popupTrigger = falsemodifiers = 0)`
After the fix: `LxMouseEvent ( type = Moved xAbs = 870 yAbs = 632 clickCount = 0 causedByTouchEvent = false button = 0 popupTrigger = false modifiers = 0 )`