### PR TITLE
Support saving the list of marshallers during generation to a file

### DIFF
--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/MarshallersProvider.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/MarshallersProvider.kt
@@ -1,0 +1,44 @@
+package com.jetbrains.rd.framework
+
+import com.jetbrains.rd.util.error
+import com.jetbrains.rd.util.getLogger
+import java.io.InputStream
+
+interface MarshallersProvider {
+    object Dummy : MarshallersProvider {
+        override fun getMarshaller(id: RdId): IMarshaller<*>? = null
+    }
+
+    companion object {
+        fun extractMarshallers(
+            stream: InputStream,
+            classsLoader: ClassLoader
+        ): List<IMarshaller<*>> = stream.reader().useLines { lines: Sequence<String> ->
+            lines.map<String, List<String>> { it.split(":") }.map<List<String>, LazyCompanionMarshaller<Any>> {
+                LazyCompanionMarshaller<Any>(RdId(it.first().toLong()), classsLoader, it.last())
+            }.toList()
+        }
+    }
+
+    fun getMarshaller(id: RdId): IMarshaller<*>?
+}
+
+class AggregatedMarshallersProvider(val providers: Sequence<MarshallersProvider>) : MarshallersProvider {
+    override fun getMarshaller(id: RdId): IMarshaller<*>? {
+        return providers.mapNotNull { it.getMarshaller(id) }.firstOrNull()
+    }
+}
+
+abstract class MarhallersProviderFromResourcesBase(val resourceName: String) : MarshallersProvider {
+    private val map: Map<RdId, IMarshaller<*>> by lazy {
+        val classLoader = javaClass.classLoader
+        val resource = classLoader.getResourceAsStream(resourceName) ?: run {
+            getLogger(this::class).error { "$resourceName is not found" }
+            return@lazy emptyMap()
+        }
+
+        MarshallersProvider.extractMarshallers(resource, classsLoader = classLoader).associateBy { it.id }
+    }
+
+    override fun getMarshaller(id: RdId): IMarshaller<*>? = map[id]
+}

--- a/rd-kt/rd-gen/src/gradlePlugin/kotlin/com/jetbrains/rd/generator/gradle/GradleGenerationSpec.kt
+++ b/rd-kt/rd-gen/src/gradlePlugin/kotlin/com/jetbrains/rd/generator/gradle/GradleGenerationSpec.kt
@@ -7,8 +7,9 @@ class GradleGenerationSpec {
     var namespace = ""
     var directory = ""
     var generatedFileSuffix = ".Generated"
+    var marshallersFile: String? = ""
 
     override fun toString(): String {
-        return "$language||$transform||$root||$namespace||$directory||$generatedFileSuffix"
+        return "$language||$transform||$root||$namespace||$directory||$generatedFileSuffix||${marshallersFile}"
     }
 }

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/GenerationSpec.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/GenerationSpec.kt
@@ -11,7 +11,8 @@ data class GenerationSpec(
     var root: String = "",
     var namespace: String = "",
     var directory: String = "",
-    var generatedFileSuffix: String = ".Generated"
+    var generatedFileSuffix: String = ".Generated",
+    var marshallersFile: String? = null,
 ) {
     companion object {
         fun loadFrom(file: File): List<GenerationSpec> {
@@ -19,10 +20,12 @@ data class GenerationSpec(
             val lines = file.readLines(Charsets.UTF_8)
             for (line in lines) {
                 val parts = line.split("||")
-                result.add(GenerationSpec(parts[0], parts[1], parts[2], parts[3], parts[4], parts[5]))
+                result.add(GenerationSpec(parts[0], parts[1], parts[2], parts[3], parts[4], parts[5], parts[6].nullIfEmpty()))
             }
             return result
         }
+
+        fun String.nullIfEmpty(): String? = if (this.isBlank()) null else this
     }
 
     fun toGeneratorAndRoot(availableRoots: List<Root>): IGeneratorAndRoot {
@@ -34,8 +37,8 @@ data class GenerationSpec(
             else -> throw GeneratorException("Unknown flow transform type ${transform}, use 'asis', 'reversed' or 'symmetric'")
         }
         val generator = when (language) {
-            "kotlin" -> Kotlin11Generator(flowTransform, namespace, File(directory), generatedFileSuffix)
-            "csharp" -> CSharp50Generator(flowTransform, namespace, File(directory), generatedFileSuffix)
+            "kotlin" -> Kotlin11Generator(flowTransform, namespace, File(directory), generatedFileSuffix, marhsallersFile = marshallersFile?.let { File(it) })
+            "csharp" -> CSharp50Generator(flowTransform, namespace, File(directory), generatedFileSuffix) // todo support for C#
             "cpp" -> Cpp17Generator(flowTransform, namespace, File(directory), generatedFileSuffix)
             else -> throw GeneratorException("Unknown language $language, use 'kotlin' or 'csharp' or 'cpp'")
         }

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/MarshallersCollector.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/MarshallersCollector.kt
@@ -1,0 +1,39 @@
+package com.jetbrains.rd.generator.nova
+
+import com.jetbrains.rd.util.hash.getPlatformIndependentHash
+import java.io.File
+
+
+interface MarshallersCollector {
+    val shouldGenerateRegistrations: Boolean
+
+    fun addMarshaller(namespace: String, name: String)
+}
+
+object DisabledMarshallersCollector : MarshallersCollector {
+    override val shouldGenerateRegistrations: Boolean
+        get() = true
+
+    override fun addMarshaller(namespace: String, name: String) {
+    }
+}
+
+class RealMarshallersCollector(val marshallersFile: File) : MarshallersCollector {
+    private val marshallers = mutableSetOf<String>()
+
+    override val shouldGenerateRegistrations: Boolean
+        get() = false // We may want to add a separate setting here, but for now just disable it
+
+    override fun addMarshaller(namespace: String, name: String) {
+        marshallers.add("${name.getPlatformIndependentHash()}:${namespace}.${name}")
+    }
+
+    fun close() {
+        marshallersFile.parentFile.mkdirs()
+        marshallersFile.writer().use { writer ->
+            marshallers.sorted().forEach {
+                writer.append(it).append("\n")
+            }
+        }
+    }
+}

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/cpp/Cpp17Generator.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/cpp/Cpp17Generator.kt
@@ -902,7 +902,7 @@ open class Cpp17Generator(
         +"//------------------------------------------------------------------------------"
     }
 
-    override fun realGenerate(toplevels: List<Toplevel>) {
+    override fun realGenerate(toplevels: List<Toplevel>, collector: MarshallersCollector) {
         if (toplevels.isEmpty()) return
 
         val root = toplevels.first().root

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/csharp/CSharp50Generator.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/csharp/CSharp50Generator.kt
@@ -360,7 +360,7 @@ open class CSharp50Generator(
 
     //generation
 
-    override fun realGenerate(toplevels: List<Toplevel>) {
+    override fun realGenerate(toplevels: List<Toplevel>, collector: MarshallersCollector) {
         toplevels.forEach { tl ->
             tl.fsPath.bufferedWriter().use { writer ->
                 PrettyPrinter().apply {


### PR DESCRIPTION
Support passing MarshallersProvider to avoid greedy registration of all serializers on the startup, and just search for them when they are needed. It also solves the `Maybe you forgot to invoke 'register()' method` problem