### PR TITLE
Fix implicit conversion from bool to int32

### DIFF
--- a/rd-cpp/src/rd_framework_cpp/src/main/wire/SocketWire.cpp
+++ b/rd-cpp/src/rd_framework_cpp/src/main/wire/SocketWire.cpp
@@ -329,7 +329,8 @@ int32_t SocketWire::Base::read_package() const
 	send_ack(seqn);
 	if (seqn <= max_received_seqn && seqn != 1)
 	{
-		return true;
+		logger->trace("{}: duplicate package seqn={} (max_received_seqn={}), skipping", this->id, seqn, max_received_seqn);
+		return 0;
 	}
 	max_received_seqn = seqn;
 


### PR DESCRIPTION
* sequence number is less or eq than latest received message - it's a duplicated of an old message, it needs to be skipped. Returning 0 means (don't need to read anything from this message)