### PR TITLE
Fix race condition in `ByteBufferAsyncProcessor`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx1024m
 
-version=2026.2.4
+version=2026.2.5-pre01
 
 deployMavenToIntelliJDependencies=false
 deployMavenToCentralPortal=false

--- a/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/threading/ByteBufferAsyncProcessor.kt
+++ b/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/threading/ByteBufferAsyncProcessor.kt
@@ -325,7 +325,14 @@ class ByteBufferAsyncProcessor(val id : String,
     }
 
     private fun growConditionally() {
-        if (chunkToFill.next.checkEmpty(this))
+        // RIDER-127935: never advance the producer onto the chunk the consumer is currently processing
+        // (`chunkToProcess`). Reusing it would let the producer overwrite that chunk's data and, worse,
+        // re-point its `next` before the consumer captures it in its finally block — re-routing the consumer
+        // into freshly-filled (newer) data ahead of older still-unfed chunks (a FIFO/ordering violation that
+        // permutes the byte stream under producer-outruns-consumer / lapping). Splicing a fresh chunk here
+        // keeps the producer strictly behind the consumer's head, so new data is always appended at the true
+        // tail and fed last.
+        if (chunkToFill.next !== chunkToProcess && chunkToFill.next.checkEmpty(this))
             return
 
         log.trace {"Grow: $chunkSize bytes" }

--- a/rd-kt/rd-core/src/test/kotlin/com/jetbrains/rd/util/test/cases/ByteBufferAsyncProcessorTest.kt
+++ b/rd-kt/rd-core/src/test/kotlin/com/jetbrains/rd/util/test/cases/ByteBufferAsyncProcessorTest.kt
@@ -1,9 +1,20 @@
 package com.jetbrains.rd.util.test.cases
 
+import com.jetbrains.rd.util.spinUntil
 import com.jetbrains.rd.util.threading.ByteBufferAsyncProcessor
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 import java.io.ByteArrayInputStream
 import java.io.InputStream
+import java.time.Duration
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import java.util.zip.CRC32
+import kotlin.concurrent.thread
+import kotlin.test.assertFalse
 
 class ByteBufferAsyncProcessorTest {
 
@@ -41,4 +52,161 @@ class ByteBufferAsyncProcessorTest {
             buffer.put(it.toByteArray())
         }
     }
+
+    // RIDER-127935: ByteBufferAsyncProcessor's public API is all `synchronized` and only
+    // clear/reprocessUnacknowledged forbid the processing thread — i.e. the class implies put()/acknowledge()
+    // are callable from any thread. This drives it exactly the way SocketWire does (many producers calling
+    // put(), one consumer/processor draining + assigning seqn + async acks) and verifies the fundamental
+    // contract: the bytes handed to the processor, concatenated in invocation order, must reconstruct the
+    // put() frames faithfully. RED: under concurrent producers the ring hands out chunks out of fill order,
+    // permuting the byte stream.
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
+    fun concurrentProducersPreserveStream() = runStreamPreservationTest(producers = 16)
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
+    fun twoProducersPreserveStream() = runStreamPreservationTest(producers = 2)
+
+    // Control: identical total volume from a single producer must stay GREEN, proving the failure is
+    // concurrency-specific (not the harness / codec / chunking).
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
+    fun oneProducerLargeFramesPreserveStream() = runStreamPreservationTest(producers = 1)
+
+    private fun runStreamPreservationTest(producers: Int) {
+        val rounds = 15
+        val iterations = 20
+        val frameSize = 128_000   // > chunkSize -> every frame spans several chunks
+        val chunkSize = 16370     // ByteBufferAsyncProcessor default
+
+        val corruptions = ArrayList<String>()                  // written only by the single processor thread
+        val verifier = StreamVerifier(frameSize, corruptions)  // re-frames the concatenated chunk stream
+        val bytesProcessed = AtomicLong(0)
+        var sentSeqn = 0L                                       // touched only by the processor thread
+        val ackExecutor = Executors.newSingleThreadExecutor()
+
+        lateinit var buffer: ByteBufferAsyncProcessor
+        buffer = ByteBufferAsyncProcessor("TestConcurrentProducers", chunkSize) { chunk ->
+            if (chunk.isNotProcessed) chunk.seqn = ++sentSeqn   // mimic SocketWire.send0
+            verifier.feed(chunk.data, chunk.ptr)                // mimic the receiver reassembling the stream
+            bytesProcessed.addAndGet(chunk.ptr.toLong())        // AFTER feed -> happens-before the final read
+            val seqn = chunk.seqn
+            ackExecutor.execute { buffer.acknowledge(seqn) }    // mimic the counterpart ack -> ring reuse/lap
+        }
+        buffer.start()
+
+        var bytesPutTotal = 0L
+        var drained = true
+        for (round in 0 until rounds) {
+            if (corruptions.isNotEmpty()) break
+            val base = round * iterations
+            val barrier = CyclicBarrier(producers)
+            val threads = (0 until producers).map { tid ->
+                thread(isDaemon = true, name = "producer-$round-$tid") {
+                    barrier.await()
+                    for (it in 0 until iterations)
+                        buffer.put(makeFrame(tid, base + it, frameSize))
+                }
+            }
+            threads.forEach {
+                it.join(60_000)
+                assertFalse(it.isAlive, "Thread ${it.name} should be terminated.")
+            }
+            bytesPutTotal += producers.toLong() * iterations * frameSize
+            drained = spinUntil(30_000) { corruptions.isNotEmpty() || bytesProcessed.get() >= bytesPutTotal }
+            if (!drained) break
+        }
+
+        buffer.terminate(Duration.ofSeconds(30))
+        ackExecutor.shutdownNow()
+
+        val expectedFrames = producers * rounds * iterations
+        assertTrue(corruptions.isEmpty(),
+            "ByteBufferAsyncProcessor corrupted the stream under $producers producer(s): ${corruptions.take(5)}")
+        assertTrue(drained,
+            "timed out draining: bytesProcessed=${bytesProcessed.get()} expected=$bytesPutTotal")
+        assertTrue(verifier.frameCount == expectedFrames,
+            "frame count ${verifier.frameCount} != expected $expectedFrames")
+    }
+}
+
+// --- RIDER-127935 stream-preservation harness (socket-free) ---------------------------------------------
+
+/** Self-verifying frame: [len:int32][producerId:int32][seq:int32][crc32:int32][filler…], big-endian. */
+private fun makeFrame(producerId: Int, seq: Int, size: Int): ByteArray {
+    val b = ByteArray(size)
+    val seed = producerId * 1_000_003 + seq
+    for (k in 16 until size) b[k] = ((seed + k) and 0xFF).toByte()
+    putIntBE(b, 0, size)
+    putIntBE(b, 4, producerId)
+    putIntBE(b, 8, seq)
+    putIntBE(b, 12, crc32(b, 16, size - 16))
+    return b
+}
+
+/**
+ * Re-frames the byte stream produced by concatenating chunk data in processor-invocation order. Holds only a
+ * single-frame buffer (no full accumulation), so memory stays bounded regardless of total volume. A
+ * chunk-level reorder splits a frame and trips the very next len/crc check.
+ */
+private class StreamVerifier(private val frameSize: Int, private val corruptions: MutableList<String>) {
+    private val frame = ByteArray(frameSize)
+    private var have = 0
+    private val seen = HashSet<Long>()
+    var frameCount = 0
+        private set
+
+    fun feed(data: ByteArray, len: Int) {
+        var pos = 0
+        while (pos < len) {
+            val take = minOf(frameSize - have, len - pos)
+            System.arraycopy(data, pos, frame, have, take)
+            have += take
+            pos += take
+            if (have == frameSize) {
+                verifyFrame()
+                have = 0
+            }
+        }
+    }
+
+    private fun verifyFrame() {
+        if (corruptions.size >= 8) return // desynced stream produces noise; the first few anomalies are enough
+        val len = getIntBE(frame, 0)
+        if (len != frameSize) {
+            corruptions.add("bad len=$len at frame #$frameCount (expected $frameSize)")
+            return
+        }
+        val pid = getIntBE(frame, 4)
+        val seq = getIntBE(frame, 8)
+        val storedCrc = getIntBE(frame, 12)
+        val actualCrc = crc32(frame, 16, frameSize - 16)
+        if (storedCrc != actualCrc) {
+            corruptions.add("crc mismatch frame #$frameCount pid=$pid seq=$seq stored=$storedCrc actual=$actualCrc")
+            return
+        }
+        val key = (pid.toLong() shl 32) or (seq.toLong() and 0xFFFFFFFFL)
+        if (!seen.add(key)) corruptions.add("duplicate frame pid=$pid seq=$seq at #$frameCount")
+        frameCount++
+    }
+}
+
+private fun putIntBE(b: ByteArray, off: Int, v: Int) {
+    b[off] = (v ushr 24).toByte()
+    b[off + 1] = (v ushr 16).toByte()
+    b[off + 2] = (v ushr 8).toByte()
+    b[off + 3] = v.toByte()
+}
+
+private fun getIntBE(b: ByteArray, off: Int): Int =
+    ((b[off].toInt() and 0xFF) shl 24) or
+        ((b[off + 1].toInt() and 0xFF) shl 16) or
+        ((b[off + 2].toInt() and 0xFF) shl 8) or
+        (b[off + 3].toInt() and 0xFF)
+
+private fun crc32(b: ByteArray, off: Int, len: Int): Int {
+    val c = CRC32()
+    c.update(b, off, len)
+    return c.value.toInt()
 }

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/SocketWire.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/SocketWire.kt
@@ -352,36 +352,44 @@ class SocketWire {
             }
         }
 
+        // RIDER-127935: serialize concurrent senders so the send buffer only ever sees a single
+        // producer at a time. ByteBufferAsyncProcessor's chunk ring is single-producer-safe; concurrent
+        // producers (e.g. AsyncRdProperty set from arbitrary threads) corrupt the chunk linkage.
+        // Reentrant by design (nested sends from the context machinery run on the same thread).
+        private val sendSerializationLock = Any()
+
         override fun send(id: RdId, writer: (AbstractBuffer) -> Unit) {
             require(!id.isNull) { "id mustn't be null" }
 
-            val unsafeBuffer = threadLocalBufferArray.get()
-            val initialPosition = unsafeBuffer.position
-            try {
+            synchronized(sendSerializationLock) {
+                val unsafeBuffer = threadLocalBufferArray.get()
+                val initialPosition = unsafeBuffer.position
+                try {
 
-                unsafeBuffer.writeInt(0) //placeholder for length
+                    unsafeBuffer.writeInt(0) //placeholder for length
 
-                id.write(unsafeBuffer) //write id
-                contexts.writeCurrentMessageContext(unsafeBuffer)
-                writer(unsafeBuffer) //write rest
+                    id.write(unsafeBuffer) //write id
+                    contexts.writeCurrentMessageContext(unsafeBuffer)
+                    writer(unsafeBuffer) //write rest
 
-                val len = unsafeBuffer.position - initialPosition
+                    val len = unsafeBuffer.position - initialPosition
 
-                if (len > maxMessageLength) {
-                    val entry = messageBroker.tryGetById(id)
-                    logger.error { "Too long message: $len. ${entry?.location?.toString() ?: "<NULL>"}" }
-                }
+                    if (len > maxMessageLength) {
+                        val entry = messageBroker.tryGetById(id)
+                        logger.error { "Too long message: $len. ${entry?.location?.toString() ?: "<NULL>"}" }
+                    }
 
-                unsafeBuffer.position = initialPosition
-                unsafeBuffer.writeInt(len - 4)
-
-                val bytes = unsafeBuffer.getArray()
-                sendBuffer.put(bytes, initialPosition, len)
-            } finally {
-                if (initialPosition == 0)
-                    unsafeBuffer.reset() // apply shrinking logic
-                else
                     unsafeBuffer.position = initialPosition
+                    unsafeBuffer.writeInt(len - 4)
+
+                    val bytes = unsafeBuffer.getArray()
+                    sendBuffer.put(bytes, initialPosition, len)
+                } finally {
+                    if (initialPosition == 0)
+                        unsafeBuffer.reset() // apply shrinking logic
+                    else
+                        unsafeBuffer.position = initialPosition
+                }
             }
         }
     }

--- a/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/SocketWire.kt
+++ b/rd-kt/rd-framework/src/main/kotlin/com/jetbrains/rd/framework/SocketWire.kt
@@ -361,35 +361,33 @@ class SocketWire {
         override fun send(id: RdId, writer: (AbstractBuffer) -> Unit) {
             require(!id.isNull) { "id mustn't be null" }
 
-            synchronized(sendSerializationLock) {
-                val unsafeBuffer = threadLocalBufferArray.get()
-                val initialPosition = unsafeBuffer.position
-                try {
+            val unsafeBuffer = threadLocalBufferArray.get()
+            val initialPosition = unsafeBuffer.position
+            try {
 
-                    unsafeBuffer.writeInt(0) //placeholder for length
+                unsafeBuffer.writeInt(0) //placeholder for length
 
-                    id.write(unsafeBuffer) //write id
-                    contexts.writeCurrentMessageContext(unsafeBuffer)
-                    writer(unsafeBuffer) //write rest
+                id.write(unsafeBuffer) //write id
+                contexts.writeCurrentMessageContext(unsafeBuffer)
+                writer(unsafeBuffer) //write rest
 
-                    val len = unsafeBuffer.position - initialPosition
+                val len = unsafeBuffer.position - initialPosition
 
-                    if (len > maxMessageLength) {
-                        val entry = messageBroker.tryGetById(id)
-                        logger.error { "Too long message: $len. ${entry?.location?.toString() ?: "<NULL>"}" }
-                    }
-
-                    unsafeBuffer.position = initialPosition
-                    unsafeBuffer.writeInt(len - 4)
-
-                    val bytes = unsafeBuffer.getArray()
-                    sendBuffer.put(bytes, initialPosition, len)
-                } finally {
-                    if (initialPosition == 0)
-                        unsafeBuffer.reset() // apply shrinking logic
-                    else
-                        unsafeBuffer.position = initialPosition
+                if (len > maxMessageLength) {
+                    val entry = messageBroker.tryGetById(id)
+                    logger.error { "Too long message: $len. ${entry?.location?.toString() ?: "<NULL>"}" }
                 }
+
+                unsafeBuffer.position = initialPosition
+                unsafeBuffer.writeInt(len - 4)
+
+                val bytes = unsafeBuffer.getArray()
+                sendBuffer.put(bytes, initialPosition, len)
+            } finally {
+                if (initialPosition == 0)
+                    unsafeBuffer.reset() // apply shrinking logic
+                else
+                    unsafeBuffer.position = initialPosition
             }
         }
     }

--- a/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/wire/SocketWireConcurrentAsyncPropertyTest.kt
+++ b/rd-kt/rd-framework/src/test/kotlin/com/jetbrains/rd/framework/test/cases/wire/SocketWireConcurrentAsyncPropertyTest.kt
@@ -1,0 +1,170 @@
+package com.jetbrains.rd.framework.test.cases.wire
+
+import com.jetbrains.rd.framework.*
+import com.jetbrains.rd.framework.base.bindTopLevel
+import com.jetbrains.rd.framework.impl.AsyncRdProperty
+import com.jetbrains.rd.framework.test.util.TestBase
+import com.jetbrains.rd.framework.test.util.TestScheduler
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.spinUntil
+import com.jetbrains.rd.util.threading.SynchronousScheduler
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicIntegerArray
+import java.util.zip.CRC32
+
+/**
+ * Regression test for RIDER-127935.
+ *
+ * Several [AsyncRdProperty] instances are mutated concurrently from several different threads, each with a
+ * large (multi-chunk) byte payload. `AsyncRdProperty.set` sends on the calling thread, so this turns the
+ * wire into a multi-producer stream — the same shape that desynced the Rider frontend/backend protocol
+ * when `RegistrySynchronizer` pushed the registry from `Dispatchers.Default`.
+ *
+ * Each payload carries an embedded {propIndex, iteration, crc32} header so the receiver can verify exact
+ * integrity. Before the fix, concurrent producers corrupted `ByteBufferAsyncProcessor`'s chunk ring
+ * (the consumer skipped filled chunks), which surfaced here as a crc/size mismatch, a deserialization
+ * error (accumulated by [TestBase] and thrown at teardown), or a stalled delivery (timeout).
+ */
+class SocketWireConcurrentAsyncPropertyTest : TestBase() {
+
+    companion object {
+        private fun server(lifetime: Lifetime): Protocol = Protocol(
+            "Server", Serializers(), SequentialIdentities(IdKind.Server), TestScheduler,
+            SocketWire.Server(lifetime, TestScheduler, null, "TestServer"), lifetime
+        )
+
+        private fun client(lifetime: Lifetime, serverProtocol: Protocol): Protocol = Protocol(
+            "Client", Serializers(), SequentialIdentities(IdKind.Client), TestScheduler,
+            SocketWire.Client(lifetime, TestScheduler, (serverProtocol.wire as SocketWire.Server).port, "TestClient"),
+            lifetime
+        )
+
+        private const val HEADER = 12 // [propIndex:int][iteration:int][crc32:int]
+
+        private fun putInt(b: ByteArray, off: Int, v: Int) {
+            b[off] = (v ushr 24).toByte()
+            b[off + 1] = (v ushr 16).toByte()
+            b[off + 2] = (v ushr 8).toByte()
+            b[off + 3] = v.toByte()
+        }
+
+        private fun getInt(b: ByteArray, off: Int): Int =
+            ((b[off].toInt() and 0xFF) shl 24) or
+                ((b[off + 1].toInt() and 0xFF) shl 16) or
+                ((b[off + 2].toInt() and 0xFF) shl 8) or
+                (b[off + 3].toInt() and 0xFF)
+
+        private fun crc(b: ByteArray, off: Int, len: Int): Int {
+            val c = CRC32()
+            c.update(b, off, len)
+            return c.value.toInt()
+        }
+
+        private fun makePayload(propIndex: Int, iteration: Int, size: Int): ByteArray {
+            val b = ByteArray(size)
+            val seed = propIndex * 1_000_003 + iteration
+            for (k in HEADER until size) b[k] = ((seed + k) and 0xFF).toByte()
+            putInt(b, 0, propIndex)
+            putInt(b, 4, iteration)
+            putInt(b, 8, crc(b, HEADER, size - HEADER))
+            return b
+        }
+
+        /** @return null if intact, otherwise a description of the corruption. */
+        private fun verify(b: ByteArray, expectedSize: Int): String? {
+            if (b.size != expectedSize) return "size=${b.size} != expected=$expectedSize"
+            val propIndex = getInt(b, 0)
+            val iteration = getInt(b, 4)
+            val storedCrc = getInt(b, 8)
+            val actualCrc = crc(b, HEADER, b.size - HEADER)
+            if (storedCrc != actualCrc)
+                return "crc mismatch prop=$propIndex it=$iteration stored=$storedCrc actual=$actualCrc"
+            return null
+        }
+    }
+
+    private lateinit var socketLifetime: Lifetime
+
+    @BeforeEach
+    fun setUp() {
+        socketLifetime = lifetime.createNested().lifetime
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
+    fun concurrentLargeAsyncPropertySends() {
+        val n = 16
+        val rounds = 15
+        val iterations = 20
+        val payloadSize = 128_000 // > ByteBufferAsyncProcessor.DefaultChunkSize (16370) -> multi-chunk
+
+        val serverProtocol = server(socketLifetime)
+        val clientProtocol = client(socketLifetime, serverProtocol)
+
+        val corruptions = ConcurrentLinkedQueue<String>()
+        val lastReceivedIteration = AtomicIntegerArray(n)
+        for (i in 0 until n) lastReceivedIteration.set(i, -1)
+
+        val clientProps = ArrayList<AsyncRdProperty<ByteArray>>(n)
+
+        for (i in 0 until n) {
+            val id = RdId((100 + i).toLong())
+
+            val serverProp = AsyncRdProperty(FrameworkMarshallers.ByteArray).also { it.master = false }
+            serverProp.withId(id).apply { bindTopLevel(socketLifetime, serverProtocol, "asyncProp$i") }
+            serverProp.change.adviseOn(socketLifetime, SynchronousScheduler) { value ->
+                val err = verify(value, payloadSize)
+                if (err != null) corruptions.add("prop#$i: $err")
+                else lastReceivedIteration.set(i, getInt(value, 4))
+            }
+
+            val clientProp = AsyncRdProperty(FrameworkMarshallers.ByteArray).also { it.master = true }
+            clientProp.withId(id).apply { bindTopLevel(socketLifetime, clientProtocol, "asyncProp$i") }
+            clientProps.add(clientProp)
+        }
+
+        // Make sure the wires are connected so the sets actually race on the live socket.
+        assertTrue(spinUntil(10_000) {
+            (clientProtocol.wire as SocketWire.Base).connected.value &&
+                (serverProtocol.wire as SocketWire.Base).connected.value
+        }, "wires did not connect")
+
+        // Each round is an independent concurrent burst; the desync is a timing race (~50% per burst),
+        // so several rounds (with fail-fast) make reproduction reliable while the fixed wire stays clean.
+        // Delivery is drained per round to keep the backlog (and runtime) bounded.
+        var sentSoFar = 0
+        var allDelivered = true
+        for (round in 0 until rounds) {
+            if (corruptions.isNotEmpty()) break
+            val base = sentSoFar
+            val startBarrier = CyclicBarrier(n)
+            val senders = (0 until n).map { i ->
+                Thread({
+                    startBarrier.await()
+                    for (it in 0 until iterations) {
+                        clientProps[i].set(makePayload(i, base + it, payloadSize))
+                    }
+                }, "async-sender-$round-$i").apply { isDaemon = true; start() }
+            }
+            senders.forEach { it.join(60_000) }
+            sentSoFar += iterations
+
+            // Wait for this round to deliver its final value intact. A desync stalls delivery -> timeout.
+            val target = sentSoFar - 1
+            allDelivered = spinUntil(30_000) {
+                corruptions.isNotEmpty() || (0 until n).all { lastReceivedIteration.get(it) == target }
+            }
+            if (!allDelivered) break
+        }
+
+        assertTrue(corruptions.isEmpty(), "byte-stream corruption detected: ${corruptions.toList()}")
+        assertTrue(allDelivered, "timed out waiting for delivery; last received per prop = " +
+            (0 until n).map { lastReceivedIteration.get(it) } + " (expected ${sentSoFar - 1})")
+    }
+}


### PR DESCRIPTION
The scenario targeted by this PR (we see it reproducing in ≈1% of cases during initial Rider loading on CI during some headless activities, most prominently [DATE EXPUNGED], see internal bulletin [RIDER-127935](https://youtrack.jetbrains.com/issue/RIDER-127935) for more details) is:
- there's a fast producer generating a lot of protocol traffic in one go, e.g. `RegistrySynchronizer`
- the consumer (socket data sender) cannot get to speed that fast

When the producer outruns the consumer and laps the ring, `growConditionally` could advance the producer onto the very chunk the consumer was processing (`chunkToProcess`) once that chunk got acked. The producer then refilled it and re-pointed its `.next` before the consumer's `finally` captured it — so the consumer followed `chunkToProcess.next` into freshly-filled (newer) data, ahead of older still-unfed chunks.

Thus causing chunk reordering inside the cyclic buffer.

This PR adds a fix and corresponding tests for `ByteBufferAsyncProcessor` and `SocketWire` to check for this certain scenario. Without a fix, tests fail 100% for me.