### PR TITLE
rd-kt: fix partial read behavior in `SocketWire`

### DIFF
--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/SocketWire.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/SocketWire.kt
@@ -267,7 +267,10 @@ class SocketWire {
 
                         pkg = ByteArray(len)
                         pos = 0
-                        stream.readByteArray(pkg)
+                        if (!stream.readByteArray(pkg)) {
+                            pkg = ByteArray(0)
+                            return -1
+                        }
 
                         if (seqn > maxReceivedSeqn) {
                             maxReceivedSeqn = seqn


### PR DESCRIPTION
Before this change, the following was theoretically possible: we read a package body, then disconnect happens in the middle, and we end up with partial body filled with zeros. We'll try to interpret it as valid payload instead of handling the disconnect. Disconnect will only be detected when we try reading the next package.

After the change, we detect the problem immediately, and reset the `PkgInputStream`'s state, so that the new `read()`s also hit the same barrier.