### PR TITLE
Fix IsBindable for default immutable arrays

### DIFF
--- a/rd-net/RdFramework/Base/IRdBindable.cs
+++ b/rd-net/RdFramework/Base/IRdBindable.cs
@@ -165,7 +165,7 @@ namespace JetBrains.Rd.Base
       {
         case IRdBindable _:
           return true;
-        case IEnumerable enumerable:
+        case IEnumerable enumerable when !(typeof(T).IsValueType && obj.Equals(default)):
         {
           foreach (var item in enumerable)
             return item is IRdBindable;

--- a/rd-net/Test.RdFramework/Util/RdBindableExUtilTest.cs
+++ b/rd-net/Test.RdFramework/Util/RdBindableExUtilTest.cs
@@ -6,7 +6,12 @@ using JetBrains.Rd.Base;
 using JetBrains.Rd.Util;
 using NUnit.Framework;
 
+#if !NET35
+using System.Collections.Immutable;
+#endif
+
 namespace Test.RdFramework.Util;
+
 
 [TestFixture]
 public class RdBindableExUtilTest
@@ -34,6 +39,11 @@ public class RdBindableExUtilTest
     Assert.IsFalse(new[] { i }.IsBindable());
     Assert.IsFalse(new List<int> { i }.IsBindable());
     Assert.IsFalse(new List<object> { i }.IsBindable());
+
+#if !NET35
+    Assert.IsFalse(new ImmutableArray<int>().IsBindable());
+    Assert.IsFalse(ImmutableArray.Create(1).IsBindable());
+#endif
   } 
   
   [Test]


### PR DESCRIPTION
Default immutable array instances cannot be enumerated. For that reason empty instances cannot be returned from the RPC calls, as IsBindable is always called on them