### PR TITLE
Fix RdId colision degradation for legacy identities

### DIFF
--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Identities.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Identities.kt
@@ -103,11 +103,11 @@ class Identities(override val dynamicKind : IdKind) : IIdentities {
         return RdIdUtil.mix(rdId, tail)
     }
 
-    override fun mix(rdId: RdId, tail: Int): RdId {
+    fun mix(rdId: RdId, tail: Int): RdId {
         return RdIdUtil.mix(rdId, tail)
     }
 
-    override fun mix(rdId: RdId, tail: Long): RdId {
+    fun mix(rdId: RdId, tail: Long): RdId {
         return RdIdUtil.mix(rdId, tail)
     }
 }
@@ -141,14 +141,12 @@ class SequentialIdentities(override val dynamicKind : IdKind) : IIdentities {
     }
 
     override fun mix(rdId: RdId, tail: String): RdId {
-        return RdId(StableMask or RdIdUtil.mix(rdId, tail).hash)
-    }
-
-    override fun mix(rdId: RdId, tail: Int): RdId {
-        return RdId(StableMask or RdIdUtil.mix(rdId, tail).hash)
-    }
-
-    override fun mix(rdId: RdId, tail: Long): RdId {
-        return RdId(StableMask or RdIdUtil.mix(rdId, tail).hash)
+        // Since dynamic RdIds are generated sequentially, the parent RdId often uses only a small number of bits (low entropy).
+        // Additionally, the tail string may be short, which can increase the risk of hash collisions.
+        // To improve hash distribution and reliability, we mix in extra data (tail length and a constant string) before mixing the tail itself.
+        var newRdId = RdIdUtil.mix(rdId, tail.length)
+        newRdId = RdIdUtil.mix(newRdId, "SequentialIdentities::Mix::RdId")
+        newRdId = RdIdUtil.mix(newRdId, tail)
+        return RdId(StableMask or newRdId.hash)
     }
 }

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Interfaces.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Interfaces.kt
@@ -173,16 +173,6 @@ interface IIdentities {
      * Creates a stable identifier by mixing the parent ID with a string key.
      */
     fun mix(rdId: RdId, tail: String): RdId
-
-    /**
-     * Creates a stable identifier by mixing the parent ID with an integer key.
-     */
-    fun mix(rdId: RdId, tail: Int): RdId
-
-    /**
-     * Creates a stable identifier by mixing the parent ID with a long key.
-     */
-    fun mix(rdId: RdId, tail: Long): RdId
 }
 
 /**

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Protocol.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/Protocol.kt
@@ -130,7 +130,7 @@ class Protocol internal constructor(
                 val newExtension = create()
                 extensions[clazz] = newExtension
                 val declName = clazz.simpleName ?: error("Can't get simple name for class $clazz")
-                newExtension.identify(identity, identity.mix(RdId.Null, declName))
+                newExtension.identify(identity, identity.mix(RdId.Null, declName), true)
                 newExtension.bindTopLevel(lifetime, this, declName)
                 newExtension
             }

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/IRdBindable.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/IRdBindable.kt
@@ -5,6 +5,7 @@ package com.jetbrains.rd.framework.base
 import com.jetbrains.rd.framework.IIdentities
 import com.jetbrains.rd.framework.IProtocol
 import com.jetbrains.rd.framework.IRdDynamic
+import com.jetbrains.rd.framework.Identities
 import com.jetbrains.rd.framework.RdId
 import com.jetbrains.rd.util.lifetime.Lifetime
 
@@ -26,9 +27,25 @@ interface IRdBindable : IRdDynamic {
     fun bind()
 
     /**
-     * Assigns IDs to this node and its child nodes in the graph.
+     * Assigns an [RdId] to this node and recursively to all its child nodes.
+     *
+     * @param identities the identity source used to generate child IDs.
+     * @param id the [RdId] to assign to this node.
+     * @param stable a recommendation for how child RdIds should be generated. Entities may override this value.
+     *   - `true` — uses [IIdentities.mix] to produce hash-based, deterministic IDs derived from the parent ID
+     *     and child name. Used when the same entity exists on both protocol sides and its children need
+     *     matching IDs to find each other (e.g., extensions with built-in maps, sets, properties).
+     *     Given the same parent ID, both sides will compute identical child IDs.
+     *   - `false` — uses [IIdentities.next] to produce dynamic IDs.
+     *     Used for entities created at runtime (e.g., items added to RdMap/RdList) where each side assigns
+     *     its own IDs independently.
+     *
+     * Entities can override this parameter when their children require a specific strategy. For example,
+     * [RdExtBase] forces `stable = true` regardless of the incoming value, because its built-in children
+     * are part of a statically known structure that must match on both protocol sides. So even if an ext
+     * is encountered during dynamic (non-stable) identification, it will switch to stable IDs for its own subtree.
      */
-    fun identify(identities: IIdentities, id: RdId)
+    fun identify(identities: IIdentities, id: RdId, stable: Boolean)
 
     /**
      * Creates a clone of this IRdBindable not bound to any protocol
@@ -36,25 +53,54 @@ interface IRdBindable : IRdDynamic {
     fun deepClone() : IRdBindable = TODO("This is a base implementation of deepClone. Shouldn't be invoked. Introduced for AWS plugin to compile with Rider SDK 19.2.")
 }
 
+private fun computeChildRdId(identities: IIdentities, parent: RdId, stable: Boolean, i: Int): RdId {
+    return if (stable) {
+        if (identities is Identities) {
+            // for backward compatibility
+            identities.mix(parent, i)
+        } else {
+            identities.mix(parent, i.toString(2))
+        }
+    } else {
+        identities.next(parent)
+    }
+}
+
 //generator comprehension methods
 fun <T:IRdBindable?> T.preBind(lf: Lifetime, parent: IRdDynamic, name: String) = this?.preBind(lf, parent, name)
 fun <T:IRdBindable?> T.bind() = this?.bind()
-fun <T:IRdBindable?> T.identify(identities: IIdentities, ids: RdId) = this?.identify(identities, ids)
+fun <T:IRdBindable?> T.identify(identities: IIdentities, ids: RdId, stable: Boolean) = this?.identify(identities, ids, stable)
 
-fun <T:IRdBindable?> Array<T>.identify(identities: IIdentities, ids: RdId) = forEachIndexed { i, v ->  v?.identify(identities, identities.mix(ids, i))}
+fun <T:IRdBindable?> Array<T>.identify(identities: IIdentities, ids: RdId, stable: Boolean) = forEachIndexed { i, v ->  v?.identify(
+    identities,
+    computeChildRdId(identities, ids, stable, i),
+    stable
+)}
 fun <T:IRdBindable?> Array<T>.preBind(lf: Lifetime, parent: IRdDynamic, name: String) = forEachIndexed { i, v ->  v?.preBind(lf,parent, "$name[$i]")}
 fun <T:IRdBindable?> Array<T>.bind() = forEachIndexed { i, v ->  v?.bind()}
 
-fun <T:IRdBindable?> List<T>.identify(identities: IIdentities, ids: RdId) = forEachIndexed { i, v ->  v?.identify(identities, identities.mix(ids, i))}
+fun <T:IRdBindable?> List<T>.identify(identities: IIdentities, ids: RdId, stable: Boolean) = forEachIndexed { i, v ->  v?.identify(
+    identities,
+    computeChildRdId(identities, ids, stable, i),
+    stable,
+)}
 fun <T:IRdBindable?> List<T>.preBind(lf: Lifetime, parent: IRdDynamic, name: String) = forEachIndexed { i, v ->  v?.preBind(lf,parent, "$name[$i]")}
 fun <T:IRdBindable?> List<T>.bind() = forEachIndexed { i, v ->  v?.bind()}
 
-internal fun Any?.identifyPolymorphic(identities: IIdentities, ids: RdId) {
+internal fun Any?.identifyPolymorphic(identities: IIdentities, ids: RdId, stable: Boolean) {
     if (this is IRdBindable) {
-        this.identify(identities, ids)
+        this.identify(identities, ids, stable)
     } else {
-        (this as? Array<*>)?.forEachIndexed { i, v  ->  (v as? IRdBindable)?.identify(identities, identities.mix(ids, i))}
-        (this as? List<*>)?.forEachIndexed { i, v  ->  (v as? IRdBindable)?.identify(identities, identities.mix(ids, i))}
+        (this as? Array<*>)?.forEachIndexed { i, v  ->  (v as? IRdBindable)?.identify(
+            identities,
+            computeChildRdId(identities, ids, stable, i),
+            stable,
+        )}
+        (this as? List<*>)?.forEachIndexed { i, v  ->  (v as? IRdBindable)?.identify(
+            identities,
+            computeChildRdId(identities, ids, stable, i),
+            stable,
+        )}
     }
 
 }

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/IRdBindable.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/IRdBindable.kt
@@ -54,13 +54,15 @@ interface IRdBindable : IRdDynamic {
 }
 
 private fun computeChildRdId(identities: IIdentities, parent: RdId, stable: Boolean, i: Int): RdId {
+    // Legacy Identities: always use mix(parent, i) — pre-fix behavior had better effective distribution
+    // for collection elements than next(parent), whose underlying hash mix(parent, counter) is a poor
+    // linear function (acc*31 + counter+1). Restore that for backward compatibility with users that
+    // haven't migrated to SequentialIdentities.
+    if (identities is Identities) {
+        return identities.mix(parent, i)
+    }
     return if (stable) {
-        if (identities is Identities) {
-            // for backward compatibility
-            identities.mix(parent, i)
-        } else {
-            identities.mix(parent, i.toString(2))
-        }
+        identities.mix(parent, i.toString(2))
     } else {
         identities.next(parent)
     }

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdBindableBase.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdBindableBase.kt
@@ -138,7 +138,7 @@ abstract class RdBindableBase : IRdBindable, IPrintable {
                     val localBindLifetime = bindLifetime
                     if (localBindLifetime.isAlive) {
                         if (newExtension.rdid == RdId.Null)
-                            newExtension.identify(proto.identity, proto.identity.mix(rdid, ".$name"))
+                            newExtension.identify(proto.identity, proto.identity.mix(rdid, ".$name"), true)
                         newExtension.preBind(localBindLifetime, this, name)
                         newExtension.bind()
                     }
@@ -205,13 +205,21 @@ abstract class RdBindableBase : IRdBindable, IPrintable {
         return child.findByRName(rName.dropNonEmptyRoot())
     }
     
-    override fun identify(identities: IIdentities, id: RdId) {
+    override fun identify(identities: IIdentities, id: RdId, stable: Boolean) {
         require(rdid.isNull) { "Already has RdId: $rdid, entity: $this" }
         require(!id.isNull) { "Assigned RdId mustn't be null, entity: $this" }
 
         rdid = id
         for ((name, child) in bindableChildren) {
-            child?.identifyPolymorphic(identities, identities.mix(id, ".$name"))
+            child?.identifyPolymorphic(identities, computeChildRdId(identities, id, name, stable), stable)
+        }
+    }
+
+    private fun computeChildRdId(identities: IIdentities, parent: RdId, name: String, stable: Boolean): RdId {
+        return if (stable) {
+            identities.mix(parent, ".$name")
+        } else {
+            identities.next(parent)
         }
     }
 

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdBindableBase.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdBindableBase.kt
@@ -216,6 +216,11 @@ abstract class RdBindableBase : IRdBindable, IPrintable {
     }
 
     private fun computeChildRdId(identities: IIdentities, parent: RdId, name: String, stable: Boolean): RdId {
+        // Legacy Identities: always use mix(parent, ".$name") regardless of stable — restores pre-fix
+        // behavior for users that haven't migrated to SequentialIdentities.
+        if (identities is Identities) {
+            return identities.mix(parent, ".$name")
+        }
         return if (stable) {
             identities.mix(parent, ".$name")
         } else {

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/base/RdExtBase.kt
@@ -113,6 +113,14 @@ abstract class RdExtBase : RdReactiveBase() {
         })
     }
 
+    override fun identify(
+        identities: IIdentities,
+        id: RdId,
+        stable: Boolean
+    ) {
+        super.identify(identities, id, true)  // enforce true to make stable ids for each built-in child
+    }
+
     override fun assertBindingThread() = Unit
 
     override fun onWireReceived(proto: IProtocol, buffer: AbstractBuffer, ctx: SerializationCtx, dispatchHelper: IRdWireableDispatchHelper) {

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/AsyncRdMap.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/AsyncRdMap.kt
@@ -77,9 +77,9 @@ class AsyncRdMap<K : Any, V : Any> private constructor(
         }
     }
 
-    override fun identify(identities: IIdentities, id: RdId) {
+    override fun identify(identities: IIdentities, id: RdId, stable: Boolean) {
         synchronized(map) {
-            map.identify(identities, id)
+            map.identify(identities, id, stable)
         }
     }
 

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/AsyncRdProperty.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/AsyncRdProperty.kt
@@ -162,7 +162,7 @@ class AsyncRdProperty<T>(val valueSerializer: ISerializer<T> = Polymorphic()) : 
         }
     }
 
-    override fun identify(identities: IIdentities, id: RdId) {
+    override fun identify(identities: IIdentities, id: RdId, stable: Boolean) {
         require(!id.isNull) { "Assigned RdId mustn't be null, entity: $this" }
 
         synchronized (property) {

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/AsyncRdSet.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/AsyncRdSet.kt
@@ -76,9 +76,9 @@ class AsyncRdSet<T : Any> private constructor(
         }
     }
 
-    override fun identify(identities: IIdentities, id: RdId) {
+    override fun identify(identities: IIdentities, id: RdId, stable: Boolean) {
         synchronized(set) {
-            set.identify(identities, id)
+            set.identify(identities, id, stable)
         }
     }
 

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/InternRoot.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/InternRoot.kt
@@ -130,7 +130,7 @@ class InternRoot<TBase: Any>(val serializer: ISerializer<TBase> = Polymorphic())
 
     }
 
-    override fun identify(identities: IIdentities, id: RdId) {
+    override fun identify(identities: IIdentities, id: RdId, stable: Boolean) {
         require(rdid.isNull) { "Already has RdId: $rdid, entity: $this" }
         require(!id.isNull) { "Assigned RdId mustn't be null, entity: $this" }
 

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdList.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdList.kt
@@ -65,7 +65,7 @@ class RdList<V : Any> private constructor(val valSzr: ISerializer<V>, private va
             for (index in 0 until size) {
                 val item = this[index]
                 if (item != null) {
-                    item.identifyPolymorphic(proto.identity, proto.identity.next(rdid))
+                    item.identifyPolymorphic(proto.identity, proto.identity.next(rdid), false)
                     definitions.add(tryPreBindValue(lifetime, item, index, false))
                 }
             }
@@ -95,7 +95,7 @@ class RdList<V : Any> private constructor(val valSzr: ISerializer<V>, private va
 
                     val value = it.newValueOpt
                     if (it !is IViewableList.Event.Remove) {
-                        value.identifyPolymorphic(proto.identity, proto.identity.next(rdid))
+                        value.identifyPolymorphic(proto.identity, proto.identity.next(rdid), false)
                         definitions.add(it.index, tryPreBindValue(lifetime, value, it.index, false))
                     }
                 }

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdMap.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdMap.kt
@@ -64,7 +64,7 @@ open class RdMap<K : Any, V : Any> private constructor(
 
             for ((key, value) in this) {
                 if (value != null) {
-                    value.identifyPolymorphic(proto.identity, proto.identity.next(rdid))
+                    value.identifyPolymorphic(proto.identity, proto.identity.next(rdid), false)
                     val definition = tryPreBindValue(lifetime, key, value, false)
                     if (definition != null)
                         definitions[key] = definition
@@ -96,7 +96,7 @@ open class RdMap<K : Any, V : Any> private constructor(
 
                     if (it !is IViewableMap.Event.Remove) {
                         val value = it.newValueOpt
-                        value.identifyPolymorphic(proto.identity, proto.identity.next(rdid))
+                        value.identifyPolymorphic(proto.identity, proto.identity.next(rdid), false)
                         val definition = tryPreBindValue(lifetime, it.key, value, false)
                         definitions.put(it.key, definition)?.terminate()
                     }

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdProperty.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdProperty.kt
@@ -80,7 +80,7 @@ abstract class RdPropertyBase<T>(val valueSerializer: ISerializer<T>) : RdReacti
                 // We need to terminate the current lifetime to unbind the existing value before assigning a new value, especially in cases where we are reassigning it.
                 bindDefinition.get()?.terminate()
 
-                v.identifyPolymorphic(proto.identity, proto.identity.next(rdid))
+                v.identifyPolymorphic(proto.identity, proto.identity.next(rdid), false)
 
                 val prevDefinition = bindDefinition.getAndSet(tryPreBindValue(lifetime, v, false))
                 prevDefinition?.terminate()
@@ -207,10 +207,10 @@ class RdOptionalProperty<T : Any>(valueSerializer: ISerializer<T> = Polymorphic(
         }
     }
 
-    override fun identify(identities: IIdentities, id: RdId) {
-        super.identify(identities, id)
+    override fun identify(identities: IIdentities, id: RdId, stable: Boolean) {
+        super.identify(identities, id, stable)
         if (!optimizeNested)
-            valueOrNull?.identifyPolymorphic(identities, identities.next(id))
+            valueOrNull?.identifyPolymorphic(identities, identities.next(id), false)
     }
 
     override fun advise(lifetime: Lifetime, handler: (T) -> Unit) {
@@ -290,10 +290,10 @@ class RdProperty<T>(defaultValue: T, valueSerializer: ISerializer<T> = Polymorph
         value = newValue
     }
 
-    override fun identify(identities: IIdentities, id: RdId) {
-        super.identify(identities, id)
+    override fun identify(identities: IIdentities, id: RdId, stable: Boolean) {
+        super.identify(identities, id, stable)
         if (!optimizeNested)
-            value?.identifyPolymorphic(identities, identities.next(id))
+            value?.identifyPolymorphic(identities, identities.next(id), false)
     }
 
     override fun advise(lifetime: Lifetime, handler: (T) -> Unit) {

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdTask.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/impl/RdTask.kt
@@ -161,7 +161,7 @@ class EndpointWiredRdTask<TReq, TRes>(
                         return@adviseOnce
                     }
 
-                    taskResult.value.identifyPolymorphic(proto.identity, proto.identity.next(rdid))
+                    taskResult.value.identifyPolymorphic(proto.identity, proto.identity.next(rdid), false)
                     lifetime.executeIfAlive {
                         taskResult.value.preBindPolymorphic(lifetime, call, rdid.toString())
                         if (lifetime.isNotAlive)

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdIdHeavyCollisionTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdIdHeavyCollisionTest.kt
@@ -1,0 +1,63 @@
+package com.jetbrains.rd.framework.test.cases
+
+import com.jetbrains.rd.framework.*
+import com.jetbrains.rd.framework.base.AllowBindingCookie
+import com.jetbrains.rd.framework.base.RdBindableBase
+import com.jetbrains.rd.framework.test.util.TestScheduler
+import com.jetbrains.rd.framework.test.util.TestWire
+import com.jetbrains.rd.util.lifetime.LifetimeDefinition
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class RdIdHeavyCollisionTest {
+
+    private companion object {
+        const val NODE_COUNT = 20000
+        const val SEED = 1L
+    }
+
+    private class Node : RdBindableBase()
+
+    @Suppress("DEPRECATION")
+    private fun legacy(): IIdentities = Identities(IdKind.Server)
+    private fun sequential(): IIdentities = SequentialIdentities(IdKind.Server)
+
+    @Test
+    fun `legacy dynamic ids collide in a large decoupled graph`() {
+        assertFailsWith<IllegalArgumentException> { buildHeavyGraph(legacy()) }
+    }
+
+    @Test
+    fun `SequentialIdentities stays unique across a large decoupled graph`() {
+        buildHeavyGraph(sequential()) // must complete without a duplicate-id exception
+    }
+
+    @Suppress("DEPRECATION")
+    private fun buildHeavyGraph(identities: IIdentities) {
+        val ld = LifetimeDefinition()
+        try {
+            val lifetime = ld.lifetime
+            val protocol = Protocol("Heavy", Serializers(), identities, TestScheduler, TestWire(TestScheduler), lifetime)
+
+            val root = Node().also { it.identify(identities, RdId(1L), false) }
+            val nodes = ArrayList<Node>().apply { add(root) }
+
+            AllowBindingCookie.allowBind {
+                root.preBind(lifetime, protocol, "root")
+
+                val random = java.util.Random(SEED)
+                for (k in 0 until NODE_COUNT) {
+                    // Attach to an arbitrary earlier node: decoupling parent id from allocation order is
+                    // what exposes legacy next's poor distribution (a balanced tree would not collide).
+                    val parent = nodes[random.nextInt(nodes.size)]
+                    val child = Node()
+                    child.identify(identities, identities.next(parent.rdid), false)
+                    child.preBind(lifetime, parent, "n$k") // registers; throws on a duplicate RdId
+                    nodes.add(child)
+                }
+            }
+        } finally {
+            ld.terminate()
+        }
+    }
+}

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdIdIdentitiesCollisionMatrixTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdIdIdentitiesCollisionMatrixTest.kt
@@ -1,0 +1,72 @@
+package com.jetbrains.rd.framework.test.cases
+
+import com.jetbrains.rd.framework.*
+import com.jetbrains.rd.framework.base.AllowBindingCookie
+import com.jetbrains.rd.framework.base.RdBindableBase
+import com.jetbrains.rd.framework.test.util.TestScheduler
+import com.jetbrains.rd.framework.test.util.TestWire
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.lifetime.LifetimeDefinition
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class RdIdIdentitiesCollisionMatrixTest {
+
+    private enum class Derivation { Dynamic, Stable }
+
+    @Suppress("DEPRECATION")
+    private fun legacy(): IIdentities = Identities(IdKind.Server)
+    private fun sequential(): IIdentities = SequentialIdentities(IdKind.Server)
+
+    @Test
+    fun `legacy dynamic ids collide even with the fix`() {
+        assertFailsWith<IllegalArgumentException> { buildTree(legacy(), Derivation.Dynamic) }
+    }
+
+    @Test
+    fun `legacy stable ids do not collide`() = buildTree(legacy(), Derivation.Stable)
+
+    @Test
+    fun `SequentialIdentities dynamic ids do not collide`() = buildTree(sequential(), Derivation.Dynamic)
+
+    @Test
+    fun `SequentialIdentities stable ids do not collide`() = buildTree(sequential(), Derivation.Stable)
+
+    @Suppress("DEPRECATION")
+    private fun buildTree(identities: IIdentities, mode: Derivation) {
+        val ld = LifetimeDefinition()
+        try {
+            val lifetime = ld.lifetime
+            val protocol = Protocol("MatrixCol", Serializers(), identities, TestScheduler, TestWire(TestScheduler), lifetime)
+
+            // p1 (id 3) is identified/filled before p2 (id 1) — reverse id order is what lets legacy collide.
+            val p1 = Node().also { it.identify(identities, RdId(3L), false) }
+            val p2 = Node().also { it.identify(identities, RdId(1L), false) }
+
+            AllowBindingCookie.allowBind {
+                p1.preBind(lifetime, protocol, "p1"); p1.bind()
+                p2.preBind(lifetime, protocol, "p2"); p2.bind()
+                addChildren(identities, p1, mode, 31, lifetime)
+                addChildren(identities, p2, mode, 1, lifetime)
+            }
+        } finally {
+            ld.terminate()
+        }
+    }
+
+    private fun addChildren(identities: IIdentities, parent: Node, mode: Derivation, count: Int, lifetime: Lifetime) {
+        for (i in 0 until count) {
+            val name = "x$i"
+            val childId = when (mode) {
+                Derivation.Dynamic -> identities.next(parent.rdid)         // dynamic (RdMap/RdList element) id
+                Derivation.Stable -> identities.mix(parent.rdid, ".$name") // stable (structural child) id
+            }
+            val child = Node()
+            child.identify(identities, childId, false)
+            child.preBind(lifetime, parent, name)
+            child.bind()
+        }
+    }
+
+    private class Node : RdBindableBase()
+}

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdIdLegacyCollisionTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdIdLegacyCollisionTest.kt
@@ -1,0 +1,63 @@
+package com.jetbrains.rd.framework.test.cases
+
+import com.jetbrains.rd.framework.*
+import com.jetbrains.rd.framework.base.AllowBindingCookie
+import com.jetbrains.rd.framework.base.RdBindableBase
+import com.jetbrains.rd.framework.test.util.TestScheduler
+import com.jetbrains.rd.framework.test.util.TestWire
+import com.jetbrains.rd.util.lifetime.LifetimeDefinition
+import kotlin.test.Test
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class RdIdLegacyCollisionTest {
+
+    private class Leaf : RdBindableBase()
+
+    private class CollisionModel(childCount: Int) : RdBindableBase() {
+        val kids: List<Leaf> = (0 until childCount).map { Leaf() }
+        init {
+            kids.forEachIndexed { i, leaf -> bindableChildren.add("x$i" to leaf) }
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun legacy(): IIdentities = Identities(IdKind.Server)
+    private fun sequential(): IIdentities = SequentialIdentities(IdKind.Server)
+
+    @Test
+    fun `legacy named child rdids do not collide across parents`() = childRdIdsDoNotCollide(legacy())
+
+    @Test
+    fun `SequentialIdentities named child rdids do not collide across parents`() = childRdIdsDoNotCollide(sequential())
+
+    @Suppress("DEPRECATION")
+    private fun childRdIdsDoNotCollide(identities: IIdentities) {
+        val ld = LifetimeDefinition()
+        val lifetime = ld.lifetime
+
+        val protocol = Protocol("Collision", Serializers(), identities, TestScheduler, TestWire(TestScheduler), lifetime)
+
+        val model1 = CollisionModel(31)
+        val model2 = CollisionModel(1)
+
+        AllowBindingCookie.allowBind {
+            model1.identify(identities, RdId(3L), false)
+            model2.identify(identities, RdId(1L), false)
+
+            model1.preBind(lifetime, protocol, "m1")
+            model1.bind()
+            // Without the fix this is where model2.x0 duplicates model1.x0 and register() throws.
+            model2.preBind(lifetime, protocol, "m2")
+            model2.bind()
+        }
+
+        assertNotEquals(model1.kids[0].rdid.hash, model2.kids[0].rdid.hash,
+            "named children of different parents must not collide")
+
+        val all = HashSet<Long>()
+        (model1.kids + model2.kids).forEach { assertTrue(all.add(it.rdid.hash), "duplicate child id ${it.rdid.hash}") }
+
+        ld.terminate()
+    }
+}

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdIdTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdIdTest.kt
@@ -41,28 +41,12 @@ class RdIdTest {
         val serverIdentities = SequentialIdentities(IdKind.Server)
 
         val testStrings = listOf("", "a", "test", "Protocol", "Extension", "InternRoot")
-        val testInts = listOf(0, 1, -1, Int.MAX_VALUE, Int.MIN_VALUE)
-        val testLongs = listOf(0L, 1L, -1L, Long.MAX_VALUE, Long.MIN_VALUE)
 
         for (s in testStrings) {
             val clientId = clientIdentities.mix(RdId.Null, s)
             val serverId = serverIdentities.mix(RdId.Null, s)
             assertTrue(clientId.hash and HIGH_BIT != 0L, "Client stable ID from string '$s' should have high bit set")
             assertTrue(serverId.hash and HIGH_BIT != 0L, "Server stable ID from string '$s' should have high bit set")
-        }
-
-        for (i in testInts) {
-            val clientId = clientIdentities.mix(RdId.Null, i)
-            val serverId = serverIdentities.mix(RdId.Null, i)
-            assertTrue(clientId.hash and HIGH_BIT != 0L, "Client stable ID from int $i should have high bit set")
-            assertTrue(serverId.hash and HIGH_BIT != 0L, "Server stable ID from int $i should have high bit set")
-        }
-
-        for (l in testLongs) {
-            val clientId = clientIdentities.mix(RdId.Null, l)
-            val serverId = serverIdentities.mix(RdId.Null, l)
-            assertTrue(clientId.hash and HIGH_BIT != 0L, "Client stable ID from long $l should have high bit set")
-            assertTrue(serverId.hash and HIGH_BIT != 0L, "Server stable ID from long $l should have high bit set")
         }
     }
 

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdSignalTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/RdSignalTest.kt
@@ -131,8 +131,8 @@ class RdSignalTest : RdFrameworkTestBase() {
             _foo.bind()
         }
 
-        override fun identify(identities: IIdentities, id: RdId) {
-            _foo.identify(identities, identities.mix(id, "foo"))
+        override fun identify(identities: IIdentities, id: RdId, stable: Boolean) {
+            _foo.identify(identities, identities.mix(id, "foo"), stable)
         }
 
 
@@ -279,8 +279,8 @@ class RdSignalTest : RdFrameworkTestBase() {
             _foo.bind()
         }
 
-        override fun identify(identities: IIdentities, id: RdId) {
-            _foo.identify(identities, identities.mix(id, "foo"))
+        override fun identify(identities: IIdentities, id: RdId, stable: Boolean) {
+            _foo.identify(identities, identities.mix(id, "foo"), stable)
         }
 
         constructor() : this(RdSignal<Unit>())

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/contexts/RdPerContextMapTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/contexts/RdPerContextMapTest.kt
@@ -246,7 +246,7 @@ class RdPerContextMapTest : RdFrameworkTestBase() {
         serverMap.bindTopLevel(serverLifetime, serverProtocol, "map")
 
         key.updateValue(server1Cid).use {
-            serverProtocol.wire.send(serverProtocol.identity.mix(RdId.Null, 10)) {} // trigger key addition by protocol write
+            serverProtocol.wire.send(serverProtocol.identity.mix(RdId.Null, "10")) {} // trigger key addition by protocol write
         }
 
         assertTrue(serverProtocol.contexts.getValueSet(key).contains(server1Cid))

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/interning/InterningRemovalsTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/interning/InterningRemovalsTest.kt
@@ -71,7 +71,7 @@ class InterningRemovalsTest : RdFrameworkTestBase() {
     }
 
     private fun <T : Any> InternRoot<T>.bindStatic(protocol: IProtocol, id: String): InternRoot<T> {
-        identify(protocol.identity, protocol.identity.mix(RdId.Null, id))
+        identify(protocol.identity, protocol.identity.mix(RdId.Null, id), true)
         bindTopLevel(if (protocol === clientProtocol) clientLifetime else serverLifetime, protocol, id)
         return this
     }

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/interning/InterningTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/interning/InterningTest.kt
@@ -289,8 +289,8 @@ class InterningTest: RdFrameworkTestBase() {
         val serverProperty = RdOptionalProperty(InterningTestModel).slave()
         val clientProperty = RdOptionalProperty(InterningTestModel)
 
-        serverProperty.identify(serverProtocol.identity, RdId(1L))
-        clientProperty.identify(clientProtocol.identity, RdId(1L))
+        serverProperty.identify(serverProtocol.identity, RdId(1L), true)
+        clientProperty.identify(clientProtocol.identity, RdId(1L), true)
 
         serverProtocol.bindStatic(serverProperty, "top")
         clientProtocol.bindStatic(clientProperty, "top")
@@ -326,7 +326,7 @@ class InterningTest: RdFrameworkTestBase() {
 
 
     private fun <T : Any> InternRoot<T>.bindStatic(protocol: IProtocol, id: String) : InternRoot<T> {
-        identify(protocol.identity, protocol.identity.mix(RdId.Null, id))
+        identify(protocol.identity, protocol.identity.mix(RdId.Null, id), true)
         bindTopLevel(if(protocol === clientProtocol) clientLifetime else serverLifetime, protocol, id)
         return this
     }

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/interning/PropertyHolderWithInternRoot.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/interning/PropertyHolderWithInternRoot.kt
@@ -25,9 +25,9 @@ class PropertyHolderWithInternRoot<T : Any>(val property: RdOptionalProperty<T>,
         super.bind()
     }
 
-    override fun identify(identities: IIdentities, id: RdId) {
-        property.identify(identities, identities.mix(id, "propertyHolderWithInternRoot"))
-        super.identify(identities, id)
+    override fun identify(identities: IIdentities, id: RdId, stable: Boolean) {
+        property.identify(identities, identities.mix(id, "propertyHolderWithInternRoot"), stable)
+        super.identify(identities, id, stable)
     }
 
     override val serializationContext: SerializationCtx

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/util/DynamicEntity.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/util/DynamicEntity.kt
@@ -41,8 +41,8 @@ class DynamicEntity<T>(val _foo: RdProperty<T>) : RdBindableBase() {
         _foo.bind()
     }
 
-    override fun identify(identities: IIdentities, id: RdId) {
-        _foo.identify(identities, identities.mix(id, "foo"))
+    override fun identify(identities: IIdentities, id: RdId, stable: Boolean) {
+        _foo.identify(identities, identities.mix(id, "foo"), stable)
     }
 
     constructor(_foo: T) : this(RdProperty<T>(_foo, Polymorphic<T>()))

--- a/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/csharp/CSharp50Generator.kt
+++ b/rd-kt/rd-gen/src/main/kotlin/com/jetbrains/rd/generator/nova/csharp/CSharp50Generator.kt
@@ -692,7 +692,7 @@ open class CSharp50Generator(
         +"{"
 
         indent {
-            +"Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, \"${decl.name}\"));"
+            +"Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, \"${decl.name}\"), true);"
             +"this.BindTopLevel(lifetime, protocol, \"${decl.name}\");" //better than nameof(${decl.name}) because one could rename generated class and it'll still able to connect to Kt
         }
         +"}"

--- a/rd-kt/rd-gen/src/test/resources/testData/asyncPrimitives/asis/AsyncPrimitivesExt.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/asyncPrimitives/asis/AsyncPrimitivesExt.cs
@@ -106,7 +106,7 @@ namespace org.example
     
     public AsyncPrimitivesExt(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "AsyncPrimitivesExt"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "AsyncPrimitivesExt"), true);
       this.BindTopLevel(lifetime, protocol, "AsyncPrimitivesExt");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/asyncPrimitives/asis/AsyncPrimitivesRoot.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/asyncPrimitives/asis/AsyncPrimitivesRoot.cs
@@ -67,7 +67,7 @@ namespace org.example
     
     public AsyncPrimitivesRoot(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "AsyncPrimitivesRoot"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "AsyncPrimitivesRoot"), true);
       this.BindTopLevel(lifetime, protocol, "AsyncPrimitivesRoot");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/asyncPrimitives/reversed/AsyncPrimitivesExt.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/asyncPrimitives/reversed/AsyncPrimitivesExt.cs
@@ -106,7 +106,7 @@ namespace org.example
     
     public AsyncPrimitivesExt(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "AsyncPrimitivesExt"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "AsyncPrimitivesExt"), true);
       this.BindTopLevel(lifetime, protocol, "AsyncPrimitivesExt");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/asyncPrimitives/reversed/AsyncPrimitivesRoot.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/asyncPrimitives/reversed/AsyncPrimitivesRoot.cs
@@ -67,7 +67,7 @@ namespace org.example
     
     public AsyncPrimitivesRoot(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "AsyncPrimitivesRoot"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "AsyncPrimitivesRoot"), true);
       this.BindTopLevel(lifetime, protocol, "AsyncPrimitivesRoot");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/documentationModelTest/asis/DocumentationModelRoot.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/documentationModelTest/asis/DocumentationModelRoot.cs
@@ -68,7 +68,7 @@ namespace org.example
     
     public DocumentationModelRoot(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "DocumentationModelRoot"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "DocumentationModelRoot"), true);
       this.BindTopLevel(lifetime, protocol, "DocumentationModelRoot");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/documentationModelTest/reversed/DocumentationModelRoot.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/documentationModelTest/reversed/DocumentationModelRoot.cs
@@ -68,7 +68,7 @@ namespace org.example
     
     public DocumentationModelRoot(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "DocumentationModelRoot"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "DocumentationModelRoot"), true);
       this.BindTopLevel(lifetime, protocol, "DocumentationModelRoot");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/asis/ExampleModelNova.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/asis/ExampleModelNova.cs
@@ -141,7 +141,7 @@ namespace org.example
     
     public ExampleModelNova(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "ExampleModelNova"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "ExampleModelNova"), true);
       this.BindTopLevel(lifetime, protocol, "ExampleModelNova");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/asis/ExampleRootNova.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/asis/ExampleRootNova.cs
@@ -67,7 +67,7 @@ namespace org.example
     
     public ExampleRootNova(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "ExampleRootNova"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "ExampleRootNova"), true);
       this.BindTopLevel(lifetime, protocol, "ExampleRootNova");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/reversed/ExampleModelNova.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/reversed/ExampleModelNova.cs
@@ -141,7 +141,7 @@ namespace org.example
     
     public ExampleModelNova(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "ExampleModelNova"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "ExampleModelNova"), true);
       this.BindTopLevel(lifetime, protocol, "ExampleModelNova");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/reversed/ExampleRootNova.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/exampleModelTest/reversed/ExampleRootNova.cs
@@ -67,7 +67,7 @@ namespace org.example
     
     public ExampleRootNova(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "ExampleRootNova"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "ExampleRootNova"), true);
       this.BindTopLevel(lifetime, protocol, "ExampleRootNova");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/extensionTest/asis/ExtensionRoot.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/extensionTest/asis/ExtensionRoot.cs
@@ -66,7 +66,7 @@ namespace ExtensionRoot
     
     public ExtensionRoot(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "ExtensionRoot"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "ExtensionRoot"), true);
       this.BindTopLevel(lifetime, protocol, "ExtensionRoot");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/extensionTest/reversed/ExtensionRoot.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/extensionTest/reversed/ExtensionRoot.cs
@@ -66,7 +66,7 @@ namespace ExtensionRoot
     
     public ExtensionRoot(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "ExtensionRoot"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "ExtensionRoot"), true);
       this.BindTopLevel(lifetime, protocol, "ExtensionRoot");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/factoryFqn/asis/Solution2.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/factoryFqn/asis/Solution2.cs
@@ -141,7 +141,7 @@ namespace Org.TestRoot1
     
     public Solution2(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "Solution2"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "Solution2"), true);
       this.BindTopLevel(lifetime, protocol, "Solution2");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/factoryFqn/asis/TestRoot1.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/factoryFqn/asis/TestRoot1.cs
@@ -67,7 +67,7 @@ namespace Org.TestRoot1
     
     public TestRoot1(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "TestRoot1"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "TestRoot1"), true);
       this.BindTopLevel(lifetime, protocol, "TestRoot1");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/factoryFqn/reversed/Solution2.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/factoryFqn/reversed/Solution2.cs
@@ -141,7 +141,7 @@ namespace Org.TestRoot1
     
     public Solution2(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "Solution2"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "Solution2"), true);
       this.BindTopLevel(lifetime, protocol, "Solution2");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/factoryFqn/reversed/TestRoot1.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/factoryFqn/reversed/TestRoot1.cs
@@ -67,7 +67,7 @@ namespace Org.TestRoot1
     
     public TestRoot1(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "TestRoot1"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "TestRoot1"), true);
       this.BindTopLevel(lifetime, protocol, "TestRoot1");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/inheritsAutomation/asis/DefaultFieldValuesRoot.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/inheritsAutomation/asis/DefaultFieldValuesRoot.cs
@@ -66,7 +66,7 @@ namespace DefaultFieldValuesRoot
     
     public DefaultFieldValuesRoot(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "DefaultFieldValuesRoot"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "DefaultFieldValuesRoot"), true);
       this.BindTopLevel(lifetime, protocol, "DefaultFieldValuesRoot");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/inheritsAutomation/asis/InheritsAutomationExtension.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/inheritsAutomation/asis/InheritsAutomationExtension.cs
@@ -67,7 +67,7 @@ namespace InheritsAutomationRoot
     
     public InheritsAutomationExtension(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "InheritsAutomationExtension"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "InheritsAutomationExtension"), true);
       this.BindTopLevel(lifetime, protocol, "InheritsAutomationExtension");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/inheritsAutomation/asis/InheritsAutomationRoot.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/inheritsAutomation/asis/InheritsAutomationRoot.cs
@@ -67,7 +67,7 @@ namespace InheritsAutomationRoot
     
     public InheritsAutomationRoot(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "InheritsAutomationRoot"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "InheritsAutomationRoot"), true);
       this.BindTopLevel(lifetime, protocol, "InheritsAutomationRoot");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/inheritsAutomation/reversed/DefaultFieldValuesRoot.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/inheritsAutomation/reversed/DefaultFieldValuesRoot.cs
@@ -66,7 +66,7 @@ namespace DefaultFieldValuesRoot
     
     public DefaultFieldValuesRoot(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "DefaultFieldValuesRoot"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "DefaultFieldValuesRoot"), true);
       this.BindTopLevel(lifetime, protocol, "DefaultFieldValuesRoot");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/inheritsAutomation/reversed/InheritsAutomationExtension.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/inheritsAutomation/reversed/InheritsAutomationExtension.cs
@@ -67,7 +67,7 @@ namespace InheritsAutomationRoot
     
     public InheritsAutomationExtension(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "InheritsAutomationExtension"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "InheritsAutomationExtension"), true);
       this.BindTopLevel(lifetime, protocol, "InheritsAutomationExtension");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/inheritsAutomation/reversed/InheritsAutomationRoot.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/inheritsAutomation/reversed/InheritsAutomationRoot.cs
@@ -67,7 +67,7 @@ namespace InheritsAutomationRoot
     
     public InheritsAutomationRoot(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "InheritsAutomationRoot"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "InheritsAutomationRoot"), true);
       this.BindTopLevel(lifetime, protocol, "InheritsAutomationRoot");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/perClientId/asis/PerClientIdRoot.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/perClientId/asis/PerClientIdRoot.cs
@@ -112,7 +112,7 @@ namespace JetBrains.Platform.Tests.Cases.RdFramework.PerClientId
     
     public PerClientIdRoot(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "PerClientIdRoot"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "PerClientIdRoot"), true);
       this.BindTopLevel(lifetime, protocol, "PerClientIdRoot");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/perClientId/reversed/PerClientIdRoot.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/perClientId/reversed/PerClientIdRoot.cs
@@ -112,7 +112,7 @@ namespace JetBrains.Platform.Tests.Cases.RdFramework.PerClientId
     
     public PerClientIdRoot(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "PerClientIdRoot"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "PerClientIdRoot"), true);
       this.BindTopLevel(lifetime, protocol, "PerClientIdRoot");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/recursivePolymorphicModelTest/asis/RecursivePolymorphicModel.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/recursivePolymorphicModelTest/asis/RecursivePolymorphicModel.cs
@@ -91,7 +91,7 @@ namespace org.example
     
     public RecursivePolymorphicModel(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "RecursivePolymorphicModel"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "RecursivePolymorphicModel"), true);
       this.BindTopLevel(lifetime, protocol, "RecursivePolymorphicModel");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/recursivePolymorphicModelTest/asis/RecursivePolymorphicModelRoot.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/recursivePolymorphicModelTest/asis/RecursivePolymorphicModelRoot.cs
@@ -67,7 +67,7 @@ namespace org.example
     
     public RecursivePolymorphicModelRoot(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "RecursivePolymorphicModelRoot"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "RecursivePolymorphicModelRoot"), true);
       this.BindTopLevel(lifetime, protocol, "RecursivePolymorphicModelRoot");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/recursivePolymorphicModelTest/reversed/RecursivePolymorphicModel.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/recursivePolymorphicModelTest/reversed/RecursivePolymorphicModel.cs
@@ -91,7 +91,7 @@ namespace org.example
     
     public RecursivePolymorphicModel(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "RecursivePolymorphicModel"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "RecursivePolymorphicModel"), true);
       this.BindTopLevel(lifetime, protocol, "RecursivePolymorphicModel");
     }
     

--- a/rd-kt/rd-gen/src/test/resources/testData/recursivePolymorphicModelTest/reversed/RecursivePolymorphicModelRoot.cs
+++ b/rd-kt/rd-gen/src/test/resources/testData/recursivePolymorphicModelTest/reversed/RecursivePolymorphicModelRoot.cs
@@ -67,7 +67,7 @@ namespace org.example
     
     public RecursivePolymorphicModelRoot(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "RecursivePolymorphicModelRoot"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "RecursivePolymorphicModelRoot"), true);
       this.BindTopLevel(lifetime, protocol, "RecursivePolymorphicModelRoot");
     }
     

--- a/rd-kt/rd-text/src/test/kotlin/com/jetbrains/rd/rdtext/test/cases/TextBufferTest.kt
+++ b/rd-kt/rd-text/src/test/kotlin/com/jetbrains/rd/rdtext/test/cases/TextBufferTest.kt
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 private fun IRdBindable.top(lifetime: Lifetime, protocol: IProtocol) {
-    identify(protocol.identity, protocol.identity.mix(RdId.Null, this.javaClass.simpleName))
+    identify(protocol.identity, protocol.identity.mix(RdId.Null, this.javaClass.simpleName), true)
     preBind(lifetime, protocol, this.javaClass.simpleName)
     bind()
 }

--- a/rd-net/RdFramework.Reflection/RdExtReflectionBindableBase.cs
+++ b/rd-net/RdFramework.Reflection/RdExtReflectionBindableBase.cs
@@ -40,10 +40,10 @@ namespace JetBrains.Rd.Reflection
       base.InitBindableFields(lifetime);
     }
 
-    public override void Identify(IIdentities identities, RdId id)
+    public override void Identify(IIdentities identities, RdId id, bool stable)
     {
       ((IReflectionBindable) this).EnsureBindableChildren();
-      base.Identify(identities, id);
+      base.Identify(identities, id, true); // enforce true to make stable ids for each built-in child
     }
 
     public override string ToString()

--- a/rd-net/RdFramework.Reflection/RdReflectionBindableBase.cs
+++ b/rd-net/RdFramework.Reflection/RdReflectionBindableBase.cs
@@ -45,10 +45,10 @@ namespace JetBrains.Rd.Reflection
       base.PreInitBindableFields(lifetime);
     }
     
-    public override void Identify(IIdentities identities, RdId id)
+    public override void Identify(IIdentities identities, RdId id, bool stable)
     {
       ((IReflectionBindable) this).EnsureBindableChildren();
-      base.Identify(identities, id);
+      base.Identify(identities, id, stable);
     }
 
     public override string ToString()

--- a/rd-net/RdFramework.Reflection/ReflectionRdActivator.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionRdActivator.cs
@@ -68,7 +68,7 @@ namespace JetBrains.Rd.Reflection
       var instance = Activate<T>();
 
       var typename = GetTypeName(typeof(T));
-      instance.Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, typename));
+      instance.Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, typename), true);
       instance.BindTopLevel(lifetime, protocol, typename);
 
       return instance;
@@ -85,7 +85,7 @@ namespace JetBrains.Rd.Reflection
 
       var typename = GetTypeName(type);
       var bindable = (RdExtReflectionBindableBase) instance;
-      bindable.Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, typename));
+      bindable.Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, typename), true);
       bindable.BindTopLevel(lifetime, protocol, typename);
 
       return bindable;

--- a/rd-net/RdFramework.Reflection/ReflectionSerializersFacade.cs
+++ b/rd-net/RdFramework.Reflection/ReflectionSerializersFacade.cs
@@ -52,7 +52,7 @@ namespace JetBrains.Rd.Reflection
     private static void Bind(IRdBindable instance, Lifetime lifetime, IProtocol protocol)
     {
       var typename = ReflectionRdActivator.GetTypeName(instance.GetType());
-      instance.Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, typename));
+      instance.Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, typename), true);
       instance.BindTopLevel(lifetime, protocol, typename);
     }
   }

--- a/rd-net/RdFramework/Base/IRdBindable.cs
+++ b/rd-net/RdFramework/Base/IRdBindable.cs
@@ -67,7 +67,29 @@ namespace JetBrains.Rd.Base
     RdId RdId { get; set; }
     void PreBind(Lifetime lf, IRdDynamic parent, string name);    
     void Bind();    
-    void Identify(IIdentities identities, RdId id);
+    /// <summary>
+    /// Assigns an <see cref="RdId"/> to this node and recursively to all its child nodes.
+    /// </summary>
+    /// <param name="identities">The identity source used to generate child IDs.</param>
+    /// <param name="id">The <see cref="RdId"/> to assign to this node.</param>
+    /// <param name="stable">
+    /// A recommendation for how child RdIds should be generated. Entities may override this value.
+    /// <list type="bullet">
+    ///   <item><c>true</c> — uses <see cref="IIdentities.Mix"/> to produce hash-based, deterministic IDs
+    ///   derived from the parent ID and child name. Used when the same entity exists on both protocol sides
+    ///   and its children need matching IDs to find each other (e.g., extensions with built-in maps, sets,
+    ///   properties). Given the same parent ID, both sides will compute identical child IDs.</item>
+    ///   <item><c>false</c> — uses <see cref="IIdentities.Next"/> to produce dynamic IDs.
+    ///   Used for entities created at runtime (e.g., items added to RdMap/RdList) where each side assigns
+    ///   its own IDs independently.</item>
+    /// </list>
+    /// Entities can override this parameter when their children require a specific strategy. For example,
+    /// <see cref="RdExtBase"/> forces <c>stable = true</c> regardless of the incoming value, because its
+    /// built-in children are part of a statically known structure that must match on both protocol sides.
+    /// So even if an ext is encountered during dynamic (non-stable) identification, it will switch to stable
+    /// IDs for its own subtree.
+    /// </param>
+    void Identify(IIdentities identities, RdId id, bool stable);
   }
 
   internal readonly ref struct AllowBindCookie
@@ -228,42 +250,64 @@ namespace JetBrains.Rd.Base
 
     #region Identify
 
-    internal static void IdentifyPolymorphic(this object? value, IIdentities ids, RdId id)
+    internal static void IdentifyPolymorphic(this object? value, IIdentities ids, RdId id, bool stable)
     {  
       if (value is IRdBindable rdBindable)
-        rdBindable.Identify(ids, id);
+        rdBindable.Identify(ids, id, stable);
       else
-        (value as IEnumerable).Identify0(ids, id);
+        (value as IEnumerable).Identify0(ids, id, stable);
     }
     
 
 
-    private static void Identify0(this IEnumerable? items, IIdentities ids, RdId id)
+    private static void Identify0(this IEnumerable? items, IIdentities ids, RdId id, bool stable)
     {
       if (items == null) return;
 
       var i = 0;
       foreach (var x in items)
       {
-        (x as IRdBindable).IdentifyEx(ids, ids.Mix(id, i++));
+        if (x is IRdBindable bindableChild)
+        {
+          var childId = ComputeChildRdId(ids, id, stable, i++);
+          bindableChild.IdentifyEx(ids, childId, stable);
+        }
       }
+    }
+    
+    private static RdId ComputeChildRdId(IIdentities identities, RdId id, bool stable, int i)
+    {
+      if (stable)
+      {
+#pragma warning disable CS0618 // Type or member is obsolete
+        if (identities is Identities legacyIdentities)
+#pragma warning restore CS0618 // Type or member is obsolete
+        {
+          // for backward compatibility
+          return legacyIdentities.Mix(id, i++);
+        }
+
+        return identities.Mix(id, Convert.ToString(i, 2));
+      }
+
+      return identities.Next(id);
     }
 
 
-    public static void IdentifyEx<T>(this T? value, IIdentities ids, RdId id) where T : IRdBindable
+    public static void IdentifyEx<T>(this T? value, IIdentities ids, RdId id, bool stable) where T : IRdBindable
     {
-      if (value != null) value.Identify(ids, id);
+      if (value != null) value.Identify(ids, id, stable);
     }
 
     //PLEASE DON'T MERGE these two methods into one with IEnumerable<T>, just believe me
-    public static void IdentifyEx<T>(this List<T>? items, IIdentities ids, RdId id) where T : IRdBindable
+    public static void IdentifyEx<T>(this List<T>? items, IIdentities ids, RdId id, bool stable) where T : IRdBindable
     {
-      items.Identify0(ids, id);
+      items.Identify0(ids, id, stable);
     }
 
-    public static void IdentifyEx<T>(this T[]? items, IIdentities ids, RdId id) where T : IRdBindable
+    public static void IdentifyEx<T>(this T[]? items, IIdentities ids, RdId id, bool stable) where T : IRdBindable
     {
-      items.Identify0(ids, id);
+      items.Identify0(ids, id, stable);
     }
 
     #endregion

--- a/rd-net/RdFramework/Base/IRdBindable.cs
+++ b/rd-net/RdFramework/Base/IRdBindable.cs
@@ -277,18 +277,19 @@ namespace JetBrains.Rd.Base
     
     private static RdId ComputeChildRdId(IIdentities identities, RdId id, bool stable, int i)
     {
-      if (stable)
-      {
+      // Legacy Identities: always use Mix(parent, i) — pre-fix behavior had better effective distribution
+      // for collection elements than Next(parent), whose underlying hash Mix(parent, counter) is a poor
+      // linear function (acc*31 + counter+1). Restore that for backward compatibility with users that
+      // haven't migrated to SequentialIdentities.
 #pragma warning disable CS0618 // Type or member is obsolete
-        if (identities is Identities legacyIdentities)
+      if (identities is Identities legacyIdentities)
 #pragma warning restore CS0618 // Type or member is obsolete
-        {
-          // for backward compatibility
-          return legacyIdentities.Mix(id, i++);
-        }
-
-        return identities.Mix(id, Convert.ToString(i, 2));
+      {
+        return legacyIdentities.Mix(id, i);
       }
+
+      if (stable)
+        return identities.Mix(id, Convert.ToString(i, 2));
 
       return identities.Next(id);
     }

--- a/rd-net/RdFramework/Base/RdBindableBase.cs
+++ b/rd-net/RdFramework/Base/RdBindableBase.cs
@@ -179,7 +179,7 @@ namespace JetBrains.Rd.Base
       }
     }
 
-    public virtual void Identify(IIdentities identities, RdId id)
+    public virtual void Identify(IIdentities identities, RdId id, bool stable)
     {
       Assertion.Require(RdId.IsNil, "Already has RdId: {0}, entity: {1}", RdId, this);      
       Assertion.Require(!id.IsNil, "Assigned RdId mustn't be null, entity: {0}", this);
@@ -187,8 +187,13 @@ namespace JetBrains.Rd.Base
       RdId = id;
       foreach (var pair in BindableChildren)
       {
-        pair.Value?.IdentifyPolymorphic(identities, identities.Mix(id, "." + pair.Key));
+        pair.Value?.IdentifyPolymorphic(identities, ComputeChildRdId(identities, id, pair.Key, stable), stable);
       }
+    }
+
+    private static RdId ComputeChildRdId(IIdentities identities, RdId parent, string name, bool stable)
+    {
+      return stable ? identities.Mix(parent, "." + name) : identities.Next(parent);
     }
 
     public virtual RdBindableBase? FindByRName(RName rName)
@@ -284,7 +289,7 @@ namespace JetBrains.Rd.Base
             if (bindLifetime.IsAlive)
             {
               if (bindable.RdId == RdId.Nil)
-                bindable.Identify(proto.Identities, proto.Identities.Mix(RdId, "." + name));
+                bindable.Identify(proto.Identities, proto.Identities.Mix(RdId, "." + name), true);
               bindable.PreBind(bindLifetime, this, name);
               bindable.Bind();
             }

--- a/rd-net/RdFramework/Base/RdBindableBase.cs
+++ b/rd-net/RdFramework/Base/RdBindableBase.cs
@@ -193,6 +193,13 @@ namespace JetBrains.Rd.Base
 
     private static RdId ComputeChildRdId(IIdentities identities, RdId parent, string name, bool stable)
     {
+      // Legacy Identities: always use Mix(parent, ".name") regardless of stable — restores pre-fix
+      // behavior for users that haven't migrated to SequentialIdentities.
+#pragma warning disable CS0618 // Type or member is obsolete
+      if (identities is Identities)
+#pragma warning restore CS0618 // Type or member is obsolete
+        return identities.Mix(parent, "." + name);
+
       return stable ? identities.Mix(parent, "." + name) : identities.Next(parent);
     }
 

--- a/rd-net/RdFramework/Base/RdDelegateBase.cs
+++ b/rd-net/RdFramework/Base/RdDelegateBase.cs
@@ -31,7 +31,7 @@ namespace JetBrains.Rd.Base
     public virtual void PreBind(Lifetime lf, IRdDynamic parent, string name) => Delegate.PreBind(lf, parent, name);
     public virtual void Bind() => Delegate.Bind();
 
-    public void Identify(IIdentities identities, RdId id) => Delegate.Identify(identities, id);
+    public void Identify(IIdentities identities, RdId id, bool stable) => Delegate.Identify(identities, id, stable);
 
     public RdId RdId
     {

--- a/rd-net/RdFramework/Base/RdExtBase.cs
+++ b/rd-net/RdFramework/Base/RdExtBase.cs
@@ -51,7 +51,7 @@ namespace JetBrains.Rd.Base
       var parentWire = parentProto.Wire;
 
       parentProto.Serializers.RegisterToplevelOnce(GetType(), Register);
-if (!TryGetSerializationContext(out var serializationContext))
+      if (!TryGetSerializationContext(out var serializationContext))
         return;
 
       var extScheduler = parentProto.Scheduler;
@@ -60,7 +60,8 @@ if (!TryGetSerializationContext(out var serializationContext))
         () =>
         {
           var parentProtocolImpl = (Protocol)parentProto;
-          var proto = new Protocol(parentProto.Name, parentProto.Serializers, parentProto.Identities, extScheduler, myExtWire, lifetime, parentProtocolImpl, this.CreateExtSignal(parentProto.Identities));
+          var proto = new Protocol(parentProto.Name, parentProto.Serializers, parentProto.Identities, extScheduler,
+            myExtWire, lifetime, parentProtocolImpl, this.CreateExtSignal(parentProto.Identities));
           myExtProtocol = proto;
 
           //protocol must be set first to allow bindable bind to it
@@ -75,20 +76,26 @@ if (!TryGetSerializationContext(out var serializationContext))
           using (Signal.NonPriorityAdviseCookie.Create())
 
 
-      {
-
-      parentProtocolImpl.SubmitExtCreated(info);
+          {
+            parentProtocolImpl.SubmitExtCreated(info);
           }
 
-          parentWire.Advise(lifetime, this);SendState(parentWire, ExtState.Ready);
+          parentWire.Advise(lifetime, this);
+          SendState(parentWire, ExtState.Ready);
 
-      Protocol.InitTrace?.Log($"{this} :: bound");},
+          Protocol.InitTrace?.Log($"{this} :: bound");
+        },
         () =>
         {
           myExtProtocol = null;
           SendState(parentWire, ExtState.Disconnected);
         }
       );
+    }
+
+    public override void Identify(IIdentities identities, RdId id, bool stable)
+    {
+      base.Identify(identities, id, true); // enforce true to make stable ids for each built-in child
     }
 
     protected override void AssertBindingThread() { }

--- a/rd-net/RdFramework/IIdentities.cs
+++ b/rd-net/RdFramework/IIdentities.cs
@@ -20,15 +20,5 @@ namespace JetBrains.Rd
     /// Creates a stable identifier by mixing the parent ID with a string key.
     /// </summary>
     RdId Mix(RdId rdId, string tail);
-
-    /// <summary>
-    /// Creates a stable identifier by mixing the parent ID with an integer key.
-    /// </summary>
-    RdId Mix(RdId rdId, int tail);
-
-    /// <summary>
-    /// Creates a stable identifier by mixing the parent ID with a long key.
-    /// </summary>
-    RdId Mix(RdId rdId, long tail);
   }
 }

--- a/rd-net/RdFramework/Impl/AsyncProperty.cs
+++ b/rd-net/RdFramework/Impl/AsyncProperty.cs
@@ -161,7 +161,7 @@ public class AsyncRdProperty<T> : IRdReactive, IAsyncProperty<T>, INotifyPropert
   public IAsyncSource<T> Change => myChange;
 
 
-  public void Identify(IIdentities identities, RdId id)
+  public void Identify(IIdentities identities, RdId id, bool stable)
   {
     Assertion.Require(!id.IsNil, $"Assigned RdId mustn't be null, entity: {this}");
 

--- a/rd-net/RdFramework/Impl/AsyncRdMap.cs
+++ b/rd-net/RdFramework/Impl/AsyncRdMap.cs
@@ -52,10 +52,10 @@ public class AsyncRdMap<K, V> : IRdBindable, IAsyncSource<MapEvent<K, V>>, IDict
       myMap.Bind();
   }
 
-  public void Identify(IIdentities identities, RdId id)
+  public void Identify(IIdentities identities, RdId id, bool stable)
   {
     lock (myMap) 
-      myMap.Identify(identities, id);
+      myMap.Identify(identities, id, stable);
   }
 
   public bool OptimizeNested

--- a/rd-net/RdFramework/Impl/AsyncRdSet.cs
+++ b/rd-net/RdFramework/Impl/AsyncRdSet.cs
@@ -53,10 +53,10 @@ public class AsyncRdSet<T> : IRdBindable, IAsyncSource<SetEvent<T>>,
       mySet.Bind();
   }
 
-  public void Identify(IIdentities identities, RdId id)
+  public void Identify(IIdentities identities, RdId id, bool stable)
   {
     lock (mySet) 
-      mySet.Identify(identities, id);
+      mySet.Identify(identities, id, stable);
   }
 
   public bool OptimizeNested

--- a/rd-net/RdFramework/Impl/Identities.cs
+++ b/rd-net/RdFramework/Impl/Identities.cs
@@ -72,20 +72,16 @@ namespace JetBrains.Rd.Impl
       // Ignore parent to avoid collisions from different creation order on client/server
       return new RdId(Interlocked.Add(ref myId, 2));
     }
-    
+
     public RdId Mix(RdId rdId, string tail)
     {
-      return new RdId(StableMask | RdIdUtil.Mix(rdId, tail).Value);
-    }
-
-    public RdId Mix(RdId rdId, int tail)
-    {
-      return new RdId(StableMask | RdIdUtil.Mix(rdId, tail).Value);
-    }
-
-    public RdId Mix(RdId rdId, long tail)
-    {
-      return new RdId(StableMask | RdIdUtil.Mix(rdId, tail).Value);
+      // Since dynamic RdIds are generated sequentially, the parent RdId often uses only a small number of bits (low entropy).
+      // Additionally, the tail string may be short, which can increase the risk of hash collisions.
+      // To improve hash distribution and reliability, we mix in extra data (tail length and a constant string) before mixing the tail itself.
+      var newRdId = RdIdUtil.Mix(rdId, tail.Length);
+      newRdId = RdIdUtil.Mix(newRdId, "SequentialIdentities::Mix::RdId");
+      newRdId = RdIdUtil.Mix(newRdId, tail);
+      return new RdId(StableMask | newRdId.Value);
     }
   }
 }

--- a/rd-net/RdFramework/Impl/InternRoot.cs
+++ b/rd-net/RdFramework/Impl/InternRoot.cs
@@ -177,7 +177,7 @@ namespace JetBrains.Rd.Impl
     {
     }
 
-    public void Identify(IIdentities identities, RdId id)
+    public void Identify(IIdentities identities, RdId id, bool stable)
     {
       Assertion.Require(RdId.IsNil, "Already has RdId: {0}, entity: {1}", RdId, this);      
       Assertion.Require(!id.IsNil, "Assigned RdId mustn't be null, entity: {0}", this);

--- a/rd-net/RdFramework/Impl/Protocol.cs
+++ b/rd-net/RdFramework/Impl/Protocol.cs
@@ -172,7 +172,7 @@ namespace JetBrains.Rd.Impl
         myExtensions[name] = res;
         if (res is IRdBindable rdBindable)
         {
-          rdBindable.Identify(Identities, Identities.Mix(RdId.Root, name));
+          rdBindable.Identify(Identities, Identities.Mix(RdId.Root, name), true);
           rdBindable.PreBind(Lifetime, this, name);
           rdBindable.Bind();
         }

--- a/rd-net/RdFramework/Impl/RdList.cs
+++ b/rd-net/RdFramework/Impl/RdList.cs
@@ -112,7 +112,7 @@ namespace JetBrains.Rd.Impl
           var item = this[index];
           if (item != null)
           {
-            item.IdentifyPolymorphic(proto.Identities, proto.Identities.Next(RdId));
+            item.IdentifyPolymorphic(proto.Identities, proto.Identities.Next(RdId), false);
             definitions.Add(TryPreBindValue(lifetime, item, index, false));
           }
         }
@@ -152,7 +152,7 @@ namespace JetBrains.Rd.Impl
 
             if (it.Kind != AddUpdateRemove.Remove && it.NewValue != null)
             {
-              it.NewValue.IdentifyPolymorphic(proto.Identities, proto.Identities.Next(RdId));
+              it.NewValue.IdentifyPolymorphic(proto.Identities, proto.Identities.Next(RdId), false);
               definitions.Insert(it.Index, TryPreBindValue(lifetime, it.NewValue, it.Index, false));
             }
           }

--- a/rd-net/RdFramework/Impl/RdMap.cs
+++ b/rd-net/RdFramework/Impl/RdMap.cs
@@ -94,7 +94,7 @@ if (!OptimizeNested)
         {
           if (value != null)
           {
-            value.IdentifyPolymorphic(proto.Identities, proto.Identities.Next(RdId));
+            value.IdentifyPolymorphic(proto.Identities, proto.Identities.Next(RdId), false);
             var definition = TryPreBindValue(lifetime, key, value, false);
             if (definition != null)
               definitions.Add(key, definition);
@@ -140,7 +140,7 @@ if (!OptimizeNested)
 
             if (it.Kind != AddUpdateRemove.Remove)
             {
-              it.NewValue.IdentifyPolymorphic(proto.Identities, proto.Identities.Next(RdId));
+              it.NewValue.IdentifyPolymorphic(proto.Identities, proto.Identities.Next(RdId), false);
               var definition = TryPreBindValue(lifetime, it.Key, it.NewValue, false);
               definitions[it.Key] = definition;
             }

--- a/rd-net/RdFramework/Impl/RdProperty.cs
+++ b/rd-net/RdFramework/Impl/RdProperty.cs
@@ -88,12 +88,12 @@ namespace JetBrains.Rd.Impl
     public bool OptimizeNested = false;
     private LifetimeDefinition? myBindDefinition;
 
-    public override void Identify(IIdentities identities, RdId id)
+    public override void Identify(IIdentities identities, RdId id, bool stable)
     {
-      base.Identify(identities, id);
+      base.Identify(identities, id, stable);
       if (!OptimizeNested)
       {
-        Maybe.ValueOrDefault.IdentifyPolymorphic(identities, identities.Next(id));
+        Maybe.ValueOrDefault.IdentifyPolymorphic(identities, identities.Next(id), false);
       }
     }
 
@@ -143,7 +143,7 @@ namespace JetBrains.Rd.Impl
           // We need to terminate the current lifetime to unbind the existing value before assigning a new value, especially in cases where we are reassigning it.
           Memory.VolatileRead(ref myBindDefinition)?.Terminate();
 
-          v.IdentifyPolymorphic(proto.Identities, proto.Identities.Next(RdId));
+          v.IdentifyPolymorphic(proto.Identities, proto.Identities.Next(RdId), false);
 
           var prevDefinition = Interlocked.Exchange(ref myBindDefinition, TryPreBindValue(lifetime, v, false));
           prevDefinition?.Terminate();

--- a/rd-net/RdFramework/Tasks/RdCall.cs
+++ b/rd-net/RdFramework/Tasks/RdCall.cs
@@ -204,7 +204,7 @@ namespace JetBrains.Rd.Tasks
           if (result.Result.IsBindable())
           {
             // we mock the endpoint side, since we are on stub wire, so identify bindable result here
-            result.Result.IdentifyPolymorphic(proto.Identities, proto.Identities.Mix(RdId, taskId.ToString()));
+            result.Result.IdentifyPolymorphic(proto.Identities, proto.Identities.Next(taskId), false);
           }
           
           task.OnResultReceived(result, new SynchronousDispatchHelper(taskId, requestLifetime));

--- a/rd-net/RdFramework/Tasks/RdCall.cs
+++ b/rd-net/RdFramework/Tasks/RdCall.cs
@@ -204,7 +204,15 @@ namespace JetBrains.Rd.Tasks
           if (result.Result.IsBindable())
           {
             // we mock the endpoint side, since we are on stub wire, so identify bindable result here
-            result.Result.IdentifyPolymorphic(proto.Identities, proto.Identities.Next(taskId), false);
+            // Legacy Identities: restore pre-fix Mix(RdId, taskId.ToString()) for backward compatibility —
+            // the string-hash path has much better distribution than Next() (mix(parent, counter), a poor
+            // linear function). SequentialIdentities continues to use the dynamic Next() path.
+#pragma warning disable CS0618 // Type or member is obsolete
+            var resultId = proto.Identities is Identities legacyIdentities
+              ? legacyIdentities.Mix(RdId, taskId.ToString())
+              : proto.Identities.Next(taskId);
+#pragma warning restore CS0618 // Type or member is obsolete
+            result.Result.IdentifyPolymorphic(proto.Identities, resultId, false);
           }
           
           task.OnResultReceived(result, new SynchronousDispatchHelper(taskId, requestLifetime));

--- a/rd-net/RdFramework/Tasks/WiredRdTask.cs
+++ b/rd-net/RdFramework/Tasks/WiredRdTask.cs
@@ -171,7 +171,7 @@ namespace JetBrains.Rd.Tasks
             }
 
             var bindableRdId = proto.Identities.Next(RdId);
-            potentiallyBindable.IdentifyPolymorphic(proto.Identities, bindableRdId);
+            potentiallyBindable.IdentifyPolymorphic(proto.Identities, bindableRdId, false);
 
             using var cookie = Lifetime.UsingExecuteIfAlive();
             if (cookie.Succeed) // lifetime can be terminated from background thread

--- a/rd-net/Test.RdFramework/Contexts/RdPerContextMapTest.cs
+++ b/rd-net/Test.RdFramework/Contexts/RdPerContextMapTest.cs
@@ -230,7 +230,7 @@ namespace Test.RdFramework.Contexts
 
       using (key.UpdateValue(server1Cid))
       {
-        ServerProtocol.Wire.Send(ServerProtocol.Identities.Mix(RdId.Nil, 10), _ => { });
+        ServerProtocol.Wire.Send(ServerProtocol.Identities.Mix(RdId.Nil, "10"), _ => { });
       }
       
       Assert.True(ServerProtocol.Contexts.GetValueSet(key).Contains(server1Cid));

--- a/rd-net/Test.RdFramework/Interning/InterningTestModel.cs
+++ b/rd-net/Test.RdFramework/Interning/InterningTestModel.cs
@@ -53,7 +53,7 @@ namespace Test.RdFramework.Interning
     
     public InterningRoot1(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, GetType().Name));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, GetType().Name), true);
       this.BindTopLevel(lifetime, protocol, GetType().Name);
       Protocol.InitTrace?.Log ($"CREATED toplevel object {this.PrintToString()}");
     }

--- a/rd-net/Test.RdFramework/Interning/InterningTestPropertyWrapper.cs
+++ b/rd-net/Test.RdFramework/Interning/InterningTestPropertyWrapper.cs
@@ -30,10 +30,10 @@ namespace Test.RdFramework.Interning
       base.Init(lifetime, proto, ctx);
     }
 
-    public override void Identify(IIdentities identities, RdId id)
+    public override void Identify(IIdentities identities, RdId id, bool stable)
     {
-      Property.Identify(identities, id);
-      base.Identify(identities, id);
+      Property.Identify(identities, id, stable);
+      base.Identify(identities, id, stable);
     }
   }
 }

--- a/rd-net/Test.RdFramework/RdIdHeavyCollisionTest.cs
+++ b/rd-net/Test.RdFramework/RdIdHeavyCollisionTest.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using JetBrains.Collections.Viewable;
+using JetBrains.Lifetimes;
+using JetBrains.Rd;
+using JetBrains.Rd.Base;
+using JetBrains.Rd.Impl;
+using JetBrains.Serialization;
+using NUnit.Framework;
+
+namespace Test.RdFramework
+{
+  [TestFixture]
+  public class RdIdHeavyCollisionTest
+  {
+    private const int NodeCount = 20000;
+    private const int Seed = 1;
+
+    private static IIdentities Legacy()
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+      return new Identities(IdKind.Server);
+#pragma warning restore CS0618
+    }
+
+    private static IIdentities Sequential() => new SequentialIdentities(IdKind.Server);
+
+    private static IEnumerable<TestCaseData> Cases()
+    {
+      yield return new TestCaseData((Func<IIdentities>)Legacy, true)
+        .SetName("legacy Next COLLIDES in a large decoupled graph");
+      yield return new TestCaseData((Func<IIdentities>)Sequential, false)
+        .SetName("SequentialIdentities stays unique across a large decoupled graph");
+    }
+
+    [TestCaseSource(nameof(Cases))]
+    public void HeavyDecoupledGraph(Func<IIdentities> identitiesFactory, bool expectCollision)
+    {
+      var ld = new LifetimeDefinition();
+      try
+      {
+        var lifetime = ld.Lifetime;
+        var protocol = new Protocol("Heavy", new Serializers(), identitiesFactory(),
+          SynchronousScheduler.Instance, new StubWire(), lifetime);
+        var identities = protocol.Identities;
+
+        var root = new Node();
+        root.Identify(identities, new RdId(1), stable: false);
+        var nodes = new List<Node> { root };
+
+        using (AllowBindCookie.Create())
+        {
+          root.PreBind(lifetime, protocol, "root");
+
+          var random = new Random(Seed);
+          TestDelegate build = () =>
+          {
+            for (var k = 0; k < NodeCount; k++)
+            {
+              // Attach to an arbitrary earlier node: decoupling parent id from allocation order is what
+              // exposes legacy Next's poor distribution (a balanced tree would not collide).
+              var parent = nodes[random.Next(nodes.Count)];
+              var child = new Node();
+              child.Identify(identities, identities.Next(parent.RdId), stable: false);
+              child.PreBind(lifetime, parent, "n" + k); // registers; throws on a duplicate RdId
+              nodes.Add(child);
+            }
+          };
+
+          if (expectCollision)
+            Assert.Throws<ArgumentException>(build, "legacy dynamic ids must collide in a large decoupled graph");
+          else
+            Assert.DoesNotThrow(build, "SequentialIdentities must stay unique across the whole graph");
+        }
+      }
+      finally
+      {
+        ld.Terminate();
+      }
+    }
+
+    private sealed class Node : RdBindableBase
+    {
+    }
+
+    private sealed class StubWire : IWire
+    {
+      public bool IsStub => true;
+      public void Send<TParam>(RdId id, TParam param, Action<TParam, UnsafeWriter> writer) { }
+      public void Advise(Lifetime lifetime, IRdWireable entity) { }
+      public ProtocolContexts Contexts { get; set; } = null!;
+      public IRdWireable? TryGetById(RdId rdId) => null;
+    }
+  }
+}

--- a/rd-net/Test.RdFramework/RdIdHierarchyGuardTest.cs
+++ b/rd-net/Test.RdFramework/RdIdHierarchyGuardTest.cs
@@ -80,9 +80,9 @@ namespace Test.RdFramework
         myValue.Bind();
       }
 
-      public override void Identify(IIdentities identities, RdId id)
+      public override void Identify(IIdentities identities, RdId id, bool stable)
       {
-        myValue.Identify(identities, id);
+        myValue.Identify(identities, id, stable);
       }
     }
   }

--- a/rd-net/Test.RdFramework/RdIdIdentitiesCollisionMatrixTest.cs
+++ b/rd-net/Test.RdFramework/RdIdIdentitiesCollisionMatrixTest.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using JetBrains.Collections.Viewable;
+using JetBrains.Lifetimes;
+using JetBrains.Rd;
+using JetBrains.Rd.Base;
+using JetBrains.Rd.Impl;
+using JetBrains.Serialization;
+using NUnit.Framework;
+
+namespace Test.RdFramework
+{
+  [TestFixture]
+  public class RdIdIdentitiesCollisionMatrixTest
+  {
+    public enum Derivation { Dynamic, Stable }
+
+    private static IIdentities Legacy()
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+      return new Identities(IdKind.Server);
+#pragma warning restore CS0618
+    }
+
+    private static IIdentities Sequential() => new SequentialIdentities(IdKind.Server);
+
+    private static IEnumerable<TestCaseData> Cases()
+    {
+      yield return new TestCaseData((Func<IIdentities>)Legacy, Derivation.Dynamic, true)
+        .SetName("legacy + dynamic Next COLLIDES even with the fix");
+      yield return new TestCaseData((Func<IIdentities>)Legacy, Derivation.Stable, false)
+        .SetName("legacy + stable Mix does not collide");
+      yield return new TestCaseData((Func<IIdentities>)Sequential, Derivation.Dynamic, false)
+        .SetName("SequentialIdentities + dynamic Next does not collide");
+      yield return new TestCaseData((Func<IIdentities>)Sequential, Derivation.Stable, false)
+        .SetName("SequentialIdentities + stable Mix does not collide");
+    }
+
+    [TestCaseSource(nameof(Cases))]
+    public void Collision(Func<IIdentities> identitiesFactory, Derivation mode, bool expectedToCollide)
+    {
+      var ld = new LifetimeDefinition();
+      try
+      {
+        var lifetime = ld.Lifetime;
+        var protocol = new Protocol("MatrixCol", new Serializers(), identitiesFactory(),
+          SynchronousScheduler.Instance, new StubWire(), lifetime);
+        var identities = protocol.Identities;
+
+        // p1 (id 3) is identified/filled before p2 (id 1) — reverse id order is what lets legacy collide.
+        var p1 = new Node();
+        var p2 = new Node();
+        p1.Identify(identities, new RdId(3), stable: false);
+        p2.Identify(identities, new RdId(1), stable: false);
+
+        using (AllowBindCookie.Create())
+        {
+          p1.PreBind(lifetime, protocol, "p1");
+          p1.Bind();
+          p2.PreBind(lifetime, protocol, "p2");
+          p2.Bind();
+
+          TestDelegate fillTree = () =>
+          {
+            AddChildren(identities, p1, mode, 31, lifetime);
+            AddChildren(identities, p2, mode, 1, lifetime);
+          };
+
+          if (expectedToCollide)
+            Assert.Throws<ArgumentException>(fillTree, "expected a duplicate-RdId registration to throw");
+          else
+            Assert.DoesNotThrow(fillTree, "ids must stay unique");
+        }
+      }
+      finally
+      {
+        ld.Terminate();
+      }
+    }
+
+    private static void AddChildren(IIdentities identities, Node parent, Derivation mode, int count, Lifetime lifetime)
+    {
+      for (var i = 0; i < count; i++)
+      {
+        var name = "x" + i;
+        var childId = mode == Derivation.Dynamic
+          ? identities.Next(parent.RdId)             // dynamic (RdMap/RdList element) id
+          : identities.Mix(parent.RdId, "." + name); // stable (structural child) id
+        var child = new Node();
+        child.Identify(identities, childId, stable: false);
+        child.PreBind(lifetime, parent, name);
+        child.Bind();
+      }
+    }
+
+    private sealed class Node : RdBindableBase
+    {
+    }
+
+    private sealed class StubWire : IWire
+    {
+      public bool IsStub => true;
+      public void Send<TParam>(RdId id, TParam param, Action<TParam, UnsafeWriter> writer) { }
+      public void Advise(Lifetime lifetime, IRdWireable entity) { }
+      public ProtocolContexts Contexts { get; set; } = null!;
+      public IRdWireable? TryGetById(RdId rdId) => null;
+    }
+  }
+}

--- a/rd-net/Test.RdFramework/RdIdLegacyCollisionTest.cs
+++ b/rd-net/Test.RdFramework/RdIdLegacyCollisionTest.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using JetBrains.Collections.Viewable;
+using JetBrains.Lifetimes;
+using JetBrains.Rd;
+using JetBrains.Rd.Base;
+using JetBrains.Rd.Impl;
+using JetBrains.Serialization;
+using NUnit.Framework;
+
+namespace Test.RdFramework
+{
+  [TestFixture]
+  public class RdIdLegacyCollisionTest
+  {
+    private sealed class Leaf : RdBindableBase
+    {
+    }
+
+    private sealed class CollisionModel : RdBindableBase
+    {
+      public readonly List<Leaf> Kids = new List<Leaf>();
+
+      public CollisionModel(int childCount)
+      {
+        for (var k = 0; k < childCount; k++)
+        {
+          var leaf = new Leaf();
+          Kids.Add(leaf);
+          BindableChildren.Add(new KeyValuePair<string, object>("x" + k, leaf));
+        }
+      }
+    }
+
+    private sealed class StubWire : IWire
+    {
+      public bool IsStub => true;
+      public void Send<TParam>(RdId id, TParam param, Action<TParam, UnsafeWriter> writer) { }
+      public void Advise(Lifetime lifetime, IRdWireable entity) { }
+      public ProtocolContexts Contexts { get; set; } = null!;
+      public IRdWireable? TryGetById(RdId rdId) => null;
+    }
+
+    private static IIdentities Legacy()
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+      return new Identities(IdKind.Server);
+#pragma warning restore CS0618
+    }
+
+    private static IIdentities Sequential() => new SequentialIdentities(IdKind.Server);
+
+    private static IEnumerable<TestCaseData> Cases()
+    {
+      yield return new TestCaseData((Func<IIdentities>)Legacy).SetName("legacy Identities (with the fix)");
+      yield return new TestCaseData((Func<IIdentities>)Sequential).SetName("SequentialIdentities");
+    }
+
+    [TestCaseSource(nameof(Cases))]
+    public void ChildRdIdsDoNotCollideAcrossParents(Func<IIdentities> identitiesFactory)
+    {
+      var ld = new LifetimeDefinition();
+      var lifetime = ld.Lifetime;
+      var protocol = new Protocol("Collision", new Serializers(), identitiesFactory(),
+        SynchronousScheduler.Instance, new StubWire(), lifetime);
+
+      var model1 = new CollisionModel(31);
+      var model2 = new CollisionModel(1);
+
+      using (AllowBindCookie.Create())
+      {
+        model1.Identify(protocol.Identities, new RdId(3), stable: false);
+        model2.Identify(protocol.Identities, new RdId(1), stable: false);
+
+        model1.PreBind(lifetime, protocol, "m1");
+        model1.Bind();
+        // Without the fix this is where model2.x0 duplicates model1.x0 and Register throws.
+        model2.PreBind(lifetime, protocol, "m2");
+        model2.Bind();
+      }
+
+      Assert.AreNotEqual(model1.Kids[0].RdId.Value, model2.Kids[0].RdId.Value,
+        "named children of different parents must not collide");
+
+      var all = new HashSet<long>();
+      foreach (var leaf in model1.Kids) Assert.True(all.Add(leaf.RdId.Value), "duplicate id in model1");
+      foreach (var leaf in model2.Kids) Assert.True(all.Add(leaf.RdId.Value), "duplicate id in model2");
+
+      ld.Terminate();
+    }
+  }
+}

--- a/rd-net/Test.RdFramework/Reflection/ProxyGeneratorCustomSignalTest.cs
+++ b/rd-net/Test.RdFramework/Reflection/ProxyGeneratorCustomSignalTest.cs
@@ -97,9 +97,9 @@ namespace Test.RdFramework.Reflection
 
       public bool TryGetSerializationContext(out SerializationCtx ctx) => myRdSignal.TryGetSerializationContext(out ctx);
 
-      public void Identify(IIdentities identities, RdId id)
+      public void Identify(IIdentities identities, RdId id, bool stable)
       {
-        myRdSignal.Identify(identities, id);
+        myRdSignal.Identify(identities, id, stable);
       }
     }
   }

--- a/rd-net/Test.RdFramework/Reflection/data/Generated/RefExt.cs
+++ b/rd-net/Test.RdFramework/Reflection/data/Generated/RefExt.cs
@@ -96,7 +96,7 @@ namespace Test.RdFramework.Reflection.Generated
     
     public RefExt(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "RefExt"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "RefExt"), true);
       this.BindTopLevel(lifetime, protocol, "RefExt");
     }
     

--- a/rd-net/Test.RdFramework/Reflection/data/Generated/RefRoot.cs
+++ b/rd-net/Test.RdFramework/Reflection/data/Generated/RefRoot.cs
@@ -67,7 +67,7 @@ namespace Test.RdFramework.Reflection.Generated
     
     public RefRoot(Lifetime lifetime, IProtocol protocol) : this()
     {
-      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "RefRoot"));
+      Identify(protocol.Identities, protocol.Identities.Mix(RdId.Root, "RefRoot"), true);
       this.BindTopLevel(lifetime, protocol, "RefRoot");
     }
     

--- a/rd-net/Test.RdFramework/SequentialIdentitiesTest.cs
+++ b/rd-net/Test.RdFramework/SequentialIdentitiesTest.cs
@@ -32,31 +32,13 @@ namespace Test.RdFramework
       var serverIdentities = new SequentialIdentities(IdKind.Server);
 
       var testStrings = new[] { "", "a", "test", "Protocol", "Extension", "InternRoot" };
-      var testInts = new[] { 0, 1, -1, int.MaxValue, int.MinValue };
-      var testLongs = new[] { 0L, 1L, -1L, long.MaxValue, long.MinValue };
-
+      
       foreach (var s in testStrings)
       {
         var clientId = clientIdentities.Mix(RdId.Nil, s);
         var serverId = serverIdentities.Mix(RdId.Nil, s);
         Assert.That(clientId.Value & HighBit, Is.Not.EqualTo(0L), $"Client stable ID from string '{s}' should have high bit set");
         Assert.That(serverId.Value & HighBit, Is.Not.EqualTo(0L), $"Server stable ID from string '{s}' should have high bit set");
-      }
-
-      foreach (var i in testInts)
-      {
-        var clientId = clientIdentities.Mix(RdId.Nil, i);
-        var serverId = serverIdentities.Mix(RdId.Nil, i);
-        Assert.That(clientId.Value & HighBit, Is.Not.EqualTo(0L), $"Client stable ID from int {i} should have high bit set");
-        Assert.That(serverId.Value & HighBit, Is.Not.EqualTo(0L), $"Server stable ID from int {i} should have high bit set");
-      }
-
-      foreach (var l in testLongs)
-      {
-        var clientId = clientIdentities.Mix(RdId.Nil, l);
-        var serverId = serverIdentities.Mix(RdId.Nil, l);
-        Assert.That(clientId.Value & HighBit, Is.Not.EqualTo(0L), $"Client stable ID from long {l} should have high bit set");
-        Assert.That(serverId.Value & HighBit, Is.Not.EqualTo(0L), $"Server stable ID from long {l} should have high bit set");
       }
     }
 

--- a/rd-net/Test.RdFramework/Util/RdBindableExUtilTest.cs
+++ b/rd-net/Test.RdFramework/Util/RdBindableExUtilTest.cs
@@ -77,6 +77,6 @@ public class RdBindableExUtilTest
 
     public void Bind() { throw new NotImplementedException(); }
 
-    public void Identify(IIdentities identities, RdId id) { throw new NotImplementedException(); }
+    public void Identify(IIdentities identities, RdId id, bool stable) { throw new NotImplementedException(); }
   }
 }


### PR DESCRIPTION
- Restore old behavior in case of legacy Identities. Use Mix instead of less reliable Next