### PR TITLE
  Fix race condition where TerminateInternal didn't wake up ThreadProc but waited for its completion

### DIFF
--- a/rd-net/Lifetimes/Threading/ByteBufferAsyncProcessor.cs
+++ b/rd-net/Lifetimes/Threading/ByteBufferAsyncProcessor.cs
@@ -105,6 +105,7 @@ namespace JetBrains.Threading
     private Chunk myChunkToFill;
 
     private bool myProcessing;
+    private long myProcessingFinishWaitingCount = 0;
     
     private volatile Chunk myChunkToProcess;
 
@@ -185,7 +186,8 @@ namespace JetBrains.Threading
         }
 
         State = state;
-        Monitor.Pulse(myLock);
+        // Use pulse all to wake up ThreadProc even if there is another waiter (to avoid accidentally leaving ThreadProc in wait infinitely) 
+        Monitor.PulseAll(myLock);
       }
 
       var res =  myAsyncProcessingThread.Join(timeoutMs);
@@ -247,8 +249,7 @@ namespace JetBrains.Threading
       Assertion.Require(Thread.CurrentThread != myAsyncProcessingThread);
       lock (myLock)
       {
-        while (myProcessing) 
-          Monitor.Wait(myLock, 1);
+        WaitProcessingFinished();
 
         var chunk = myChunkToFill.Next;
         while (chunk != myChunkToFill)
@@ -333,9 +334,21 @@ namespace JetBrains.Threading
               if (myChunkToProcess.Ptr == 0)
                 myAllDataProcessed = true;
             }
+
+            if (myProcessingFinishWaitingCount > 0)
+            {
+              Monitor.PulseAll(myLock);
+            }
           }
         }
       }
+    }
+    
+    [MustUseReturnValue]
+    private ProcessingFinishedCountCookie ProcessingFinishedCookie()
+    {
+      Assertion.Assert(Monitor.IsEntered(myLock));
+      return new ProcessingFinishedCountCookie(this);
     }
 
     #endregion
@@ -408,8 +421,11 @@ namespace JetBrains.Threading
     {
       if (Thread.CurrentThread == myAsyncProcessingThread) return; //don't want to deadlock
       
-      while (myProcessing) 
-        Monitor.Wait(myLock, 1);
+      using (ProcessingFinishedCookie())
+      {
+        while (myProcessing) 
+          Monitor.Wait(myLock, 1);
+      }
     }
 
     public bool Resume([NotNull] string reason)
@@ -547,5 +563,21 @@ namespace JetBrains.Threading
     }
     #endregion
 
+    private readonly ref struct ProcessingFinishedCountCookie
+    {
+      private readonly ByteBufferAsyncProcessor myProcessor;
+
+      public ProcessingFinishedCountCookie(ByteBufferAsyncProcessor processor)
+      {
+        myProcessor = processor;
+        processor.myProcessingFinishWaitingCount++;
+      }
+
+      public void Dispose()
+      {
+        myProcessor.myProcessingFinishWaitingCount--;
+        Assertion.Assert(Monitor.IsEntered(myProcessor.myLock));
+      }
+    }
   }
 }

--- a/rd-net/Test.Lifetimes/Threading/ByteBufferAsyncProcessorTest.cs
+++ b/rd-net/Test.Lifetimes/Threading/ByteBufferAsyncProcessorTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -241,6 +242,38 @@ namespace Test.Lifetimes.Threading
       {
         cookie.Writer.WriteInt64(l);
         buffer.Put(cookie);
+      }
+    }
+  
+    [Test]
+    public void AbandonedThreadProcTest()
+    {
+      const string disconnect = "Disconnect";
+      for (int i = 0; i < 20_000; i++)
+      {
+        ByteBufferAsyncProcessor processor = null;
+        
+        var bytes = new byte[1];
+        var tasks = new ConcurrentQueue<Task>();
+        var mre = new ManualResetEvent(false);
+        
+        processor = new ByteBufferAsyncProcessor("Processor", (byte[] data, int offset, int len, ref long n) =>
+        {
+          mre.Set();
+          processor!.Pause(disconnect);
+          
+          tasks.Enqueue(Task.Run(() =>
+          {
+            processor.Pause(disconnect);
+          }));
+        });
+        
+        processor.Start();
+        processor.Put(bytes);
+        mre.WaitOne();
+        var success = processor.Stop(5000);
+        Assert.IsTrue(success);
+        Task.WaitAll(tasks.ToArray());
       }
     }
   }


### PR DESCRIPTION
  The race can happen in the following scenario:

  1) Sender thread pauses the processor due to a socket closed exception while it is still in the processing state
  2) Receiver thread also pauses the processor and waits for the current processing task via WaitProcessingFinished
  3) Sender thread completes the active task and waits for pulse/resume because there is an active pause reason

  !!!Now ThreadProc is second in the wait queue!!!

  4) Main thread tries to stop the processor, updates state to Stopping, and pulses ONLY ONE waiter — the Pause call waiting for current task completion
  5) Receiver thread leaves Pause (since it was notified) but ThreadProc is not woken up
  6) Main thread waits 5 seconds for the processor thread to complete

  The fix:
  - TerminateInternal now wakes up all waiters
  - ThreadProc now wakes up all myProcessing waiters

  Add a test