### PR TITLE
fix sync calls timeout tests

### DIFF
--- a/rd-net/RdFramework.Reflection/ProxyGeneratorUtil.cs
+++ b/rd-net/RdFramework.Reflection/ProxyGeneratorUtil.cs
@@ -67,7 +67,7 @@ namespace JetBrains.Rd.Reflection
       var scheduler = protocol.Scheduler as IRunWhileScheduler;
       Assertion.Assert(scheduler != null, "Scheduler must implement IRunWhileScheduler for nested calls. Scheduler type: {0}", protocol.Scheduler.GetType());
 
-      var task = call.Start(lifetime, request, null);
+      var task = (RdTask<TRes>)call.Start(lifetime, request, null);
 
       RpcTimeouts timeoutsToUse = RpcTimeouts.GetRpcTimeouts(timeouts);
 
@@ -78,7 +78,10 @@ namespace JetBrains.Rd.Reflection
       stopwatch.Stop();
 
       if (!completed)
+      {
+        task.SetCancelled();
         throw new TimeoutException($"Sync execution of rpc `{call.Location}` is timed out in {timeoutsToUse.ErrorAwaitTime.TotalMilliseconds} ms");
+      }
 
       var freezeTime = stopwatch.ElapsedMilliseconds;
       if (freezeTime > timeoutsToUse.WarnAwaitTime.TotalMilliseconds)

--- a/rd-net/Test.RdFramework/Reflection/ProxyGeneratorRpcTimeoutOverrideTest.cs
+++ b/rd-net/Test.RdFramework/Reflection/ProxyGeneratorRpcTimeoutOverrideTest.cs
@@ -1,8 +1,9 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using JetBrains.Lifetimes;
 using JetBrains.Rd.Reflection;
 using NUnit.Framework;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Test.RdFramework.Reflection;
 
@@ -18,32 +19,31 @@ public class ProxyGeneratorRpcTimeoutOverrideTest : ProxyGeneratorTestBase
   public interface ICallTest
   {
     [RpcTimeout(1)]
-    void MTimeout();
+    void MTimeout(Lifetime cancel);
 
     [RpcTimeout]
-    void MQuick();
+    void MQuick(Lifetime cancel);
   }
 
   [RdExt]
   internal class CallTest : RdExtReflectionBindableBase, ICallTest
   {
-    public void MTimeout() => Thread.Sleep(50);
-    public void MQuick() { }
+    public void MTimeout(Lifetime cancel) => SpinWait.SpinUntil(() => !cancel.IsAlive, 5000);
+    public void MQuick(Lifetime cancel) { }
   }
 
-  [Test]
+  [Test, Timeout(1000)]
   public async Task TestRpcTimeouts()
   {
     ThrowLoggedExceptions();
 
     await TestTemplate<CallTest, ICallTest>(model =>
     {
-      model.MQuick(); // should not throw, timeouts are satisfied
-      ThrowLoggedExceptions(); 
+      model.MQuick(TestLifetime); // should not throw, timeouts are satisfied
+      ThrowLoggedExceptions();
 
-      // should produce log message with level=Error, timeout 1ms is violated
-      model.MTimeout();
-      Assert.Throws<Exception>(ThrowLoggedExceptions);
+      // should exit fast, expected timeout 1ms is violated, returning TimeoutException
+      Assert.Throws<TimeoutException>(() => model.MTimeout(TestLifetime));
 
       return Task.CompletedTask;
     });
@@ -54,22 +54,21 @@ public class ProxyGeneratorRpcTimeoutOverrideTest : ProxyGeneratorTestBase
   [RdRpc, RpcTimeout(1)]
   public interface ICall2Test
   {
-    void MTimeout();
+    void MTimeout(Lifetime cancel);
   }
   [RdExt]
   internal class Call2Test : RdExtReflectionBindableBase, ICall2Test
   {
-    public void MTimeout() => Thread.Sleep(50);
+    public void MTimeout(Lifetime cancel) => SpinWait.SpinUntil(() => !cancel.IsAlive, 5000);
   }
 
-  [Test]
+  [Test, Timeout(1000)]
   public async Task TestRpcTimeouts2()
   {
     await TestTemplate<Call2Test, ICall2Test>(model =>
     {
-      // should produce log message with level=Error, timeout 1ms is violated
-      model.MTimeout();
-      Assert.Throws<Exception>(ThrowLoggedExceptions);
+      // should exit fast, expected timeout 1ms is violated, returning TimeoutException
+      Assert.Throws<TimeoutException>(() => model.MTimeout(TestLifetime));
       return Task.CompletedTask;
     });
   }


### PR DESCRIPTION
The expected behavior was wrongly documented in tests and implemented: we expect that sync calls will throw on timeout. It was the designed behaviour for Rider and ReSharper OOP to prevent deadlocks.
The mistake was caused by the tricky SwitchingScheduler logic, which relies on static and cannot be properly mocked in a single-process application.

After chaning sync nested logic in #595 and correcton in #609 these tests finally checks that they were supposed to check