### PR TITLE
An exception can happen while rendering the full exception during RdFault creation

### DIFF
--- a/rd-net/RdFramework/Tasks/RdFault.cs
+++ b/rd-net/RdFramework/Tasks/RdFault.cs
@@ -19,7 +19,14 @@ namespace JetBrains.Rd.Tasks
     {
       ReasonTypeFqn = inner.GetType().FullName;
       ReasonMessage = inner.Message;
-      ReasonText = inner.ToString(); //todo Use system capabilities, stack traces, etc
+      try
+      {
+        ReasonText = inner.ToString(); //todo Use system capabilities, stack traces, etc
+      }
+      catch (Exception e)
+      {
+        ReasonText = $"An error occurred while attempting to render the full exception: {e.Message}";
+      }
     }
 
     [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]


### PR DESCRIPTION
reported by @estrizhok 

```
   at System.ModuleHandle.ResolveType(QCallModule module, Int32 typeToken, IntPtr* typeInstArgs, Int32 typeInstCount, IntPtr* methodInstArgs, Int32 methodInstCount, ObjectHandleOnStack type)
   at System.ModuleHandle.ResolveTypeHandle(Int32 typeToken, RuntimeTypeHandle[] typeInstantiationContext, RuntimeTypeHandle[] methodInstantiationContext) in System\ModuleHandle.cs:line 122
   at System.Reflection.RuntimeModule.ResolveType(Int32 metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments) in System.Reflection\RuntimeModule.cs:line 290
   at System.Reflection.CustomAttribute.FilterCustomAttributeRecord(MetadataToken caCtorToken, MetadataImport& scope, RuntimeModule decoratedModule, MetadataToken decoratedToken, RuntimeType attributeFilterType, Boolean mustBeInheritable, ListBuilder`1& derivedAttributes, RuntimeType& attributeType, IRuntimeMethodInfo& ctorWithParameters, Boolean& isVarArg) in System.Reflection\CustomAttribute.cs:line 392
   at System.Reflection.CustomAttribute.IsCustomAttributeDefined(RuntimeModule decoratedModule, Int32 decoratedMetadataToken, RuntimeType attributeFilterType, Int32 attributeCtorToken, Boolean mustBeInheritable) in System.Reflection\CustomAttribute.cs:line 266
   at System.Reflection.CustomAttribute.IsDefined(RuntimeType type, RuntimeType caType, Boolean inherit) in System.Reflection\CustomAttribute.cs:line 19
   at System.RuntimeType.IsDefined(Type attributeType, Boolean inherit) in System\RuntimeType.cs:line 3567
   at System.Diagnostics.StackTrace.ToString(TraceFormat traceFormat, StringBuilder sb) in System.Diagnostics\StackTrace.cs:line 240
   at System.Diagnostics.StackTrace.ToString(TraceFormat traceFormat) in System.Diagnostics\StackTrace.cs:line 210
   at System.Exception.get_StackTrace() in System\Exception.cs:line 156
   at System.IO.FileNotFoundException.ToString() in System.IO\FileNotFoundException.cs:line 89
   at System.Exception.ToString() in System\Exception.cs:line 388
   at System.Exception.ToString() in System\Exception.cs:line 388
   at JetBrains.Rd.Tasks.RdFault..ctor(Exception inner) in JetBrains.Rd.Tasks\RdFault.cs:line 25
   at JetBrains.Rd.Tasks.RdTaskResult`1.Faulted(Exception exception) in JetBrains.Rd.Tasks\RdTaskResult.cs:line 35
   at JetBrains.Rd.Tasks.RdTask`1.Set(Exception e) in JetBrains.Rd.Tasks\RdTask.cs:line 26
   at JetBrains.Rd.Tasks.RdTaskEx.<>c__DisplayClass4_0`1.<ToRdTask>b__0(Task`1 t) in JetBrains.Rd.Tasks\RdTaskEx.cs:line 65
   at System.Threading.Tasks.ContinuationTaskFromResultTask`1.InnerInvoke() in System.Threading.Tasks\ContinuationTaskFromResultTask.cs:line 26
   at System.Threading.Tasks.Task.<>c.<.cctor>b__272_0(Object obj) in System.Threading.Tasks\Task.cs:line 971
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state) in System.Threading\ExecutionContext.cs:line 137
--- End of stack trace from previous location ---
```