### PR TITLE
Add Contains and IndexOf methods for consistency with System.Collections.Generic.List<>

### DIFF
--- a/rd-net/Lifetimes/Collections/CompactList.cs
+++ b/rd-net/Lifetimes/Collections/CompactList.cs
@@ -69,6 +69,27 @@ namespace JetBrains.Collections
       myMultipleValues = null;
     }
 
+    public bool Contains(T item, IEqualityComparer<T?> comparer)
+    {
+      return IndexOf(item, comparer) >= 0;
+    }
+
+    public int IndexOf(T item, IEqualityComparer<T?> comparer)
+    {
+      switch (Count)
+      {
+        case 0: return -1;
+        case 1: return comparer.Equals(mySingleValue, item) ? 0 : -1;
+        default:
+          Assertion.AssertNotNull(myMultipleValues);
+          for (var i = 0; i < myMultipleValues.Count; i++)
+          {
+            if (comparer.Equals(myMultipleValues[i], item)) return i;
+          }
+          return -1;
+      }
+    }
+
     public int LastIndexOf(T item, IEqualityComparer<T?> comparer)
     {
       switch (Count)      

--- a/rd-net/Test.Lifetimes/Collections/CompactListTest.cs
+++ b/rd-net/Test.Lifetimes/Collections/CompactListTest.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using JetBrains.Collections;
+using NUnit.Framework;
+
+namespace Test.Lifetimes.Collections
+{
+  [TestFixture]
+  public class CompactListTest
+  {
+    [TestCase(new int[0], 1, false)]
+    [TestCase(new[] { 1 }, 1, true)]
+    [TestCase(new[] { 1 }, 2, false)]
+    [TestCase(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, 5, true)]
+    [TestCase(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, 0, false)]
+    public void TestContains(int[] values, int value, bool expected)
+    {
+      var compactList = new CompactList<int>();
+      for (int i = 0; i < values.Length; i++)
+      {
+        compactList.Add(values[i]);
+      }
+
+      Assert.AreEqual(compactList.Contains(value, EqualityComparer<int>.Default), expected);
+    }
+
+    [TestCase(new int[0], 1, -1)]
+    [TestCase(new[] { 1 }, 1, 0)]
+    [TestCase(new[] { 1 }, 2, -1)]
+    [TestCase(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, 5, 4)]
+    [TestCase(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, 0, -1)]
+    public void TestIndexOf(int[] values, int value, int expectedIndex)
+    {
+      var compactList = new CompactList<int>();
+      for (int i = 0; i < values.Length; i++)
+      {
+        compactList.Add(values[i]);
+      }
+
+      Assert.AreEqual(compactList.IndexOf(value, EqualityComparer<int>.Default), expectedIndex);
+    }
+  }
+}


### PR DESCRIPTION
Hi! I found that _CompactList_ does not contain _Contains_ and _IndexOf_ methods, which makes it impossible to use in situations where it replaces _System.Collections.Generic.List<>_. I implemented them in a similar way to the existing _LastIndexOf_. I would be glad if you can accept this changes or tell me what needs to be improved