### PR TITLE
RdBindableExUtilTest: fix test

### DIFF
--- a/rd-net/RdFramework/Base/IRdBindable.cs
+++ b/rd-net/RdFramework/Base/IRdBindable.cs
@@ -165,7 +165,7 @@ namespace JetBrains.Rd.Base
       {
         case IRdBindable _:
           return true;
-        case IEnumerable enumerable when !(typeof(T).IsValueType && obj.Equals(default)):
+        case IEnumerable enumerable when !(typeof(T).IsValueType && obj.Equals((T)default!)):
         {
           foreach (var item in enumerable)
             return item is IRdBindable;

--- a/rd-net/Test.RdFramework/Util/RdBindableExUtilTest.cs
+++ b/rd-net/Test.RdFramework/Util/RdBindableExUtilTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using JetBrains.Diagnostics;
 using JetBrains.Lifetimes;
@@ -5,7 +6,6 @@ using JetBrains.Rd;
 using JetBrains.Rd.Base;
 using JetBrains.Rd.Util;
 using NUnit.Framework;
-
 #if !NET35
 using System.Collections.Immutable;
 #endif
@@ -41,7 +41,7 @@ public class RdBindableExUtilTest
     Assert.IsFalse(new List<object> { i }.IsBindable());
 
 #if !NET35
-    Assert.IsFalse(new ImmutableArray<int>().IsBindable());
+    Assert.IsFalse(ImmutableArray.Create<int>().IsBindable());
     Assert.IsFalse(ImmutableArray.Create(1).IsBindable());
 #endif
   } 
@@ -70,17 +70,17 @@ public class RdBindableExUtilTest
   private class RdBindableTestClass : IRdBindable
   {
     public RName Location { get; }
-    public IProtocol TryGetProto() { throw new System.NotImplementedException(); }
+    public IProtocol TryGetProto() { throw new NotImplementedException(); }
 
-    public bool TryGetSerializationContext(out SerializationCtx ctx) { throw new System.NotImplementedException(); }
+    public bool TryGetSerializationContext(out SerializationCtx ctx) { throw new NotImplementedException(); }
 
-    public void Print(PrettyPrinter printer) { throw new System.NotImplementedException(); }
+    public void Print(PrettyPrinter printer) { throw new NotImplementedException(); }
 
     public RdId RdId { get; set; }
-    public void PreBind(Lifetime lf, IRdDynamic parent, string name) { throw new System.NotImplementedException(); }
+    public void PreBind(Lifetime lf, IRdDynamic parent, string name) { throw new NotImplementedException(); }
 
-    public void Bind() { throw new System.NotImplementedException(); }
+    public void Bind() { throw new NotImplementedException(); }
 
-    public void Identify(IIdentities identities, RdId id) { throw new System.NotImplementedException(); }
+    public void Identify(IIdentities identities, RdId id) { throw new NotImplementedException(); }
   }
 }

--- a/rd-net/Test.RdFramework/Util/RdBindableExUtilTest.cs
+++ b/rd-net/Test.RdFramework/Util/RdBindableExUtilTest.cs
@@ -41,7 +41,7 @@ public class RdBindableExUtilTest
     Assert.IsFalse(new List<object> { i }.IsBindable());
 
 #if !NET35
-    Assert.IsFalse(ImmutableArray.Create<int>().IsBindable());
+    Assert.IsFalse(((ImmutableArray<int>)default).IsBindable()); // cannot be enumerated, but should not throw exception
     Assert.IsFalse(ImmutableArray.Create(1).IsBindable());
 #endif
   } 


### PR DESCRIPTION
`new ImmutableArray<int>()` is invalid.

This test generates an exception on all the platforms:
```
System.InvalidOperationException : This operation cannot be performed on a default instance of ImmutableArray<T>.  Consider initializing the array, or checking the ImmutableArray<T>.IsDefault property.
   at System.Collections.Immutable.ImmutableArray`1.ThrowInvalidOperationIfNotInitialized()
   at System.Collections.Immutable.ImmutableArray`1.System.Collections.IEnumerable.GetEnumerator()
   at JetBrains.Rd.Base.RdBindableEx.IsBindable[T](T obj) in D:\a\rd\rd\rd-net\RdFramework\Base\IRdBindable.cs:line 170
   at Test.RdFramework.Util.RdBindableExUtilTest.IsBindableTest() in D:\a\rd\rd\rd-net\Test.RdFramework\Util\RdBindableExUtilTest.cs:line 44
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```