### PR TITLE
Adds a check on reading/writing the length field of strings and arrays

### DIFF
--- a/rd-net/Lifetimes/Serialization/UnsafeReader.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeReader.cs
@@ -64,8 +64,15 @@ namespace JetBrains.Serialization
       // NOTE: having this makes it possible for JIT to just drop the remaining method's body when assertions are disabled
       if (!Mode.IsAssertion) return;
 
+      CheckLength(size);
+    }
+
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    private void CheckLength(int size)
+    {
       var alreadyRead = (int)(myPtr - myInitialPtr);
-      if (alreadyRead + size > myMaxlen)
+      // size < 0 protects against overflows when writing strings with length bigger than 0x4000_0000
+      if (size < 0 || alreadyRead + size > myMaxlen)
       {
         ThrowOutOfRange(size, alreadyRead);
       }
@@ -84,7 +91,7 @@ namespace JetBrains.Serialization
     [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     public byte* ReadRaw(int count)
     {
-      AssertLength(count);
+      CheckLength(count);
       var res = myPtr;
       myPtr += count;
       return res;

--- a/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
+++ b/rd-net/Lifetimes/Serialization/UnsafeWriter.cs
@@ -760,18 +760,32 @@ namespace JetBrains.Serialization
       }
     }
 
+    [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
+    private static void CheckDataLength(int dataLength, int count, int itemSize)
+    {
+      if (dataLength < 0)
+      {
+        Assertion.Fail("Can't write an array that big: count={0}, itemSize={1}. " +
+                       "Maximum allowed length is {2}. ", count, itemSize, int.MaxValue / itemSize);
+      }
+    }
+
     // Mono 5.4 tries to inline this method and crashes.
     // [MethodImpl(MethodImplAdvancedOptions.AggressiveInlining)]
     private static void WriteStringContentInternalAfterMono5(UnsafeWriter writer, string value, int offset, int count)
     {
+      var dataLength = count * sizeof(char);
+      CheckDataLength(dataLength, count, sizeof(char));
       fixed (char* c = value)
       {
-        writer.Write((byte*) (c + offset), count * sizeof(char));
+        writer.Write((byte*) (c + offset), dataLength);
       }
     }
 
     private static void WriteStringContentInternalBeforeMono5(UnsafeWriter writer, string value, int offset, int count)
     {
+      var dataLength = count * sizeof(char);
+      CheckDataLength(dataLength, count, sizeof(char));
       for (var index = offset; index < offset + count; index++)
       {
         writer.WriteChar(value[index]);
@@ -837,9 +851,11 @@ namespace JetBrains.Serialization
       else
       {
         WriteInt32(value.Length);
+        var dataLength = value.Length * sizeof(int);
+        CheckDataLength(dataLength, value.Length, sizeof(int));
         fixed (int* c = value)
         {
-          Write((byte*)c, value.Length * sizeof(int));
+          Write((byte*)c, dataLength);
         }
       }
     }


### PR DESCRIPTION
Should prevent process crashes if the field has an incorrect value. For example spurious bit-flip, which makes us read out of bounds.

Should fix the crash [RIDER-141455 Random critical failure on Ubuntu 24.04](https://youtrack.jetbrains.com/issue/RIDER-141455)