### PR TITLE
Suppress the compiler warning regarding the javaClass.classLoader

### DIFF
--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/kotlin/Kotlin11Generator.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/kotlin/Kotlin11Generator.kt
@@ -632,6 +632,7 @@ open class Kotlin11Generator(
             types.filter { !it.isAbstract }.filterIsInstance<IType>().forEach {
                 if (it is Declaration) {
                     if (first && collector.shouldGenerateRegistrations) {
+                        + """@Suppress("JAVA_CLASS_ON_COMPANION")"""
                         +"val classLoader = javaClass.classLoader"
                         first = false
                     }

--- a/rd-kt/rd-gen/src/test/resources/testData/callGeneratedCode/asis/CallGeneratedCodeRoot.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/callGeneratedCode/asis/CallGeneratedCodeRoot.kt
@@ -25,6 +25,7 @@ class CallGeneratedCodeRoot private constructor(
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
+            @Suppress("JAVA_CLASS_ON_COMPANION")
             val classLoader = javaClass.classLoader
             serializers.register(LazyCompanionMarshaller(RdId(18933576544), classLoader, "call.generated.code.root.Editor"))
             serializers.register(LazyCompanionMarshaller(RdId(20513), classLoader, "call.generated.code.root.Es"))

--- a/rd-kt/rd-gen/src/test/resources/testData/callGeneratedCode/reversed/CallGeneratedCodeRoot.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/callGeneratedCode/reversed/CallGeneratedCodeRoot.kt
@@ -25,6 +25,7 @@ class CallGeneratedCodeRoot private constructor(
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
+            @Suppress("JAVA_CLASS_ON_COMPANION")
             val classLoader = javaClass.classLoader
             serializers.register(LazyCompanionMarshaller(RdId(18933576544), classLoader, "call.generated.code.root.Editor"))
             serializers.register(LazyCompanionMarshaller(RdId(20513), classLoader, "call.generated.code.root.Es"))

--- a/rd-kt/rd-gen/src/test/resources/testData/defaultNlsValues/asis/DefaultNlsValuesRoot.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/defaultNlsValues/asis/DefaultNlsValuesRoot.kt
@@ -25,6 +25,7 @@ class DefaultNlsValuesRoot private constructor(
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
+            @Suppress("JAVA_CLASS_ON_COMPANION")
             val classLoader = javaClass.classLoader
             serializers.register(LazyCompanionMarshaller(RdId(17439278522805508), classLoader, "DefaultNlsValuesRoot.ClassModel"))
             DefaultNlsValuesRoot.register(serializers)

--- a/rd-kt/rd-gen/src/test/resources/testData/defaultNlsValues/reversed/DefaultNlsValuesRoot.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/defaultNlsValues/reversed/DefaultNlsValuesRoot.kt
@@ -25,6 +25,7 @@ class DefaultNlsValuesRoot private constructor(
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
+            @Suppress("JAVA_CLASS_ON_COMPANION")
             val classLoader = javaClass.classLoader
             serializers.register(LazyCompanionMarshaller(RdId(17439278522805508), classLoader, "DefaultNlsValuesRoot.ClassModel"))
             DefaultNlsValuesRoot.register(serializers)

--- a/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/asis/ExampleModelNova.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/asis/ExampleModelNova.kt
@@ -31,6 +31,7 @@ class ExampleModelNova private constructor(
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
+            @Suppress("JAVA_CLASS_ON_COMPANION")
             val classLoader = javaClass.classLoader
             serializers.register(LazyCompanionMarshaller(RdId(576020388116153), classLoader, "org.example.Selection"))
             serializers.register(LazyCompanionMarshaller(RdId(632584), classLoader, "org.example.Baz"))

--- a/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/reversed/ExampleModelNova.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/reversed/ExampleModelNova.kt
@@ -31,6 +31,7 @@ class ExampleModelNova private constructor(
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
+            @Suppress("JAVA_CLASS_ON_COMPANION")
             val classLoader = javaClass.classLoader
             serializers.register(LazyCompanionMarshaller(RdId(576020388116153), classLoader, "org.example.Selection"))
             serializers.register(LazyCompanionMarshaller(RdId(632584), classLoader, "org.example.Baz"))

--- a/rd-kt/rd-gen/src/test/resources/testData/extensionTest/asis/ExtensionRoot.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/extensionTest/asis/ExtensionRoot.kt
@@ -25,6 +25,7 @@ class ExtensionRoot private constructor(
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
+            @Suppress("JAVA_CLASS_ON_COMPANION")
             val classLoader = javaClass.classLoader
             serializers.register(LazyCompanionMarshaller(RdId(-1687597404575351130), classLoader, "ExtensionRoot.ClassWithStr"))
             serializers.register(LazyCompanionMarshaller(RdId(-2602185343174852445), classLoader, "ExtensionRoot.StructWithStr"))

--- a/rd-kt/rd-gen/src/test/resources/testData/extensionTest/reversed/ExtensionRoot.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/extensionTest/reversed/ExtensionRoot.kt
@@ -25,6 +25,7 @@ class ExtensionRoot private constructor(
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
+            @Suppress("JAVA_CLASS_ON_COMPANION")
             val classLoader = javaClass.classLoader
             serializers.register(LazyCompanionMarshaller(RdId(-1687597404575351130), classLoader, "ExtensionRoot.ClassWithStr"))
             serializers.register(LazyCompanionMarshaller(RdId(-2602185343174852445), classLoader, "ExtensionRoot.StructWithStr"))

--- a/rd-kt/rd-gen/src/test/resources/testData/interningModelsTest/asis/InternedModelsRoot.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/interningModelsTest/asis/InternedModelsRoot.kt
@@ -26,6 +26,7 @@ class InternedModelsRoot private constructor(
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
+            @Suppress("JAVA_CLASS_ON_COMPANION")
             val classLoader = javaClass.classLoader
             serializers.register(LazyCompanionMarshaller(RdId(18933576544), classLoader, "InternedModelsRoot.Editor"))
             serializers.register(LazyCompanionMarshaller(RdId(631631), classLoader, "InternedModelsRoot.Abc"))

--- a/rd-kt/rd-gen/src/test/resources/testData/interningModelsTest/reversed/InternedModelsRoot.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/interningModelsTest/reversed/InternedModelsRoot.kt
@@ -26,6 +26,7 @@ class InternedModelsRoot private constructor(
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
+            @Suppress("JAVA_CLASS_ON_COMPANION")
             val classLoader = javaClass.classLoader
             serializers.register(LazyCompanionMarshaller(RdId(18933576544), classLoader, "InternedModelsRoot.Editor"))
             serializers.register(LazyCompanionMarshaller(RdId(631631), classLoader, "InternedModelsRoot.Abc"))

--- a/rd-kt/rd-gen/src/test/resources/testData/perClientId/asis/PerClientIdRoot.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/perClientId/asis/PerClientIdRoot.kt
@@ -30,6 +30,7 @@ class PerClientIdRoot private constructor(
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
+            @Suppress("JAVA_CLASS_ON_COMPANION")
             val classLoader = javaClass.classLoader
             serializers.register(LazyCompanionMarshaller(RdId(17599967238820149), classLoader, "com.jetbrains.rd.framework.test.cases.perClientId.InnerClass"))
             serializers.register(LazyCompanionMarshaller(RdId(948719498381570149), classLoader, "com.jetbrains.rd.framework.test.cases.perClientId.PerClientIdStruct"))

--- a/rd-kt/rd-gen/src/test/resources/testData/perClientId/reversed/PerClientIdRoot.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/perClientId/reversed/PerClientIdRoot.kt
@@ -30,6 +30,7 @@ class PerClientIdRoot private constructor(
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
+            @Suppress("JAVA_CLASS_ON_COMPANION")
             val classLoader = javaClass.classLoader
             serializers.register(LazyCompanionMarshaller(RdId(17599967238820149), classLoader, "com.jetbrains.rd.framework.test.cases.perClientId.InnerClass"))
             serializers.register(LazyCompanionMarshaller(RdId(948719498381570149), classLoader, "com.jetbrains.rd.framework.test.cases.perClientId.PerClientIdStruct"))

--- a/rd-kt/rd-gen/src/test/resources/testData/recursivePolymorphicModelTest/asis/RecursivePolymorphicModel.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/recursivePolymorphicModelTest/asis/RecursivePolymorphicModel.kt
@@ -27,6 +27,7 @@ class RecursivePolymorphicModel private constructor(
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
+            @Suppress("JAVA_CLASS_ON_COMPANION")
             val classLoader = javaClass.classLoader
             serializers.register(LazyCompanionMarshaller(RdId(8163186073645594862), classLoader, "org.example.BeTreeGridLine"))
             serializers.register(LazyCompanionMarshaller(RdId(7212854712083994073), classLoader, "org.example.BeTreeGridLine_Unknown"))

--- a/rd-kt/rd-gen/src/test/resources/testData/recursivePolymorphicModelTest/reversed/RecursivePolymorphicModel.kt
+++ b/rd-kt/rd-gen/src/test/resources/testData/recursivePolymorphicModelTest/reversed/RecursivePolymorphicModel.kt
@@ -27,6 +27,7 @@ class RecursivePolymorphicModel private constructor(
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
+            @Suppress("JAVA_CLASS_ON_COMPANION")
             val classLoader = javaClass.classLoader
             serializers.register(LazyCompanionMarshaller(RdId(8163186073645594862), classLoader, "org.example.BeTreeGridLine"))
             serializers.register(LazyCompanionMarshaller(RdId(7212854712083994073), classLoader, "org.example.BeTreeGridLine_Unknown"))


### PR DESCRIPTION
Suppress the compiler warning regarding the `javaClass.classLoader` in `registerSerializersCore`
Fix #492 