### PR TITLE
PlatformDependent: drop type aliases

### DIFF
--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/AdditionalApi.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/AdditionalApi.kt
@@ -7,7 +7,7 @@ import com.jetbrains.rd.util.reactive.IScheduler
 import com.jetbrains.rd.util.reactive.ISource
 import java.time.Duration
 import java.util.*
-import java.util.EnumSet
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.schedule
 
 private val timer by lazy { Timer("rd throttler", true) }

--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/BitSlice.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/BitSlice.kt
@@ -1,5 +1,7 @@
 package com.jetbrains.rd.util
 
+import java.util.concurrent.atomic.AtomicInteger
+
 open class BitSlice(val lowBit: Int, val bitCount: Int) {
     init {
         require(lowBit >= 0)  { "[lowBit] must be >= 0, actual: '$lowBit'"}

--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/PlatformUtils.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/PlatformUtils.kt
@@ -1,36 +1,16 @@
 package com.jetbrains.rd.util
 
 import com.jetbrains.rd.util.threading.SpinWait
+import java.io.Closeable
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.util.Date
-import java.util.concurrent.CancellationException
-import java.util.concurrent.ExecutionException
-import java.util.concurrent.TimeoutException
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicReference
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.io.use
 import kotlin.reflect.KClass
 
-typealias ExecutionException = ExecutionException
-
 fun currentThreadName() : String = Thread.currentThread().run { "$id:$name"}
-
-class AtomicReference<T> constructor(initial: T) {
-    private val impl = AtomicReference(initial)
-    fun get(): T = impl.get()
-    fun getAndUpdate(f: (T) -> T): T = impl.getAndUpdate(f)
-    fun getAndSet(newValue: T): T = impl.getAndSet(newValue)
-    fun compareAndSet(expectedValue: T, newValue: T): Boolean = impl.compareAndSet(expectedValue, newValue)
-}
-
-typealias CancellationException = CancellationException
-typealias TimeoutException = TimeoutException
-
-typealias ThreadLocal<T> = java.lang.ThreadLocal<T>
 
 fun <T> threadLocalWithInitial(initial: () -> T) : ThreadLocal<T> = ThreadLocal.withInitial(initial)
 
@@ -47,14 +27,14 @@ object Sync {
         return synchronized(obj, acton)
     }
     fun notifyAll(obj: Any) = (obj as Object).notifyAll()
-    fun notify(obj: Any) = (obj as Object).notify()
     fun wait(obj: Any) = (obj as Object).wait()
     fun wait(obj: Any, timeout: Long) = (obj as Object).wait(timeout)
 }
 
-fun<K,V> concurrentMapOf() : MutableMap<K,V> = ConcurrentHashMap()
+// For the protocol generator to avoid imports from java.util:
+typealias Date = java.util.Date
+typealias EnumSet<T> = java.util.EnumSet<T>
 
-typealias Closeable = java.io.Closeable
 inline fun <T : Closeable?, R> T.use(block:(T) -> R) : R = use(block)
 
 fun Throwable.getThrowableText(): String = StringWriter().apply { printStackTrace(PrintWriter(this)) }.toString()
@@ -62,18 +42,6 @@ fun Throwable.getThrowableText(): String = StringWriter().apply { printStackTrac
 fun qualifiedName(kclass: KClass<*>) : String = kclass.qualifiedName?:"<anonymous>"
 
 fun measureTimeMillis(block: () -> Unit): Long = kotlin.system.measureTimeMillis(block)
-
-//special jvm classes
-typealias URI = java.net.URI
-
-typealias Date = Date
-
-typealias UUID = java.util.UUID
-
-typealias AtomicInteger = AtomicInteger
-
-typealias Queue<E> = java.util.concurrent.LinkedBlockingQueue<E>
-typealias ConcurrentHashMap<K, V> = java.util.concurrent.ConcurrentHashMap<K, V>
 
 fun printlnError(msg: String) = System.err.println(msg)
 
@@ -84,11 +52,5 @@ inline fun assert(value: Boolean, lazyMessage: () -> Any)  = kotlin.assert(value
 inline fun spinUntil(condition: () -> Boolean) = SpinWait.spinUntil(condition)
 inline fun spinUntil(timeoutMs: Long, condition: () -> Boolean) = SpinWait.spinUntil(timeoutMs, condition)
 
-typealias EnumSet<T> = java.util.EnumSet<T>
 inline fun <reified T : Enum<T>> enumSetOf(values: Set<T> = emptySet()) : EnumSet<T> = EnumSet.noneOf(T::class.java).apply { addAll(values) }
 fun <T: Enum<T>> EnumSet<T>.values() : Set<T> = this
-
-typealias Runnable = java.lang.Runnable
-typealias Callable<T> = java.util.concurrent.Callable<T>
-
-typealias CopyOnWriteArrayList<T> = java.util.concurrent.CopyOnWriteArrayList<T>

--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/Statics.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/Statics.kt
@@ -1,5 +1,7 @@
 package com.jetbrains.rd.util
 
+import java.io.Closeable
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.reflect.KClass
 
 /**

--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/lifetime/RLifetime.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/lifetime/RLifetime.kt
@@ -10,6 +10,9 @@ import com.jetbrains.rd.util.reactive.viewNotNull
 import com.jetbrains.rd.util.threading.coroutines.RdCoroutineScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
+import java.io.Closeable
+import java.util.concurrent.CancellationException
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.min
 
 

--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/lifetime/SequentialLifetimes.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/lifetime/SequentialLifetimes.kt
@@ -1,8 +1,8 @@
 package com.jetbrains.rd.util.lifetime
 
-import com.jetbrains.rd.util.AtomicReference
 import com.jetbrains.rd.util.Logger
 import com.jetbrains.rd.util.error
+import java.util.concurrent.atomic.AtomicReference
 
 open class SequentialLifetimes(private val parentLifetime: Lifetime) {
     private val currentDef = AtomicReference(LifetimeDefinition.Terminated)

--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/reactive/RdFault.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/reactive/RdFault.kt
@@ -1,7 +1,7 @@
 package com.jetbrains.rd.util.reactive
 
-import com.jetbrains.rd.util.ExecutionException
 import com.jetbrains.rd.util.getThrowableText
+import java.util.concurrent.ExecutionException
 
 
 class RdFault constructor(val reasonTypeFqn: String, val reasonMessage: String, val reasonAsText: String, reason: Throwable? = null)

--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/reactive/Signal.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/reactive/Signal.kt
@@ -1,11 +1,11 @@
 package com.jetbrains.rd.util.reactive
 
-import com.jetbrains.rd.util.TlsBoxed
 import com.jetbrains.rd.util.*
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.lifetime.isAlive
 import com.jetbrains.rd.util.reflection.incrementCookie
 import com.jetbrains.rd.util.reflection.usingValue
+import java.util.concurrent.atomic.AtomicReference
 
 open class Signal<T> : ISignal<T> {
     companion object {

--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/reactive/Task.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/reactive/Task.kt
@@ -1,6 +1,6 @@
 package com.jetbrains.rd.util.reactive
 
-import com.jetbrains.rd.util.*
+import java.util.concurrent.CancellationException
 
 sealed class TaskResult<out T> {
 

--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/threading/coroutines/RdCoroutineScope.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/threading/coroutines/RdCoroutineScope.kt
@@ -1,10 +1,11 @@
 package com.jetbrains.rd.util.threading.coroutines
 
-import com.jetbrains.rd.util.*
+import com.jetbrains.rd.util.error
+import com.jetbrains.rd.util.getLogger
 import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.trace
 import kotlinx.coroutines.*
-import kotlinx.coroutines.CancellationException
-import java.lang.IllegalStateException
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 

--- a/rd-kt/rd-core/src/test/kotlin/com/jetbrains/rd/util/test/cases/BackgroundSchedulerTest.kt
+++ b/rd-kt/rd-core/src/test/kotlin/com/jetbrains/rd/util/test/cases/BackgroundSchedulerTest.kt
@@ -1,14 +1,17 @@
 package com.jetbrains.rd.util.test.cases
 
-import com.jetbrains.rd.util.AtomicInteger
-import com.jetbrains.rd.util.Closeable
 import com.jetbrains.rd.util.ILoggerFactory
 import com.jetbrains.rd.util.Statics
 import com.jetbrains.rd.util.log.ErrorAccumulatorLoggerFactory
 import com.jetbrains.rd.util.threading.TestSingleThreadScheduler
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.Closeable
+import java.util.concurrent.atomic.AtomicInteger
 
 
 class BackgroundSchedulerTest {

--- a/rd-kt/rd-core/src/test/kotlin/com/jetbrains/rd/util/test/framework/RdTestBase.kt
+++ b/rd-kt/rd-core/src/test/kotlin/com/jetbrains/rd/util/test/framework/RdTestBase.kt
@@ -1,10 +1,14 @@
 package com.jetbrains.rd.util.test.framework
 
-import com.jetbrains.rd.util.*
+import com.jetbrains.rd.util.ILoggerFactory
+import com.jetbrains.rd.util.Statics
+import com.jetbrains.rd.util.error
+import com.jetbrains.rd.util.getLogger
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.lifetime.SequentialLifetimes
 import com.jetbrains.rd.util.log.ErrorAccumulatorLoggerFactory
 import com.jetbrains.rd.util.threading.Linearization
+import java.io.Closeable
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/FrameworkMarshallers.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/FrameworkMarshallers.kt
@@ -1,8 +1,12 @@
 package com.jetbrains.rd.framework
 
 import com.jetbrains.rd.framework.impl.RdSecureString
-import com.jetbrains.rd.util.*
-import kotlin.reflect.*
+import com.jetbrains.rd.util.Date
+import com.jetbrains.rd.util.EnumSet
+import com.jetbrains.rd.util.PublicApi
+import java.net.URI
+import java.util.*
+import kotlin.reflect.KClass
 import kotlin.time.Duration
 
 open class UniversalMarshaller<T : Any>(

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Identities.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Identities.kt
@@ -1,9 +1,9 @@
 package com.jetbrains.rd.framework
 
 
-import com.jetbrains.rd.util.AtomicInteger
 import com.jetbrains.rd.util.hash.getPlatformIndependentHash
 import com.jetbrains.rd.util.string.condstr
+import java.util.concurrent.atomic.AtomicInteger
 
 enum class IdKind {
     Client,

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/RdEntitiesRegistrar.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/RdEntitiesRegistrar.kt
@@ -1,8 +1,8 @@
 package com.jetbrains.rd.framework
 
-import com.jetbrains.rd.util.ConcurrentHashMap
 import com.jetbrains.rd.util.addUnique
 import com.jetbrains.rd.util.lifetime.Lifetime
+import java.util.concurrent.ConcurrentHashMap
 
 class RdEntitiesRegistrar {
     private val map = ConcurrentHashMap<RdId, IRdDynamic>()

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Serializers.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Serializers.kt
@@ -3,8 +3,13 @@ package com.jetbrains.rd.framework
 import com.jetbrains.rd.framework.base.ISerializersOwner
 import com.jetbrains.rd.framework.impl.RdSecureString
 import com.jetbrains.rd.util.*
+import com.jetbrains.rd.util.Date
+import com.jetbrains.rd.util.EnumSet
 import com.jetbrains.rd.util.hash.getPlatformIndependentHash
 import com.jetbrains.rd.util.lifetime.Lifetime
+import java.net.URI
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 import kotlin.time.Duration
 import kotlin.time.DurationUnit

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
@@ -3,12 +3,17 @@ package com.jetbrains.rd.framework.base
 import com.jetbrains.rd.framework.*
 import com.jetbrains.rd.framework.impl.ProtocolContexts
 import com.jetbrains.rd.framework.impl.RdPropertyBase
-import com.jetbrains.rd.util.*
+import com.jetbrains.rd.util.Logger
+import com.jetbrains.rd.util.Sync
+import com.jetbrains.rd.util.assert
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.lifetime.isNotAlive
 import com.jetbrains.rd.util.reactive.*
 import com.jetbrains.rd.util.string.printToString
 import com.jetbrains.rd.util.threading.asSequentialScheduler
+import com.jetbrains.rd.util.trace
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.atomic.AtomicReference
 import javax.management.openmbean.InvalidOpenTypeException
 
 abstract class RdExtBase : RdReactiveBase() {
@@ -285,7 +290,7 @@ class ExtWire : IWire {
         }
 
 
-    private val sendQ = Queue<QueueItem>()
+    private val sendQ = LinkedBlockingQueue<QueueItem>()
 
     init {
         connected.whenTrue(Lifetime.Eternal) { _ ->

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/InternRoot.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/InternRoot.kt
@@ -1,13 +1,16 @@
 package com.jetbrains.rd.framework.impl
 
 import com.jetbrains.rd.framework.*
-import com.jetbrains.rd.util.*
-import com.jetbrains.rd.util.lifetime.Lifetime
-import com.jetbrains.rd.util.string.RName
-import com.jetbrains.rd.framework.IInternRoot
 import com.jetbrains.rd.framework.base.IRdBindable
 import com.jetbrains.rd.framework.base.IRdWireableDispatchHelper
 import com.jetbrains.rd.framework.base.RdReactiveBase
+import com.jetbrains.rd.util.assert
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.string.RName
+import com.jetbrains.rd.util.trace
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.collections.set
 
 class InternRoot<TBase: Any>(val serializer: ISerializer<TBase> = Polymorphic()): IInternRoot<TBase> {
     override fun deepClone(): IRdBindable {

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/ProtocolContexts.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/ProtocolContexts.kt
@@ -1,19 +1,22 @@
 package com.jetbrains.rd.framework.impl
 
-import com.jetbrains.rd.framework.*
-import com.jetbrains.rd.framework.base.*
+import com.jetbrains.rd.framework.AbstractBuffer
+import com.jetbrains.rd.framework.IProtocol
+import com.jetbrains.rd.framework.RdContext
+import com.jetbrains.rd.framework.SerializationCtx
+import com.jetbrains.rd.framework.base.IRdBindable
+import com.jetbrains.rd.framework.base.IRdWireableDispatchHelper
 import com.jetbrains.rd.framework.base.ISingleContextHandler
-import com.jetbrains.rd.util.ConcurrentHashMap
-import com.jetbrains.rd.util.CopyOnWriteArrayList
+import com.jetbrains.rd.framework.base.RdReactiveBase
 import com.jetbrains.rd.util.Sync
 import com.jetbrains.rd.util.assert
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.reactive.IAppendOnlyViewableConcurrentSet
-import com.jetbrains.rd.util.reactive.IMutableViewableSet
-import com.jetbrains.rd.util.reactive.IScheduler
 import com.jetbrains.rd.util.reactive.ViewableList
 import com.jetbrains.rd.util.reflection.threadLocal
 import com.jetbrains.rd.util.reflection.usingValue
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * This class handles RdContext on protocol level. It tracks existing contexts and allows access to their value sets (when present)

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdProperty.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdProperty.kt
@@ -2,15 +2,13 @@ package com.jetbrains.rd.framework.impl
 
 import com.jetbrains.rd.framework.*
 import com.jetbrains.rd.framework.base.*
-import com.jetbrains.rd.framework.base.bindPolymorphic
-import com.jetbrains.rd.framework.base.identifyPolymorphic
-import com.jetbrains.rd.util.AtomicReference
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.lifetime.LifetimeDefinition
 import com.jetbrains.rd.util.lifetime.isNotAlive
 import com.jetbrains.rd.util.reactive.*
 import com.jetbrains.rd.util.string.*
 import com.jetbrains.rd.util.trace
+import java.util.concurrent.atomic.AtomicReference
 
 abstract class RdPropertyBase<T>(val valueSerializer: ISerializer<T>) : RdReactiveBase(), IMutablePropertyBase<T> {
     companion object {

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdTask.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdTask.kt
@@ -11,7 +11,8 @@ import com.jetbrains.rd.util.string.RName
 import com.jetbrains.rd.util.string.condstr
 import com.jetbrains.rd.util.string.printToString
 import com.jetbrains.rd.util.threading.SynchronousScheduler
-import java.lang.IllegalStateException
+import java.util.concurrent.CancellationException
+import java.util.concurrent.TimeoutException
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
 

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/CoroutineTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/CoroutineTest.kt
@@ -1,21 +1,22 @@
 package com.jetbrains.rd.framework.test.cases
 
 import com.jetbrains.rd.framework.util.*
-import com.jetbrains.rd.util.*
+import com.jetbrains.rd.util.assert
+import com.jetbrains.rd.util.error
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.lifetime.LifetimeDefinition
 import com.jetbrains.rd.util.lifetime.LifetimeStatus
 import com.jetbrains.rd.util.lifetime.isAlive
 import com.jetbrains.rd.util.reactive.IScheduler
 import com.jetbrains.rd.util.reactive.Signal
+import com.jetbrains.rd.util.spinUntil
 import com.jetbrains.rd.util.threading.CompoundThrowable
 import com.jetbrains.rd.util.threading.coroutines.RdCoroutineScope
 import kotlinx.coroutines.*
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Runnable
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import java.time.Duration
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.CoroutineContext
 import kotlin.test.*
 

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdAsyncTaskTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdAsyncTaskTest.kt
@@ -8,10 +8,12 @@ import com.jetbrains.rd.framework.impl.RdSignal
 import com.jetbrains.rd.framework.impl.RdTask
 import com.jetbrains.rd.framework.test.util.RdFrameworkTestBase
 import com.jetbrains.rd.framework.util.*
-import com.jetbrains.rd.util.AtomicInteger
 import com.jetbrains.rd.util.error
 import com.jetbrains.rd.util.getLogger
-import com.jetbrains.rd.util.lifetime.*
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.lifetime.LifetimeDefinition
+import com.jetbrains.rd.util.lifetime.isAlive
+import com.jetbrains.rd.util.lifetime.isNotAlive
 import com.jetbrains.rd.util.reactive.RdFault
 import com.jetbrains.rd.util.reactive.hasValue
 import com.jetbrains.rd.util.reactive.valueOrThrow
@@ -26,6 +28,7 @@ import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 
 class RdAsyncTaskTest : RdFrameworkTestBase() {

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/sync/TestTwoClients.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/sync/TestTwoClients.kt
@@ -10,7 +10,11 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import test.synchronization.*
+import test.synchronization.Clazz
+import test.synchronization.SyncModelExt
+import test.synchronization.extToClazz
+import test.synchronization.syncModelExt
+import java.util.concurrent.atomic.AtomicInteger
 
 private val serverId = AtomicInteger()
 

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/util/RdFrameworkTestBase.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/util/RdFrameworkTestBase.kt
@@ -2,8 +2,6 @@ package com.jetbrains.rd.framework.test.util
 
 import com.jetbrains.rd.framework.*
 import com.jetbrains.rd.framework.base.*
-import com.jetbrains.rd.framework.base.bindTopLevel
-import com.jetbrains.rd.util.Closeable
 import com.jetbrains.rd.util.ILoggerFactory
 import com.jetbrains.rd.util.Statics
 import com.jetbrains.rd.util.lifetime.Lifetime
@@ -11,6 +9,7 @@ import com.jetbrains.rd.util.lifetime.LifetimeDefinition
 import com.jetbrains.rd.util.log.ErrorAccumulatorLoggerFactory
 import com.jetbrains.rd.util.reactive.ExecutionOrder
 import com.jetbrains.rd.util.reactive.IScheduler
+import java.io.Closeable
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/util/TestWire.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/util/TestWire.kt
@@ -1,11 +1,10 @@
 package com.jetbrains.rd.framework.test.util
 
-import com.jetbrains.rd.framework.RdId
 import com.jetbrains.rd.framework.AbstractBuffer
+import com.jetbrains.rd.framework.RdId
 import com.jetbrains.rd.framework.RdMessage
 import com.jetbrains.rd.framework.base.WireBase
 import com.jetbrains.rd.framework.createAbstractBuffer
-import com.jetbrains.rd.util.Queue
 import com.jetbrains.rd.util.reactive.IScheduler
 import java.util.concurrent.ConcurrentLinkedQueue
 

--- a/rd-kt/rd-text/src/test/kotlin/com/jetbrains/rd/rdtext/test/util/TestWire.kt
+++ b/rd-kt/rd-text/src/test/kotlin/com/jetbrains/rd/rdtext/test/util/TestWire.kt
@@ -4,7 +4,6 @@ import com.jetbrains.rd.framework.AbstractBuffer
 import com.jetbrains.rd.framework.RdId
 import com.jetbrains.rd.framework.base.WireBase
 import com.jetbrains.rd.framework.createAbstractBuffer
-import com.jetbrains.rd.util.Queue
 import com.jetbrains.rd.util.reactive.IScheduler
 import java.util.concurrent.ConcurrentLinkedQueue
 


### PR DESCRIPTION
They were only necessary for the Kotlin multiplatform project back then, and Rd is no longer a multiplatform project.

This will reduce possible confusion between Rd and system classes.