### PR TITLE
Au/sync calls callback

### DIFF
--- a/rd-net/RdFramework.Reflection/ProxyGeneratorUtil.cs
+++ b/rd-net/RdFramework.Reflection/ProxyGeneratorUtil.cs
@@ -80,6 +80,7 @@ namespace JetBrains.Rd.Reflection
       if (!completed)
       {
         task.SetCancelled();
+        SyncCallMonitor.RaiseSyncCallTimedOut(new SyncCallInfo(call.Location, stopwatch.Elapsed, timeoutsToUse));
         throw new TimeoutException($"Sync execution of rpc `{call.Location}` is timed out in {timeoutsToUse.ErrorAwaitTime.TotalMilliseconds} ms");
       }
 
@@ -87,6 +88,7 @@ namespace JetBrains.Rd.Reflection
       if (freezeTime > timeoutsToUse.WarnAwaitTime.TotalMilliseconds)
         Log.Root.Warn("Sync execution of rpc `{0}` executed too long: {1} ms", call.Location, freezeTime);
 
+      SyncCallMonitor.RaiseSyncCallFinished(new SyncCallInfo(call.Location, stopwatch.Elapsed, timeoutsToUse));
       return task.Result.Value.Unwrap();
     }
 

--- a/rd-net/RdFramework.Reflection/ProxyGeneratorUtil.cs
+++ b/rd-net/RdFramework.Reflection/ProxyGeneratorUtil.cs
@@ -84,10 +84,6 @@ namespace JetBrains.Rd.Reflection
         throw new TimeoutException($"Sync execution of rpc `{call.Location}` is timed out in {timeoutsToUse.ErrorAwaitTime.TotalMilliseconds} ms");
       }
 
-      var freezeTime = stopwatch.ElapsedMilliseconds;
-      if (freezeTime > timeoutsToUse.WarnAwaitTime.TotalMilliseconds)
-        Log.Root.Warn("Sync execution of rpc `{0}` executed too long: {1} ms", call.Location, freezeTime);
-
       SyncCallMonitor.RaiseSyncCallFinished(new SyncCallInfo(call.Location, stopwatch.Elapsed, timeoutsToUse));
       return task.Result.Value.Unwrap();
     }

--- a/rd-net/RdFramework/Tasks/RdCall.cs
+++ b/rd-net/RdFramework/Tasks/RdCall.cs
@@ -168,7 +168,6 @@ namespace JetBrains.Rd.Tasks
           SyncCallMonitor.RaiseSyncCallTimedOut(new SyncCallInfo(Location, stopwatch.Elapsed, timeoutsToUse));
           throw new TimeoutException($"Sync execution of rpc `{Location}` is timed out in {timeoutsToUse.ErrorAwaitTime.TotalMilliseconds} ms, the freeze time is {stopwatch.ElapsedMilliseconds} ms");
         }
-        Log.Root.Error("Sync execution of rpc `{0}` executed too long: {1} ms, the freeze time: {2} ms", Location, timeoutsToUse.WarnAwaitTime.TotalMilliseconds, stopwatch.ElapsedMilliseconds);
       }
 
       stopwatch.Stop();

--- a/rd-net/RdFramework/Tasks/RdCall.cs
+++ b/rd-net/RdFramework/Tasks/RdCall.cs
@@ -162,12 +162,17 @@ namespace JetBrains.Rd.Tasks
         var deltaAwaitTime = timeoutsToUse.ErrorAwaitTime - timeoutsToUse.WarnAwaitTime;
         var res = deltaAwaitTime > TimeSpan.Zero && task.Wait(deltaAwaitTime);
         stopwatch.Stop();
-        
+
         if (!res)
+        {
+          SyncCallMonitor.RaiseSyncCallTimedOut(new SyncCallInfo(Location, stopwatch.Elapsed, timeoutsToUse));
           throw new TimeoutException($"Sync execution of rpc `{Location}` is timed out in {timeoutsToUse.ErrorAwaitTime.TotalMilliseconds} ms, the freeze time is {stopwatch.ElapsedMilliseconds} ms");
+        }
         Log.Root.Error("Sync execution of rpc `{0}` executed too long: {1} ms, the freeze time: {2} ms", Location, timeoutsToUse.WarnAwaitTime.TotalMilliseconds, stopwatch.ElapsedMilliseconds);
       }
 
+      stopwatch.Stop();
+      SyncCallMonitor.RaiseSyncCallFinished(new SyncCallInfo(Location, stopwatch.Elapsed, timeoutsToUse));
       return task.Result.Value.Unwrap();
     }
 

--- a/rd-net/RdFramework/Tasks/SyncCallMonitor.cs
+++ b/rd-net/RdFramework/Tasks/SyncCallMonitor.cs
@@ -30,6 +30,19 @@ namespace JetBrains.Rd.Tasks
   /// </summary>
   public static class SyncCallMonitor
   {
+    /// The default <see cref="SyncCallFinished"/> handler: logs when a call exceeds WarnAwaitTime.
+    /// Opt-out.
+    public static readonly Action<SyncCallInfo> DefaultWarnHandler = static info =>
+    {
+      if (info.ElapsedTime > info.Timeouts.WarnAwaitTime)
+        Log.Root.Error("Sync execution of rpc `{0}` executed too long: {1} ms, the freeze time: {2} ms", info.Location, info.Timeouts.WarnAwaitTime.TotalMilliseconds, info.ElapsedTime.TotalMilliseconds);
+    };
+
+    static SyncCallMonitor()
+    {
+      SyncCallFinished += DefaultWarnHandler;
+    }
+
     /// <summary>
     /// Raised after every synchronous RPC call that completed within its timeout.
     /// Use this to track sync call volume and identify candidates for async migration.

--- a/rd-net/RdFramework/Tasks/SyncCallMonitor.cs
+++ b/rd-net/RdFramework/Tasks/SyncCallMonitor.cs
@@ -1,0 +1,49 @@
+using System;
+using JetBrains.Diagnostics;
+
+namespace JetBrains.Rd.Tasks
+{
+  /// <summary>
+  /// Information about a synchronous RPC call, provided by <see cref="SyncCallMonitor"/>.
+  /// </summary>
+  public readonly struct SyncCallInfo
+  {
+    /// <summary>The location (endpoint path) of the RPC call.</summary>
+    public RName Location { get; }
+
+    /// <summary>How long the synchronous call took.</summary>
+    public TimeSpan ElapsedTime { get; }
+
+    /// <summary>The timeouts configured for this call.</summary>
+    public RpcTimeouts Timeouts { get; }
+
+    public SyncCallInfo(RName location, TimeSpan elapsedTime, RpcTimeouts timeouts)
+    {
+      Location = location;
+      ElapsedTime = elapsedTime;
+      Timeouts = timeouts;
+    }
+  }
+
+  /// <summary>
+  /// Provides observability for synchronous RPC calls.
+  /// </summary>
+  public static class SyncCallMonitor
+  {
+    /// <summary>
+    /// Raised after every synchronous RPC call that completed within its timeout.
+    /// Use this to track sync call volume and identify candidates for async migration.
+    /// </summary>
+    public static event Action<SyncCallInfo>? SyncCallFinished;
+
+    /// <summary>
+    /// Raised when a synchronous RPC call exceeds its error timeout, before the
+    /// <see cref="TimeoutException"/> is thrown to the caller.
+    /// Use this to aggregate timeout-affected endpoints.
+    /// </summary>
+    public static event Action<SyncCallInfo>? SyncCallTimedOut;
+
+    public static void RaiseSyncCallFinished(SyncCallInfo info) => SyncCallFinished?.Invoke(info);
+    public static void RaiseSyncCallTimedOut(SyncCallInfo info) => SyncCallTimedOut?.Invoke(info);
+  }
+}

--- a/rd-net/Test.RdFramework/Reflection/SyncCallMonitorTest.cs
+++ b/rd-net/Test.RdFramework/Reflection/SyncCallMonitorTest.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Lifetimes;
+using JetBrains.Rd.Reflection;
+using JetBrains.Rd.Tasks;
+using NUnit.Framework;
+
+namespace Test.RdFramework.Reflection;
+
+/// <summary>
+/// Tests for <see cref="SyncCallMonitor"/> covering the <see cref="ProxyGeneratorUtil.SyncNested"/> code path.
+/// </summary>
+[TestFixture]
+public class SyncCallMonitorViaProxyTest : ProxyGeneratorTestBase
+{
+  protected override bool IsAsync => true;
+  protected override bool RespectRpcTimeouts => true;
+
+  [RdRpc]
+  public interface IMonitorCallTest
+  {
+    void FastCall(Lifetime cancel);
+
+    [RpcTimeout(1)]
+    void SlowCall(Lifetime cancel);
+  }
+
+  [RdExt]
+  internal class MonitorCallTest : RdExtReflectionBindableBase, IMonitorCallTest
+  {
+    public void FastCall(Lifetime cancel) { }
+    public void SlowCall(Lifetime cancel) => SpinWait.SpinUntil(() => !cancel.IsAlive, 5000);
+  }
+
+  private SyncCallInfo? myFinished;
+  private SyncCallInfo? myTimedOut;
+
+  public override void SetUp()
+  {
+    base.SetUp();
+    myFinished = null;
+    myTimedOut = null;
+    SyncCallMonitor.SyncCallFinished += OnFinished;
+    SyncCallMonitor.SyncCallTimedOut += OnTimedOut;
+  }
+
+  public override void TearDown()
+  {
+    SyncCallMonitor.SyncCallFinished -= OnFinished;
+    SyncCallMonitor.SyncCallTimedOut -= OnTimedOut;
+    base.TearDown();
+  }
+
+  private void OnFinished(SyncCallInfo info) => myFinished = info;
+  private void OnTimedOut(SyncCallInfo info) => myTimedOut = info;
+
+  [Test, Timeout(5000)]
+  public async Task SuccessfulCall_FiresSyncCallFinished_NotTimedOut()
+  {
+    await TestTemplate<MonitorCallTest, IMonitorCallTest>(model =>
+    {
+      model.FastCall(TestLifetime);
+
+      Assert.NotNull(myFinished);
+      Assert.Null(myTimedOut);
+      Assert.IsNotEmpty(myFinished!.Value.Location.ToString());
+      Assert.GreaterOrEqual(myFinished.Value.ElapsedTime.TotalMilliseconds, 0);
+      return Task.CompletedTask;
+    });
+  }
+
+  [Test, Timeout(5000)]
+  public async Task TimedOutCall_FiresSyncCallTimedOut_NotFinished()
+  {
+    await TestTemplate<MonitorCallTest, IMonitorCallTest>(model =>
+    {
+      Assert.Throws<TimeoutException>(() => model.SlowCall(TestLifetime));
+
+      Assert.NotNull(myTimedOut);
+      Assert.Null(myFinished);
+      Assert.IsNotEmpty(myTimedOut!.Value.Location.ToString());
+      Assert.GreaterOrEqual(myTimedOut.Value.ElapsedTime.TotalMilliseconds, 0);
+      return Task.CompletedTask;
+    });
+  }
+}
+
+/// <summary>
+/// Tests for <see cref="SyncCallMonitor"/> covering the <see cref="RdCall{TReq,TRes}.Sync"/> code path.
+/// </summary>
+[TestFixture]
+[Apartment(ApartmentState.STA)]
+public class SyncCallMonitorDirectSyncTest : RdFrameworkTestBase
+{
+  private const int ourKey = 1;
+  private bool myPreviousRespectRpcTimeouts;
+
+  private SyncCallInfo? myFinished;
+  private SyncCallInfo? myTimedOut;
+
+  public override void SetUp()
+  {
+    myPreviousRespectRpcTimeouts = RpcTimeouts.RespectRpcTimeouts;
+    RpcTimeouts.RespectRpcTimeouts = true;
+    base.SetUp();
+    ClientWire.AutoTransmitMode = true;
+    ServerWire.AutoTransmitMode = true;
+    SyncCallMonitor.SyncCallFinished += OnFinished;
+    SyncCallMonitor.SyncCallTimedOut += OnTimedOut;
+    myFinished = null;
+    myTimedOut = null;
+  }
+
+  public override void TearDown()
+  {
+    SyncCallMonitor.SyncCallFinished -= OnFinished;
+    SyncCallMonitor.SyncCallTimedOut -= OnTimedOut;
+    RpcTimeouts.RespectRpcTimeouts = myPreviousRespectRpcTimeouts;
+    base.TearDown();
+  }
+
+  private void OnFinished(SyncCallInfo info) => myFinished = info;
+  private void OnTimedOut(SyncCallInfo info) => myTimedOut = info;
+
+  [Test]
+  public void SuccessfulCall_FiresSyncCallFinished_NotTimedOut()
+  {
+    var caller = BindToServer(TestLifetime, NewRdCall<int, string>(), ourKey);
+    BindToClient(TestLifetime, NewRdCall<int, string>(), ourKey)
+      .SetSync((_, req) => req.ToString());
+
+    var result = caller.Sync(42);
+
+    Assert.AreEqual("42", result);
+    Assert.NotNull(myFinished);
+    Assert.Null(myTimedOut);
+    Assert.IsNotEmpty(myFinished!.Value.Location.ToString());
+    Assert.GreaterOrEqual(myFinished.Value.ElapsedTime.TotalMilliseconds, 0);
+  }
+
+  [Test]
+  public void TimedOutCall_FiresSyncCallTimedOut_NotFinished()
+  {
+    // Disable auto-transmit so the request is queued but never delivered: the task never
+    // completes and Sync times out waiting for it.
+    ServerWire.AutoTransmitMode = false;
+
+    var caller = BindToServer(TestLifetime, NewRdCall<int, string>(), ourKey);
+    BindToClient(TestLifetime, NewRdCall<int, string>(), ourKey)
+      .SetSync((_, req) => req.ToString());
+
+    var timeouts = new RpcTimeouts(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(1));
+    Assert.Throws<TimeoutException>(() => caller.Sync(42, timeouts));
+    ServerWire.MissOneMessage(); // drop queued request to satisfy TearDown wire-empty assertion
+
+    Assert.NotNull(myTimedOut);
+    Assert.Null(myFinished);
+    Assert.IsNotEmpty(myTimedOut!.Value.Location.ToString());
+    Assert.AreEqual(timeouts.WarnAwaitTime, myTimedOut.Value.Timeouts.WarnAwaitTime);
+    Assert.AreEqual(timeouts.ErrorAwaitTime, myTimedOut.Value.Timeouts.ErrorAwaitTime);
+  }
+}


### PR DESCRIPTION
Add observability for synchronous RPC calls via SyncCallMonitor.

The previously unconditional slow-call warning is now opt-out via DefaultWarnHandler (unified with RdReflection and regular Rd)