### PR TITLE
Fix large messages send in rd-cpp

### DIFF
--- a/rd-cpp/src/rd_framework_cpp/src/main/wire/ByteBufferAsyncProcessor.cpp
+++ b/rd-cpp/src/rd_framework_cpp/src/main/wire/ByteBufferAsyncProcessor.cpp
@@ -9,12 +9,14 @@ namespace rd
 {
 size_t ByteBufferAsyncProcessor::INITIAL_CAPACITY = 1024 * 1024;
 
+size_t ByteBufferAsyncProcessor::DEFAULT_CHUNK_SIZE = 16370;
+
 std::shared_ptr<spdlog::logger> ByteBufferAsyncProcessor::logger =
 	spdlog::stderr_color_mt<spdlog::synchronous_factory>("byteBufferLog", spdlog::color_mode::automatic);
 
 ByteBufferAsyncProcessor::ByteBufferAsyncProcessor(
-	std::string id, std::function<bool(Buffer::ByteArray const&, sequence_number_t)> processor)
-	: id(std::move(id)), processor(std::move(processor))
+	std::string id, std::function<bool(Buffer::ByteArray const&, sequence_number_t)> processor, size_t chunk_size)
+	: id(std::move(id)), processor(std::move(processor)), chunk_size(chunk_size)
 {
 	data.reserve(INITIAL_CAPACITY);
 }
@@ -219,7 +221,23 @@ void ByteBufferAsyncProcessor::put(Buffer::ByteArray new_data)
 		{
 			return;
 		}
-		data.emplace_back(std::move(new_data));
+
+		const size_t count = new_data.size();
+
+		if (count <= chunk_size)
+		{
+			data.emplace_back(std::move(new_data));
+		}
+		else
+		{
+			logger->debug("{}: splitting message of {} bytes into packages of {} bytes", id, count, chunk_size);
+			for (size_t ptr = 0; ptr < count; ptr += chunk_size)
+			{
+				const size_t rest = count - ptr;
+				const size_t copylen = rest < chunk_size ? rest : chunk_size;
+				data.emplace_back(new_data.begin() + ptr, new_data.begin() + ptr + copylen);
+			}
+		}
 	}
 	cv.notify_all();
 }

--- a/rd-cpp/src/rd_framework_cpp/src/main/wire/ByteBufferAsyncProcessor.h
+++ b/rd-cpp/src/rd_framework_cpp/src/main/wire/ByteBufferAsyncProcessor.h
@@ -35,6 +35,7 @@ private:
 	using time_t = std::chrono::milliseconds;
 
 	static size_t INITIAL_CAPACITY;
+	static size_t DEFAULT_CHUNK_SIZE;
 
 	std::recursive_mutex lock;
 	std::condition_variable_any cv;
@@ -49,6 +50,7 @@ private:
 	std::thread::id async_thread_id;
 	std::future<void> async_future;
 
+	size_t chunk_size = DEFAULT_CHUNK_SIZE;
 	std::vector<Buffer::ByteArray> data;
 	std::mutex queue_lock;
 	std::deque<Buffer::ByteArray> queue{};
@@ -66,7 +68,7 @@ private:
 public:
 	// region ctor/dtor
 
-	explicit ByteBufferAsyncProcessor(std::string id, std::function<bool(Buffer::ByteArray const&, sequence_number_t)> processor);
+	explicit ByteBufferAsyncProcessor(std::string id, std::function<bool(Buffer::ByteArray const&, sequence_number_t)> processor, size_t chunk_size = DEFAULT_CHUNK_SIZE);
 
 	// endregion
 private:


### PR DESCRIPTION
Make ByteBufferAsyncProcessor to split messages into chunks if the message is larger than 16370 bytes